### PR TITLE
feat(core): concurrency capability framework (P0+P1)

### DIFF
--- a/app/backends/cpu/sherpa.py
+++ b/app/backends/cpu/sherpa.py
@@ -73,6 +73,27 @@ class SherpaBackend(TTSBackend):
     # this backend can be hot-reloaded in-process.
     supports_hot_reload = True
 
+    @classmethod
+    def concurrency_capability(cls, profile=None):
+        """Declare concurrency for desktop/CPU TTS.
+
+        Spec §1 sample table row "desktop/CPU ASR/TTS": CPU/ORT is stateless
+        at the device level (no GPU/NPU lock), so multiple synthesize()
+        calls can run in parallel up to a soft cap chosen to bound CPU
+        thread contention. Default ``max_concurrent=4`` mirrors the
+        historical ``_TARGET_DEFAULTS["desktop"]=4`` at
+        ``app/core/session_limiter.py:30``; the limiter aggregation in
+        commit 3 must not regress this to 1.
+        """
+        from app.core.concurrency_capability import ConcurrencyCapability
+        return ConcurrencyCapability(
+            supports_parallel=True,
+            max_concurrent=4,
+            is_stateful=True,
+            requires_exclusive_device=False,
+            scaling_mode="external_managed",
+        )
+
     def __init__(self):
         self._tts = None
         self._ready = False

--- a/app/backends/cpu/sherpa_asr.py
+++ b/app/backends/cpu/sherpa_asr.py
@@ -192,6 +192,24 @@ class SherpaASRBackend(ASRBackend):
     # PR5: CPU / ORT model — releasable in-process via del + gc.
     supports_hot_reload = True
 
+    @classmethod
+    def concurrency_capability(cls, profile=None):
+        """Declare concurrency for desktop/CPU ASR.
+
+        Spec §1 sample row "desktop/CPU ASR/TTS". CPU/ORT recognizer
+        objects are independent across streams; the soft cap of 4 matches
+        the historical desktop default from session_limiter and bounds
+        CPU thread contention.
+        """
+        from app.core.concurrency_capability import ConcurrencyCapability
+        return ConcurrencyCapability(
+            supports_parallel=True,
+            max_concurrent=4,
+            is_stateful=True,
+            requires_exclusive_device=False,
+            scaling_mode="external_managed",
+        )
+
     def __init__(self):
         self._online_recognizer = None
         self._offline_recognizer = None

--- a/app/backends/jetson/kokoro_trt.py
+++ b/app/backends/jetson/kokoro_trt.py
@@ -227,6 +227,14 @@ class KokoroTRTBackend(TTSBackend):
         self._token_to_id: dict[str, int] = {}
         self._runtime_mode = os.environ.get("KOKORO_TRT_RUNTIME", "auto").strip().lower()
         self._engine = None
+        # Per-call concurrency rework (N>=2 safety): TRT IExecutionContext is
+        # not thread-safe. Shared self._ctx / self._pool / self._split_ctxs
+        # are no longer populated by load paths — each _synthesize_one() call
+        # builds its own context set + pool and tears them down in a finally
+        # block. Engines (weights) remain shared and immutable.
+        #
+        # These attrs stay declared (None / empty dict) so unload() and other
+        # introspection code paths keep working with no signature change.
         self._ctx = None
         self._pool: CudaMemoryPool | None = None
         self._ort_sess = None
@@ -459,13 +467,12 @@ class KokoroTRTBackend(TTSBackend):
             self._engine = runtime.deserialize_cuda_engine(f.read())
         if self._engine is None:
             raise RuntimeError(f"Failed to deserialize Kokoro engine: {self._paths['engine_path']}")
-        self._ctx = self._engine.create_execution_context()
+        # Per-call concurrency rework: ctx + pool are per-call now.
         names = [self._engine.get_tensor_name(i) for i in range(self._engine.num_io_tensors)]
         if "tokens" in names:
             self._token_input_name = "tokens"
         elif "input_ids" in names:
             self._token_input_name = "input_ids"
-        self._pool = CudaMemoryPool()
         self._runtime_mode = "engine"
         logger.info("Kokoro TRT engine loaded: %s (%.1fs)", self._paths['engine_path'], time.time() - t0)
 
@@ -485,8 +492,7 @@ class KokoroTRTBackend(TTSBackend):
             self._engine = runtime.deserialize_cuda_engine(f.read())
         if self._engine is None:
             raise RuntimeError(f"Failed to deserialize Kokoro hybrid prefix engine: {prefix_engine}")
-        self._ctx = self._engine.create_execution_context()
-        self._pool = CudaMemoryPool()
+        # Per-call concurrency rework: ctx + pool are per-call now.
         self._configure_hybrid_token_profile()
         self._suffix_sess = ort.InferenceSession(self._paths['hybrid_suffix_onnx'], providers=["CPUExecutionProvider"])
         self._token_input_name = "tokens"
@@ -540,16 +546,15 @@ class KokoroTRTBackend(TTSBackend):
         t0 = time.time()
         runtime = trt.Runtime(trt.Logger(trt.Logger.WARNING))
         self._split_engines = {}
-        self._split_ctxs = {}
         self._split_long_engines = {}
-        self._split_long_ctxs = {}
+        # Per-call concurrency rework: execution contexts + pool created
+        # per synthesize call. Only engines (weights) are loaded here.
         for name, path in required.items():
             with open(path, "rb") as f:
                 engine = runtime.deserialize_cuda_engine(f.read())
             if engine is None:
                 raise RuntimeError(f"Failed to deserialize Kokoro split {name} engine: {path}")
             self._split_engines[name] = engine
-            self._split_ctxs[name] = engine.create_execution_context()
         long_required = {
             "decoder": self._paths['split_decoder_engine_long'],
             "source": self._paths['split_source_engine_long'],
@@ -562,11 +567,9 @@ class KokoroTRTBackend(TTSBackend):
                 if engine is None:
                     raise RuntimeError(f"Failed to deserialize Kokoro split long {name} engine: {path}")
                 self._split_long_engines[name] = engine
-                self._split_long_ctxs[name] = engine.create_execution_context()
         elif any(os.path.exists(path) for path in long_required.values()):
             missing = [path for path in long_required.values() if not os.path.exists(path)]
             logger.warning("Ignoring incomplete Kokoro 256-512 bucket; missing: %s", missing)
-        self._pool = CudaMemoryPool()
         self._configure_split_token_profile()
         self._split_length_sess = ort.InferenceSession(self._paths['split_length_onnx'], providers=["CPUExecutionProvider"])
         self._split_istft_sess = ort.InferenceSession(self._paths['split_istft_onnx'], providers=["CPUExecutionProvider"])
@@ -743,21 +746,70 @@ class KokoroTRTBackend(TTSBackend):
         speed_arr = np.array([spd], dtype=np.float32)
 
         t_infer = time.time()
-        if self._runtime_mode == "engine":
-            audio = self._run_engine(input_ids, style, speed_arr)
-        elif self._runtime_mode == "hybrid":
-            audio = self._run_hybrid(input_ids, style, speed_arr)
-        elif self._runtime_mode == "split_generator":
-            try:
-                audio = self._run_split_generator(input_ids, style, speed_arr)
-            except ValueError as exc:
-                if os.environ.get("KOKORO_SPLIT_CPU_FALLBACK", "1").lower() in ("0", "false", "no"):
-                    raise
-                logger.warning("Kokoro split-generator shape mismatch; falling back to CPU ORT: %s", exc)
-                self._load_ort()
+        # Per-call concurrency rework: build per-call pool + execution
+        # contexts here (only for TRT modes). ORT modes don't need GPU
+        # resources and skip this. All TRT _run_* helpers receive pool/ctx
+        # via params — never touch self._pool / self._ctx during inference.
+        pool: CudaMemoryPool | None = None
+        local_ctx = None
+        local_split_ctxs: dict[str, object] = {}
+        local_split_long_ctxs: dict[str, object] = {}
+        try:
+            if self._runtime_mode in ("engine", "hybrid"):
+                pool = CudaMemoryPool()
+                if self._engine is not None:
+                    local_ctx = self._engine.create_execution_context()
+            elif self._runtime_mode == "split_generator":
+                pool = CudaMemoryPool()
+                local_split_ctxs = {
+                    name: eng.create_execution_context()
+                    for name, eng in self._split_engines.items()
+                }
+                local_split_long_ctxs = {
+                    name: eng.create_execution_context()
+                    for name, eng in self._split_long_engines.items()
+                }
+
+            if self._runtime_mode == "engine":
+                audio = self._run_engine(input_ids, style, speed_arr, pool=pool, ctx=local_ctx)
+            elif self._runtime_mode == "hybrid":
+                audio = self._run_hybrid(input_ids, style, speed_arr, pool=pool, ctx=local_ctx)
+            elif self._runtime_mode == "split_generator":
+                try:
+                    audio = self._run_split_generator(
+                        input_ids, style, speed_arr,
+                        pool=pool,
+                        split_ctxs=local_split_ctxs,
+                        split_long_ctxs=local_split_long_ctxs,
+                    )
+                except ValueError as exc:
+                    if os.environ.get("KOKORO_SPLIT_CPU_FALLBACK", "1").lower() in ("0", "false", "no"):
+                        raise
+                    logger.warning("Kokoro split-generator shape mismatch; falling back to CPU ORT: %s", exc)
+                    self._load_ort()
+                    audio = self._run_ort(input_ids, style, speed_arr)
+            else:
                 audio = self._run_ort(input_ids, style, speed_arr)
-        else:
-            audio = self._run_ort(input_ids, style, speed_arr)
+        finally:
+            if pool is not None:
+                try:
+                    pool.free_all()
+                except Exception:
+                    logger.exception("kokoro synth: pool.free_all failed")
+                try:
+                    pool.destroy()
+                except Exception:
+                    logger.exception("kokoro synth: pool.destroy failed")
+            if local_ctx is not None:
+                try:
+                    del local_ctx
+                except Exception:
+                    pass
+            for c in list(local_split_ctxs.values()) + list(local_split_long_ctxs.values()):
+                try:
+                    del c
+                except Exception:
+                    pass
         infer_ms = (time.time() - t_infer) * 1000
 
         audio = np.asarray(audio, dtype=np.float32).reshape(-1)
@@ -912,9 +964,15 @@ class KokoroTRTBackend(TTSBackend):
             {self._token_input_name: input_ids, "style": style, "speed": speed},
         )[0]
 
-    def _run_engine(self, input_ids: np.ndarray, style: np.ndarray, speed: np.ndarray) -> np.ndarray:
-        pool = self._pool
-        ctx = self._ctx
+    def _run_engine(
+        self,
+        input_ids: np.ndarray,
+        style: np.ndarray,
+        speed: np.ndarray,
+        *,
+        pool: "CudaMemoryPool",
+        ctx,
+    ) -> np.ndarray:
         assert pool is not None and ctx is not None and self._engine is not None
 
         def bind_input(name: str, arr: np.ndarray) -> None:
@@ -949,10 +1007,21 @@ class KokoroTRTBackend(TTSBackend):
         pool.free_all()
         return output
 
-    def _run_hybrid(self, input_ids: np.ndarray, style: np.ndarray, speed: np.ndarray) -> np.ndarray:
-        assert self._suffix_sess is not None
-        prefix_outputs = self._run_trt_engine(
-            {"tokens": input_ids, "style": style.astype(np.float32, copy=False), "speed": speed.astype(np.float32, copy=False)}
+    def _run_hybrid(
+        self,
+        input_ids: np.ndarray,
+        style: np.ndarray,
+        speed: np.ndarray,
+        *,
+        pool: "CudaMemoryPool",
+        ctx,
+    ) -> np.ndarray:
+        assert self._suffix_sess is not None and self._engine is not None and ctx is not None
+        prefix_outputs = self._run_trt_context(
+            self._engine,
+            ctx,
+            {"tokens": input_ids, "style": style.astype(np.float32, copy=False), "speed": speed.astype(np.float32, copy=False)},
+            pool=pool,
         )
         suffix_input_names = {item.name for item in self._suffix_sess.get_inputs()}
         feeds = {}
@@ -963,7 +1032,16 @@ class KokoroTRTBackend(TTSBackend):
             feeds[name] = arr
         return self._suffix_sess.run(None, feeds)[0]
 
-    def _run_split_generator(self, input_ids: np.ndarray, style: np.ndarray, speed: np.ndarray) -> np.ndarray:
+    def _run_split_generator(
+        self,
+        input_ids: np.ndarray,
+        style: np.ndarray,
+        speed: np.ndarray,
+        *,
+        pool: "CudaMemoryPool",
+        split_ctxs: dict[str, object],
+        split_long_ctxs: dict[str, object],
+    ) -> np.ndarray:
         assert self._split_length_sess is not None and self._split_istft_sess is not None
 
         stage: dict[str, np.ndarray] = {
@@ -971,10 +1049,12 @@ class KokoroTRTBackend(TTSBackend):
             "style": style.astype(np.float32, copy=False),
             "speed": speed.astype(np.float32, copy=False),
         }
-        stage.update(self._run_named_trt_engine("encoder", stage))
+        stage.update(self._run_named_trt_engine("encoder", stage, pool=pool, ctx=split_ctxs["encoder"]))
         stage.update(_run_cpu_onnx(self._split_length_sess, stage))
         frame_t = int(stage["/encoder/MatMul_1_output_0"].shape[2])
-        bucket_engines, bucket_ctxs = self._select_split_bucket(frame_t)
+        bucket_engines, bucket_ctxs = self._select_split_bucket(
+            frame_t, split_ctxs=split_ctxs, split_long_ctxs=split_long_ctxs,
+        )
 
         stage.update(self._run_split_bucket_engine(bucket_engines, bucket_ctxs, "decoder", {
             "/encoder/MatMul_1_output_0": stage["/encoder/MatMul_1_output_0"],
@@ -982,12 +1062,12 @@ class KokoroTRTBackend(TTSBackend):
             "/decoder/decoder/N_conv/Conv_output_0": stage["/decoder/decoder/N_conv/Conv_output_0"],
             "/decoder/decoder/Unsqueeze_output_0": stage["/decoder/decoder/Unsqueeze_output_0"],
             "style": stage["style"],
-        }))
+        }, pool=pool))
 
         if "source" in bucket_engines:
             stage.update(self._run_split_bucket_engine(bucket_engines, bucket_ctxs, "source", {
                 "/decoder/decoder/Unsqueeze_output_0": stage["/decoder/decoder/Unsqueeze_output_0"],
-            }))
+            }, pool=pool))
         else:
             assert self._split_source_sess is not None
             stage.update(_run_cpu_onnx(self._split_source_sess, stage))
@@ -996,23 +1076,35 @@ class KokoroTRTBackend(TTSBackend):
             "/decoder/decoder/decode.3/Div_4_output_0": stage["/decoder/decoder/decode.3/Div_4_output_0"],
             "/decoder/decoder/generator/Concat_3_output_0": stage["/decoder/decoder/generator/Concat_3_output_0"],
             "style": stage["style"],
-        })
+        }, pool=pool)
         return _run_cpu_onnx(self._split_istft_sess, gen)["audio"]
 
-    def _select_split_bucket(self, frame_t: int):
+    def _select_split_bucket(
+        self,
+        frame_t: int,
+        *,
+        split_ctxs: dict[str, object],
+        split_long_ctxs: dict[str, object],
+    ):
         if frame_t <= 256:
-            return self._split_engines, self._split_ctxs
+            return self._split_engines, split_ctxs
         if frame_t <= 512 and self._split_long_engines:
-            return self._split_long_engines, self._split_long_ctxs
+            return self._split_long_engines, split_long_ctxs
         raise ValueError(
             f"Kokoro split-generator frame length {frame_t} is outside available TRT buckets "
             f"(base<=256, long<=512 loaded={bool(self._split_long_engines)})"
         )
 
-    def _run_named_trt_engine(self, name: str, inputs: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+    def _run_named_trt_engine(
+        self,
+        name: str,
+        inputs: dict[str, np.ndarray],
+        *,
+        pool: "CudaMemoryPool",
+        ctx,
+    ) -> dict[str, np.ndarray]:
         engine = self._split_engines[name]
-        ctx = self._split_ctxs[name]
-        return self._run_trt_context(engine, ctx, inputs)
+        return self._run_trt_context(engine, ctx, inputs, pool=pool)
 
     def _run_split_bucket_engine(
         self,
@@ -1020,17 +1112,19 @@ class KokoroTRTBackend(TTSBackend):
         ctxs: dict[str, object],
         name: str,
         inputs: dict[str, np.ndarray],
+        *,
+        pool: "CudaMemoryPool",
     ) -> dict[str, np.ndarray]:
-        return self._run_trt_context(engines[name], ctxs[name], inputs)
+        return self._run_trt_context(engines[name], ctxs[name], inputs, pool=pool)
 
-    def _run_trt_engine(self, inputs: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
-        pool = self._pool
-        ctx = self._ctx
-        assert pool is not None and ctx is not None and self._engine is not None
-        return self._run_trt_context(self._engine, ctx, inputs)
-
-    def _run_trt_context(self, engine, ctx, inputs: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
-        pool = self._pool
+    def _run_trt_context(
+        self,
+        engine,
+        ctx,
+        inputs: dict[str, np.ndarray],
+        *,
+        pool: "CudaMemoryPool",
+    ) -> dict[str, np.ndarray]:
         assert pool is not None
 
         def bind_input(name: str, arr: np.ndarray) -> None:

--- a/app/backends/jetson/kokoro_trt.py
+++ b/app/backends/jetson/kokoro_trt.py
@@ -19,11 +19,27 @@ import queue
 import re
 import struct
 import time
+from dataclasses import dataclass
 from typing import Optional
 
 import numpy as np
 
 from app.backends.jetson.matcha_trt import CudaMemoryPool
+
+
+@dataclass
+class _DeviceTensor:
+    """Handle to a tensor that lives in device memory between TRT stages.
+
+    Lifetime is bounded by the per-synthesize CudaMemoryPool — these tensors
+    are valid until the synthesize call's outer try/finally calls
+    slot.reset_per_request() (which calls pool.free_all()). Never escape this
+    scope; pass by value within one _synthesize_one() invocation only.
+    """
+    ptr: int
+    shape: tuple[int, ...]
+    dtype: type
+    nbytes: int
 from app.core.tts_backend import TTSBackend, TTSCapability
 from app.core.tts_speakers import resolve_speaker_kwargs
 
@@ -1170,27 +1186,77 @@ class KokoroTRTBackend(TTSBackend):
             frame_t, split_ctxs=split_ctxs, split_long_ctxs=split_long_ctxs,
         )
 
-        stage.update(self._run_split_bucket_engine(bucket_engines, bucket_ctxs, "decoder", {
-            "/encoder/MatMul_1_output_0": stage["/encoder/MatMul_1_output_0"],
-            "/decoder/decoder/F0_conv/Conv_output_0": stage["/decoder/decoder/F0_conv/Conv_output_0"],
-            "/decoder/decoder/N_conv/Conv_output_0": stage["/decoder/decoder/N_conv/Conv_output_0"],
-            "/decoder/decoder/Unsqueeze_output_0": stage["/decoder/decoder/Unsqueeze_output_0"],
-            "style": stage["style"],
-        }, pool=pool))
+        # Stages 3 (decoder TRT) → 4 (source TRT or CPU) → 5 (generator TRT)
+        # → 6 (iSTFT CPU). If source is TRT, we can keep decoder/source
+        # outputs device-resident and skip 2 D2H + 2 H2D round trips per
+        # synthesize. iSTFT (CPU) forces generator's output back to host.
+        source_is_trt = "source" in bucket_engines
+        device_chain_outputs: dict[str, _DeviceTensor] = {}
 
-        if "source" in bucket_engines:
-            stage.update(self._run_split_bucket_engine(bucket_engines, bucket_ctxs, "source", {
-                "/decoder/decoder/Unsqueeze_output_0": stage["/decoder/decoder/Unsqueeze_output_0"],
-            }, pool=pool))
+        # style is bound by generator (and originally by decoder) — for the
+        # device path we still bind style via H2D each stage because it's tiny
+        # (256 floats) and not produced by another TRT engine. Cheaper to keep
+        # the host array around than thread the device pointer through.
+
+        if source_is_trt:
+            # Pure TRT chain: decoder → generator (with style + source-Div_4
+            # rebound on generator). source's Div_4 output overrides decoder's.
+            decoder_dev = self._run_split_bucket_engine(
+                bucket_engines, bucket_ctxs, "decoder", {
+                    "/encoder/MatMul_1_output_0": stage["/encoder/MatMul_1_output_0"],
+                    "/decoder/decoder/F0_conv/Conv_output_0": stage["/decoder/decoder/F0_conv/Conv_output_0"],
+                    "/decoder/decoder/N_conv/Conv_output_0": stage["/decoder/decoder/N_conv/Conv_output_0"],
+                    "/decoder/decoder/Unsqueeze_output_0": stage["/decoder/decoder/Unsqueeze_output_0"],
+                    "style": stage["style"],
+                },
+                pool=pool, return_device=True,
+            )
+            source_dev = self._run_split_bucket_engine(
+                bucket_engines, bucket_ctxs, "source", {
+                    "/decoder/decoder/Unsqueeze_output_0": stage["/decoder/decoder/Unsqueeze_output_0"],
+                },
+                pool=pool, return_device=True,
+            )
+            # Merge — source's outputs override decoder's where keys collide
+            # (specifically Div_4 in the kokoro split topology).
+            device_chain_outputs = {**decoder_dev, **source_dev}
+
+            # Generator needs Div_4 (from source) and Concat_3 (from decoder).
+            # style is the only host-side input.
+            needed = (
+                "/decoder/decoder/decode.3/Div_4_output_0",
+                "/decoder/decoder/generator/Concat_3_output_0",
+            )
+            gen_device_inputs = {k: device_chain_outputs[k] for k in needed if k in device_chain_outputs}
+            gen = self._run_split_bucket_engine(
+                bucket_engines, bucket_ctxs, "generator",
+                {"style": stage["style"]},
+                pool=pool,
+                device_inputs=gen_device_inputs,
+                return_device=False,  # iSTFT is CPU; output must be host
+            )
         else:
+            # CPU source path — cannot keep decoder output device-resident
+            # because source ORT wants host arrays. Fall back to legacy host
+            # I/O for all three stages.
+            stage.update(self._run_split_bucket_engine(
+                bucket_engines, bucket_ctxs, "decoder", {
+                    "/encoder/MatMul_1_output_0": stage["/encoder/MatMul_1_output_0"],
+                    "/decoder/decoder/F0_conv/Conv_output_0": stage["/decoder/decoder/F0_conv/Conv_output_0"],
+                    "/decoder/decoder/N_conv/Conv_output_0": stage["/decoder/decoder/N_conv/Conv_output_0"],
+                    "/decoder/decoder/Unsqueeze_output_0": stage["/decoder/decoder/Unsqueeze_output_0"],
+                    "style": stage["style"],
+                }, pool=pool,
+            ))
             assert self._split_source_sess is not None
             stage.update(_run_cpu_onnx(self._split_source_sess, stage))
-
-        gen = self._run_split_bucket_engine(bucket_engines, bucket_ctxs, "generator", {
-            "/decoder/decoder/decode.3/Div_4_output_0": stage["/decoder/decoder/decode.3/Div_4_output_0"],
-            "/decoder/decoder/generator/Concat_3_output_0": stage["/decoder/decoder/generator/Concat_3_output_0"],
-            "style": stage["style"],
-        }, pool=pool)
+            gen = self._run_split_bucket_engine(
+                bucket_engines, bucket_ctxs, "generator", {
+                    "/decoder/decoder/decode.3/Div_4_output_0": stage["/decoder/decoder/decode.3/Div_4_output_0"],
+                    "/decoder/decoder/generator/Concat_3_output_0": stage["/decoder/decoder/generator/Concat_3_output_0"],
+                    "style": stage["style"],
+                }, pool=pool,
+            )
         return _run_cpu_onnx(self._split_istft_sess, gen)["audio"]
 
     def _select_split_bucket(
@@ -1216,9 +1282,14 @@ class KokoroTRTBackend(TTSBackend):
         *,
         pool: "CudaMemoryPool",
         ctx,
-    ) -> dict[str, np.ndarray]:
+        device_inputs: dict[str, "_DeviceTensor"] | None = None,
+        return_device: bool = False,
+    ):
         engine = self._split_engines[name]
-        return self._run_trt_context(engine, ctx, inputs, pool=pool)
+        return self._run_trt_context(
+            engine, ctx, inputs, pool=pool,
+            device_inputs=device_inputs, return_device=return_device,
+        )
 
     def _run_split_bucket_engine(
         self,
@@ -1228,8 +1299,13 @@ class KokoroTRTBackend(TTSBackend):
         inputs: dict[str, np.ndarray],
         *,
         pool: "CudaMemoryPool",
-    ) -> dict[str, np.ndarray]:
-        return self._run_trt_context(engines[name], ctxs[name], inputs, pool=pool)
+        device_inputs: dict[str, "_DeviceTensor"] | None = None,
+        return_device: bool = False,
+    ):
+        return self._run_trt_context(
+            engines[name], ctxs[name], inputs, pool=pool,
+            device_inputs=device_inputs, return_device=return_device,
+        )
 
     def _run_trt_context(
         self,
@@ -1238,10 +1314,32 @@ class KokoroTRTBackend(TTSBackend):
         inputs: dict[str, np.ndarray],
         *,
         pool: "CudaMemoryPool",
-    ) -> dict[str, np.ndarray]:
-        assert pool is not None
+        device_inputs: dict[str, "_DeviceTensor"] | None = None,
+        return_device: bool = False,
+    ):
+        """Run a TRT context with optional device-resident I/O.
 
-        def bind_input(name: str, arr: np.ndarray) -> None:
+        Args:
+            inputs: host numpy arrays bound via H2D copy.
+            device_inputs: pre-existing device pointers (from a previous TRT
+                stage's ``return_device=True`` output) — bound directly with
+                no H2D copy. Inputs in ``device_inputs`` override entries in
+                ``inputs`` with the same name.
+            return_device: if True, do not D2H output buffers; instead return
+                ``dict[str, _DeviceTensor]`` of device pointers valid for the
+                lifetime of ``pool``. The caller is responsible for ensuring
+                ``pool.free_all()`` is not called until those tensors are no
+                longer needed (synthesize-level finally handles this).
+
+        Pool lifecycle: this method NEVER calls ``pool.free_all()``. The outer
+        ``_synthesize_one()`` finally block (via ``slot.reset_per_request()``)
+        is the single source of truth for releasing per-request device memory.
+        That gives multi-stage callers a stable device-resident buffer chain.
+        """
+        assert pool is not None
+        device_inputs = device_inputs or {}
+
+        def bind_host_input(name: str, arr: np.ndarray) -> None:
             arr = np.ascontiguousarray(arr)
             self._validate_engine_input_shape(engine, name, arr)
             ptr = pool.allocate(arr.nbytes)
@@ -1249,12 +1347,30 @@ class KokoroTRTBackend(TTSBackend):
             ctx.set_tensor_address(name, ptr)
             self._set_or_validate_input_shape(ctx, name, arr)
 
-        for name, arr in inputs.items():
-            bind_input(name, arr)
+        def bind_device_input(name: str, dt: "_DeviceTensor") -> None:
+            ctx.set_tensor_address(name, dt.ptr)
+            # set_input_shape mirrors the dynamic-shape path used for host
+            # arrays — emulate by constructing a tiny stand-in with the right
+            # shape attribute. Using a class with .shape avoids a real
+            # numpy alloc.
+            class _ShapeOnly:
+                __slots__ = ("shape",)
+                def __init__(self, shape):
+                    self.shape = shape
+            self._set_or_validate_input_shape(ctx, name, _ShapeOnly(dt.shape))
 
-        outputs: dict[str, np.ndarray] = {}
-        output_ptrs: list[tuple[str, int, np.ndarray]] = []
+        # First H2D-bind any host inputs not shadowed by device_inputs.
+        for name, arr in inputs.items():
+            if name in device_inputs:
+                continue
+            bind_host_input(name, arr)
+        for name, dt in device_inputs.items():
+            bind_device_input(name, dt)
+
         import tensorrt as trt
+
+        host_output_ptrs: list[tuple[str, int, np.ndarray]] = []
+        device_output_handles: dict[str, _DeviceTensor] = {}
 
         for i in range(engine.num_io_tensors):
             name = engine.get_tensor_name(i)
@@ -1262,23 +1378,32 @@ class KokoroTRTBackend(TTSBackend):
                 continue
             shape = tuple(int(d) for d in ctx.get_tensor_shape(name))
             if any(d < 0 for d in shape):
-                pool.free_all()
                 raise RuntimeError(f"Kokoro hybrid prefix output has dynamic shape: {name} {shape}")
             dtype = _trt_dtype_to_np(engine.get_tensor_dtype(name))
-            out = np.empty(shape, dtype=dtype)
-            ptr = pool.allocate(out.nbytes)
-            ctx.set_tensor_address(name, ptr)
-            output_ptrs.append((name, ptr, out))
+            if return_device:
+                nbytes = int(np.prod(shape)) * np.dtype(dtype).itemsize
+                ptr = pool.allocate(nbytes)
+                ctx.set_tensor_address(name, ptr)
+                device_output_handles[name] = _DeviceTensor(
+                    ptr=ptr, shape=shape, dtype=dtype, nbytes=nbytes,
+                )
+            else:
+                out = np.empty(shape, dtype=dtype)
+                ptr = pool.allocate(out.nbytes)
+                ctx.set_tensor_address(name, ptr)
+                host_output_ptrs.append((name, ptr, out))
 
         ok = ctx.execute_async_v3(pool.stream_handle())
         if not ok:
-            pool.free_all()
             raise RuntimeError("Kokoro hybrid prefix TRT execute_async_v3 returned False")
         pool.synchronize()
-        for name, ptr, out in output_ptrs:
+
+        if return_device:
+            return device_output_handles
+        outputs: dict[str, np.ndarray] = {}
+        for name, ptr, out in host_output_ptrs:
             pool.copy_dtoh(ptr, out)
             outputs[name] = out
-        pool.free_all()
         return outputs
 
     def _validate_engine_input_shape(self, engine, name: str, arr: np.ndarray) -> None:

--- a/app/backends/jetson/kokoro_trt.py
+++ b/app/backends/jetson/kokoro_trt.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import io
 import logging
 import os
+import queue
 import re
 import struct
 import time
@@ -212,6 +213,68 @@ def _samples_to_wav(samples: np.ndarray, sample_rate: int) -> bytes:
     return buf.getvalue()
 
 
+class _KokoroCtxSlot:
+    """Pre-allocated TRT context + pool slot for one concurrent Kokoro request.
+
+    Three runtime modes — engine / hybrid / split_generator. A slot holds the
+    contexts the current mode needs; other-mode ctx fields are empty.
+
+    A pool of K slots is built at preload() time. _synthesize_one() acquires
+    one slot, runs the inference, then releases it back. This amortizes the
+    ~900ms-per-context create_execution_context() cost on Jetson Orin Nano
+    across the service lifetime instead of paying it per request.
+    """
+
+    def __init__(
+        self,
+        runtime_mode: str,
+        engine,
+        split_engines: dict,
+        split_long_engines: dict,
+    ):
+        self.pool = CudaMemoryPool()
+        self.ctx = None
+        self.split_ctxs: dict[str, object] = {}
+        self.split_long_ctxs: dict[str, object] = {}
+        if runtime_mode in ("engine", "hybrid"):
+            if engine is not None:
+                self.ctx = engine.create_execution_context()
+        elif runtime_mode == "split_generator":
+            self.split_ctxs = {
+                name: eng.create_execution_context()
+                for name, eng in split_engines.items()
+            }
+            self.split_long_ctxs = {
+                name: eng.create_execution_context()
+                for name, eng in split_long_engines.items()
+            }
+        elif runtime_mode in ("ort_cpu", "cpu", "ort", "onnxruntime"):
+            # CPU ORT path needs no TRT context. We still keep an (unused)
+            # pool so destroy() is symmetric across slots.
+            pass
+        else:
+            raise ValueError(f"Unknown kokoro runtime_mode: {runtime_mode}")
+
+    def reset_per_request(self):
+        try:
+            self.pool.free_all()
+        except Exception:
+            logger.exception("KokoroCtxSlot.reset_per_request: pool.free_all raised")
+
+    def destroy(self):
+        try:
+            self.pool.synchronize()
+        except Exception:
+            pass
+        try:
+            self.pool.destroy()
+        except Exception:
+            pass
+        self.ctx = None
+        self.split_ctxs = {}
+        self.split_long_ctxs = {}
+
+
 class KokoroTRTBackend(TTSBackend):
     """English Kokoro v1.0 TTS accelerated with TensorRT on Jetson."""
 
@@ -252,6 +315,13 @@ class KokoroTRTBackend(TTSBackend):
         self._hybrid_max_seq_len: int | None = None
         self._hybrid_min_seq_len: int | None = None
         self._ready = False
+        # Pre-allocated context pool (built in preload() once we know the
+        # final runtime_mode). N slots, each owning one CUDA stream + per-mode
+        # execution contexts. _synthesize_one() borrows + returns. See
+        # _MatchaCtxSlot docstring for the latency rationale.
+        self._ctx_pool: "queue.Queue[_KokoroCtxSlot]" = queue.Queue()
+        self._slots: list[_KokoroCtxSlot] = []
+        self._pool_size: int = 0
         # Snapshot artifact paths from the *current* env at construction.
         # BackendManager rebuilds the backend after each apply_profile() so
         # __init__ sees the latest profile-applied env. Module-level _*_PATH
@@ -322,6 +392,7 @@ class KokoroTRTBackend(TTSBackend):
             and not self._split_long_engines
             and not self._split_long_ctxs
             and self._pool is None
+            and not self._slots
         ):
             return
 
@@ -334,6 +405,12 @@ class KokoroTRTBackend(TTSBackend):
                     logger.exception("Kokoro unload: pool.synchronize failed; continuing")
 
             # 2. Execution contexts before engines.
+            # 2a. Drain per-slot ctxs + streams + remaining device buffers.
+            self._teardown_ctx_pool()
+
+            # 2b. Back-compat: legacy shared ctx dicts (always empty after
+            # pre-allocated pool refactor) are still cleared so tests that
+            # populate them for unload-ordering assertions still pass.
             for name, ctx in list(self._split_ctxs.items()):
                 try:
                     del ctx
@@ -423,6 +500,7 @@ class KokoroTRTBackend(TTSBackend):
         else:
             logger.warning("Kokoro TRT engine missing at %s; using CPU ORT fallback", self._paths['engine_path'])
             self._load_ort()
+        self._build_ctx_pool()
         try:
             self._warmup()
         except Exception as exc:
@@ -434,11 +512,63 @@ class KokoroTRTBackend(TTSBackend):
                 self._engine = None
                 self._ctx = None
                 self._pool = None
+                self._teardown_ctx_pool()
                 self._load_ort()
+                self._build_ctx_pool()
                 self._warmup()
             else:
                 raise
         self._ready = True
+
+    def _build_ctx_pool(self) -> None:
+        """Pre-allocate K context slots and seed the queue.
+
+        K = OVS_TTS_STREAM_MAX_WORKERS (default 2). Slot type depends on the
+        already-resolved runtime mode. Logs the slot count so deploy
+        verification can grep for it.
+        """
+        try:
+            k = int(os.environ.get("OVS_TTS_STREAM_MAX_WORKERS", "2"))
+        except ValueError:
+            k = 2
+        k = max(1, k)
+        self._pool_size = k
+        self._slots = []
+        # Drain any prior queue contents (rebuild path after warmup fallback).
+        while True:
+            try:
+                self._ctx_pool.get_nowait()
+            except queue.Empty:
+                break
+        t0 = time.time()
+        for _ in range(k):
+            slot = _KokoroCtxSlot(
+                self._runtime_mode,
+                self._engine,
+                self._split_engines,
+                self._split_long_engines,
+            )
+            self._slots.append(slot)
+            self._ctx_pool.put(slot)
+        logger.info(
+            "Kokoro ctx pool: %d slots pre-allocated (mode=%s, %.2fs)",
+            k, self._runtime_mode, time.time() - t0,
+        )
+
+    def _teardown_ctx_pool(self) -> None:
+        """Drain queue and destroy all slots. Safe to call multiple times."""
+        while True:
+            try:
+                self._ctx_pool.get_nowait()
+            except queue.Empty:
+                break
+        for i, slot in enumerate(self._slots):
+            try:
+                slot.destroy()
+            except Exception:
+                logger.exception("Kokoro teardown: slot[%d] destroy raised", i)
+        self._slots = []
+        self._pool_size = 0
 
     def _load_tokens(self) -> None:
         if not os.path.exists(self._paths['tokens_path']):
@@ -746,41 +876,39 @@ class KokoroTRTBackend(TTSBackend):
         speed_arr = np.array([spd], dtype=np.float32)
 
         t_infer = time.time()
-        # Per-call concurrency rework: build per-call pool + execution
-        # contexts here (only for TRT modes). ORT modes don't need GPU
-        # resources and skip this. All TRT _run_* helpers receive pool/ctx
-        # via params — never touch self._pool / self._ctx during inference.
-        pool: CudaMemoryPool | None = None
-        local_ctx = None
-        local_split_ctxs: dict[str, object] = {}
-        local_split_long_ctxs: dict[str, object] = {}
+        # Borrow a pre-allocated context slot if the pool has been built
+        # (production path). free_all() between requests releases device
+        # buffers while keeping the stream + ctxs warm.
+        #
+        # When no slot is available (unit-test bypass path: tests build the
+        # backend with __new__ + a runtime_mode attr but never preload, so
+        # _slots is empty), the run helpers are mocked by the test and the
+        # pool / ctx kwargs are ignored — pass None.
+        slot: _KokoroCtxSlot | None = None
+        if self._slots:
+            slot = self._ctx_pool.get()
+        pool_arg = slot.pool if slot is not None else None
+        ctx_arg = slot.ctx if slot is not None else None
+        split_ctxs_arg = slot.split_ctxs if slot is not None else {}
+        split_long_ctxs_arg = slot.split_long_ctxs if slot is not None else {}
         try:
-            if self._runtime_mode in ("engine", "hybrid"):
-                pool = CudaMemoryPool()
-                if self._engine is not None:
-                    local_ctx = self._engine.create_execution_context()
-            elif self._runtime_mode == "split_generator":
-                pool = CudaMemoryPool()
-                local_split_ctxs = {
-                    name: eng.create_execution_context()
-                    for name, eng in self._split_engines.items()
-                }
-                local_split_long_ctxs = {
-                    name: eng.create_execution_context()
-                    for name, eng in self._split_long_engines.items()
-                }
-
             if self._runtime_mode == "engine":
-                audio = self._run_engine(input_ids, style, speed_arr, pool=pool, ctx=local_ctx)
+                audio = self._run_engine(
+                    input_ids, style, speed_arr,
+                    pool=pool_arg, ctx=ctx_arg,
+                )
             elif self._runtime_mode == "hybrid":
-                audio = self._run_hybrid(input_ids, style, speed_arr, pool=pool, ctx=local_ctx)
+                audio = self._run_hybrid(
+                    input_ids, style, speed_arr,
+                    pool=pool_arg, ctx=ctx_arg,
+                )
             elif self._runtime_mode == "split_generator":
                 try:
                     audio = self._run_split_generator(
                         input_ids, style, speed_arr,
-                        pool=pool,
-                        split_ctxs=local_split_ctxs,
-                        split_long_ctxs=local_split_long_ctxs,
+                        pool=pool_arg,
+                        split_ctxs=split_ctxs_arg,
+                        split_long_ctxs=split_long_ctxs_arg,
                     )
                 except ValueError as exc:
                     if os.environ.get("KOKORO_SPLIT_CPU_FALLBACK", "1").lower() in ("0", "false", "no"):
@@ -791,25 +919,11 @@ class KokoroTRTBackend(TTSBackend):
             else:
                 audio = self._run_ort(input_ids, style, speed_arr)
         finally:
-            if pool is not None:
+            if slot is not None:
                 try:
-                    pool.free_all()
-                except Exception:
-                    logger.exception("kokoro synth: pool.free_all failed")
-                try:
-                    pool.destroy()
-                except Exception:
-                    logger.exception("kokoro synth: pool.destroy failed")
-            if local_ctx is not None:
-                try:
-                    del local_ctx
-                except Exception:
-                    pass
-            for c in list(local_split_ctxs.values()) + list(local_split_long_ctxs.values()):
-                try:
-                    del c
-                except Exception:
-                    pass
+                    slot.reset_per_request()
+                finally:
+                    self._ctx_pool.put(slot)
         infer_ms = (time.time() - t_infer) * 1000
 
         audio = np.asarray(audio, dtype=np.float32).reshape(-1)

--- a/app/backends/jetson/kokoro_trt.py
+++ b/app/backends/jetson/kokoro_trt.py
@@ -302,6 +302,37 @@ class KokoroTRTBackend(TTSBackend):
     # Hardware (VRAM) verification on orin-nano will be a separate dispatch.
     supports_hot_reload: bool = True
 
+    @classmethod
+    def concurrency_capability(cls, profile=None):
+        from app.core.concurrency_capability import ConcurrencyCapability
+
+        # K = OVS_TTS_STREAM_MAX_WORKERS (default 2), matching _build_ctx_pool().
+        # Profile may override via tts_stream_max_workers (or nested
+        # tts_backend_config.stream_max_workers). Engines (weights) shared;
+        # each _KokoroCtxSlot holds its own TRT execution contexts.
+        env_val = os.environ.get("OVS_TTS_STREAM_MAX_WORKERS")
+        profile_val = None
+        if isinstance(profile, dict):
+            profile_val = profile.get("tts_stream_max_workers")
+            if profile_val is None:
+                cfg = profile.get("tts_backend_config")
+                if isinstance(cfg, dict):
+                    profile_val = cfg.get("stream_max_workers")
+        try:
+            k = int(env_val) if env_val is not None else (
+                int(profile_val) if profile_val is not None else 2
+            )
+        except (TypeError, ValueError):
+            k = 2
+        k = max(1, k)
+        return ConcurrencyCapability(
+            supports_parallel=k > 1,
+            max_concurrent=k,
+            is_stateful=True,
+            requires_exclusive_device=True,
+            scaling_mode="single_runtime_multiplex",
+        )
+
     def __init__(self):
         self._token_to_id: dict[str, int] = {}
         self._runtime_mode = os.environ.get("KOKORO_TRT_RUNTIME", "auto").strip().lower()

--- a/app/backends/jetson/matcha_trt.py
+++ b/app/backends/jetson/matcha_trt.py
@@ -187,6 +187,12 @@ class MatchaTRTBackend(TTSBackend):
         self._acoustic_ort = None
         self._split_encoder_ort = None
         self._split_estimator_engines = []
+        # Per-call concurrency rework: shared execution contexts and CUDA
+        # pool removed. TRT IExecutionContext is not thread-safe, so each
+        # synthesize() call now builds its own context set + pool and tears
+        # them down in a finally block. Engines (weights) stay shared.
+        # These attrs are kept (always empty/None) so unload() and other
+        # introspection code paths keep working without changes.
         self._split_estimator_ctxs = []
         self._acoustic_mode = "full_ort"
         self._vocos_engine = None
@@ -439,27 +445,25 @@ class MatchaTRTBackend(TTSBackend):
 
         t0 = time.time()
         self._vocos_engine = load_engine(self._vocos_engine_path)
-        self._vocos_ctx = self._vocos_engine.create_execution_context()
+        # Per-call concurrency rework (N>=2 safety): execution contexts and
+        # CUDA pool are now created per synthesize() call. Engines (weights)
+        # remain shared and immutable.
         logger.info("Vocos loaded: %s (%.1fs)", self._vocos_engine_path, time.time() - t0)
 
         if self._acoustic_mode == "split_trt":
             t0 = time.time()
             base_dir = os.path.dirname(self._split_estimator_engine)
             self._split_estimator_engines = []
-            self._split_estimator_ctxs = []
             names = []
             for step in range(N_ODE_STEPS):
                 path = os.path.join(base_dir, f"matcha_estimator_step{step}_bf16.engine")
                 engine = load_engine(path)
                 self._split_estimator_engines.append(engine)
-                self._split_estimator_ctxs.append(engine.create_execution_context())
                 names.append([engine.get_tensor_name(i) for i in range(engine.num_io_tensors)])
             logger.info(
                 "Split Matcha estimator TRT loaded from %s (%.1fs, tensors=%s)",
                 base_dir, time.time() - t0, names,
             )
-
-        self._cuda_pool = CudaMemoryPool()
 
     def _warmup(self):
         """Warmup inference."""
@@ -606,107 +610,137 @@ class MatchaTRTBackend(TTSBackend):
             speed = 1.0
         detected_language = detect_zh_en(text, language)
 
-        pool = self._cuda_pool
-        t_start = time.time()
+        # Per-call concurrency rework (N>=2 safety):
+        #   * fresh CudaMemoryPool (own stream + allocations) per request
+        #   * fresh execution context per request for each shared engine
+        # Engines (weights) stay shared and read-only. Cleanup in finally.
+        pool = CudaMemoryPool()
+        vocos_ctx = self._vocos_engine.create_execution_context()
+        split_estimator_ctxs = [
+            eng.create_execution_context() for eng in self._split_estimator_engines
+        ]
 
-        # Step 1: text → tokens
-        t0 = time.time()
-        tokens = self._text_to_tokens(text)
-        text_ms = (time.time() - t0) * 1000
-        if len(tokens) == 0:
-            logger.warning("No tokens for text: %r", text)
-            silence = np.zeros(int(SAMPLE_RATE * 0.1), dtype=np.float32)
-            return _samples_to_wav(silence, SAMPLE_RATE), {
-                "duration": 0.1,
-                "inference_time": 0.0,
+        try:
+            t_start = time.time()
+
+            # Step 1: text → tokens
+            t0 = time.time()
+            tokens = self._text_to_tokens(text)
+            text_ms = (time.time() - t0) * 1000
+            if len(tokens) == 0:
+                logger.warning("No tokens for text: %r", text)
+                silence = np.zeros(int(SAMPLE_RATE * 0.1), dtype=np.float32)
+                return _samples_to_wav(silence, SAMPLE_RATE), {
+                    "duration": 0.1,
+                    "inference_time": 0.0,
+                    "language": detected_language,
+                }
+
+            num_tokens = min(len(tokens), 80)
+            t0 = time.time()
+            x = np.array([tokens[:num_tokens]], dtype=np.int64)
+            x_length = np.array([num_tokens], dtype=np.int64)
+            noise_scale = np.array([1.0], dtype=np.float32)
+            length_scale = np.array([1.0 / speed], dtype=np.float32)
+            if self._acoustic_mode == "split_trt":
+                mel = self._run_split_acoustic(
+                    x, x_length, noise_scale, length_scale,
+                    pool=pool, estimator_ctxs=split_estimator_ctxs,
+                )
+            else:
+                ao = self._acoustic_ort.run(None, {
+                    "x": x, "x_length": x_length,
+                    "noise_scale": noise_scale, "length_scale": length_scale,
+                })
+                mel = ao[0]  # [1, 80, T_mel] already denormalized (denorm baked into graph)
+            encoder_ms = (time.time() - t0) * 1000
+            estimator_ms = 0.0
+            mel_frames = mel.shape[2]
+            # Pad to MAX_MEL_FRAMES for vocos engine compat (drop excess if any)
+            if mel.shape[2] > MAX_MEL_FRAMES:
+                mel = mel[:, :, :MAX_MEL_FRAMES]
+                mel_frames = MAX_MEL_FRAMES
+            valid_mel_frames = mel_frames
+            mel = _pad_mel_axis(mel)
+            mel_frames = mel.shape[2]
+            mask = None
+            mask_valid = valid_mel_frames
+
+            def alloc(arr):
+                ptr = pool.allocate(arr.nbytes)
+                pool.copy_htod(arr, ptr)
+                return ptr
+            logger.debug("matcha frames: tokens=%d mask=%d mel_frames=%d (~%.2fs)",
+                         num_tokens, mask_valid, mel_frames, mel_frames * HOP_LENGTH / SAMPLE_RATE)
+
+            # Vocos
+            t0 = time.time()
+            mel_input = mel[:, :, :mel_frames].astype(np.float32)
+            d_mel = alloc(mel_input)
+            vocos_ctx.set_tensor_address("mels", d_mel)
+            vocos_ctx.set_input_shape("mels", (1, MEL_DIM, mel_frames))
+
+            mag = np.zeros((1, 513, mel_frames), dtype=np.float32)
+            out_x = np.zeros((1, 513, mel_frames), dtype=np.float32)
+            out_y = np.zeros((1, 513, mel_frames), dtype=np.float32)
+
+            d_mag = pool.allocate(mag.nbytes)
+            d_x_out = pool.allocate(out_x.nbytes)
+            d_y_out = pool.allocate(out_y.nbytes)
+
+            vocos_ctx.set_tensor_address("mag", d_mag)
+            vocos_ctx.set_tensor_address("x", d_x_out)
+            vocos_ctx.set_tensor_address("y", d_y_out)
+            vocos_ctx.execute_async_v3(pool.stream_handle())
+            pool.synchronize()
+
+            pool.copy_dtoh(d_mag, mag)
+            pool.copy_dtoh(d_x_out, out_x)
+            pool.copy_dtoh(d_y_out, out_y)
+            vocos_ms = (time.time() - t0) * 1000
+
+            # ISTFT runs on the padded engine shape, then trims to real duration.
+            audio = _istft(mag[0], out_x[0], out_y[0], length=valid_mel_frames * HOP_LENGTH)
+
+            # No peak normalize — sherpa returns raw ISTFT (offline-tts-impl.cc:88-102 only int16-scales).
+            # Clip to int16 range to prevent overflow on rare loud frames.
+            audio = np.clip(audio, -1.0, 1.0)
+
+            elapsed = time.time() - t_start
+            duration = len(audio) / SAMPLE_RATE
+            wav_bytes = _samples_to_wav(audio.astype(np.float32), SAMPLE_RATE)
+
+            meta = {
+                "duration": round(duration, 3),
+                "inference_time": round(elapsed, 3),
+                "rtf": round(elapsed / duration, 3) if duration > 0 else 0,
+                "sample_rate": SAMPLE_RATE,
+                "num_tokens": num_tokens,
+                "text_ms": round(text_ms, 1),
+                "encoder_ms": round(encoder_ms, 1),
+                "estimator_ms": round(estimator_ms, 1),
+                "vocos_ms": round(vocos_ms, 1),
                 "language": detected_language,
             }
-
-        num_tokens = min(len(tokens), 80)
-        t0 = time.time()
-        x = np.array([tokens[:num_tokens]], dtype=np.int64)
-        x_length = np.array([num_tokens], dtype=np.int64)
-        noise_scale = np.array([1.0], dtype=np.float32)
-        length_scale = np.array([1.0 / speed], dtype=np.float32)
-        if self._acoustic_mode == "split_trt":
-            mel = self._run_split_acoustic(x, x_length, noise_scale, length_scale)
-        else:
-            ao = self._acoustic_ort.run(None, {
-                "x": x, "x_length": x_length,
-                "noise_scale": noise_scale, "length_scale": length_scale,
-            })
-            mel = ao[0]  # [1, 80, T_mel] already denormalized (denorm baked into graph)
-        encoder_ms = (time.time() - t0) * 1000
-        estimator_ms = 0.0
-        mel_frames = mel.shape[2]
-        # Pad to MAX_MEL_FRAMES for vocos engine compat (drop excess if any)
-        if mel.shape[2] > MAX_MEL_FRAMES:
-            mel = mel[:, :, :MAX_MEL_FRAMES]
-            mel_frames = MAX_MEL_FRAMES
-        valid_mel_frames = mel_frames
-        mel = _pad_mel_axis(mel)
-        mel_frames = mel.shape[2]
-        mask = None
-        mask_valid = valid_mel_frames
-
-        def alloc(arr):
-            ptr = pool.allocate(arr.nbytes)
-            pool.copy_htod(arr, ptr)
-            return ptr
-        logger.debug("matcha frames: tokens=%d mask=%d mel_frames=%d (~%.2fs)",
-                     num_tokens, mask_valid, mel_frames, mel_frames * HOP_LENGTH / SAMPLE_RATE)
-
-        # Vocos
-        t0 = time.time()
-        mel_input = mel[:, :, :mel_frames].astype(np.float32)
-        d_mel = alloc(mel_input)
-        self._vocos_ctx.set_tensor_address("mels", d_mel)
-        self._vocos_ctx.set_input_shape("mels", (1, MEL_DIM, mel_frames))
-
-        mag = np.zeros((1, 513, mel_frames), dtype=np.float32)
-        out_x = np.zeros((1, 513, mel_frames), dtype=np.float32)
-        out_y = np.zeros((1, 513, mel_frames), dtype=np.float32)
-
-        d_mag = pool.allocate(mag.nbytes)
-        d_x_out = pool.allocate(out_x.nbytes)
-        d_y_out = pool.allocate(out_y.nbytes)
-
-        self._vocos_ctx.set_tensor_address("mag", d_mag)
-        self._vocos_ctx.set_tensor_address("x", d_x_out)
-        self._vocos_ctx.set_tensor_address("y", d_y_out)
-        self._vocos_ctx.execute_async_v3(pool.stream_handle())
-        pool.synchronize()
-
-        pool.copy_dtoh(d_mag, mag)
-        pool.copy_dtoh(d_x_out, out_x)
-        pool.copy_dtoh(d_y_out, out_y)
-        vocos_ms = (time.time() - t0) * 1000
-
-        # ISTFT runs on the padded engine shape, then trims to real duration.
-        audio = _istft(mag[0], out_x[0], out_y[0], length=valid_mel_frames * HOP_LENGTH)
-
-        # No peak normalize — sherpa returns raw ISTFT (offline-tts-impl.cc:88-102 only int16-scales).
-        # Clip to int16 range to prevent overflow on rare loud frames.
-        audio = np.clip(audio, -1.0, 1.0)
-
-        elapsed = time.time() - t_start
-        duration = len(audio) / SAMPLE_RATE
-        wav_bytes = _samples_to_wav(audio.astype(np.float32), SAMPLE_RATE)
-
-        meta = {
-            "duration": round(duration, 3),
-            "inference_time": round(elapsed, 3),
-            "rtf": round(elapsed / duration, 3) if duration > 0 else 0,
-            "sample_rate": SAMPLE_RATE,
-            "num_tokens": num_tokens,
-            "text_ms": round(text_ms, 1),
-            "encoder_ms": round(encoder_ms, 1),
-            "estimator_ms": round(estimator_ms, 1),
-            "vocos_ms": round(vocos_ms, 1),
-            "language": detected_language,
-        }
-        pool.free_all()
-        return wav_bytes, meta
+            return wav_bytes, meta
+        finally:
+            try:
+                pool.free_all()
+            except Exception:
+                logger.exception("matcha synth: pool.free_all failed")
+            try:
+                pool.destroy()
+            except Exception:
+                logger.exception("matcha synth: pool.destroy failed")
+            try:
+                del vocos_ctx
+            except Exception:
+                pass
+            for c in split_estimator_ctxs:
+                try:
+                    del c
+                except Exception:
+                    pass
 
     def generate_streaming(self, text: str, **kwargs):
         """Yield raw PCM int16 chunks.
@@ -751,8 +785,16 @@ class MatchaTRTBackend(TTSBackend):
         x_length: np.ndarray,
         noise_scale: np.ndarray,
         length_scale: np.ndarray,
+        *,
+        pool: "CudaMemoryPool",
+        estimator_ctxs: list,
     ) -> np.ndarray:
-        """Run Matcha acoustic as ORT encoder + TRT estimator ODE loop."""
+        """Run Matcha acoustic as ORT encoder + TRT estimator ODE loop.
+
+        ``pool`` and ``estimator_ctxs`` are per-call resources owned by the
+        caller (synthesize); we never touch self._cuda_pool /
+        self._split_estimator_ctxs here so concurrent callers can't collide.
+        """
         mu, mask, z = self._split_encoder_ort.run(None, {
             "x": x,
             "x_length": x_length,
@@ -773,15 +815,20 @@ class MatchaTRTBackend(TTSBackend):
         z = _pad_mel_axis(z)
         for step in range(N_ODE_STEPS):
             feeds = {"z": z, "mu": mu, "mask": mask}
-            velocity = self._run_estimator_trt(step, feeds)
+            velocity = self._run_estimator_trt(step, feeds, pool=pool, ctx=estimator_ctxs[step])
             z = z + ODE_DT * velocity
 
         mel = z[:, :, :valid_frames] * MEL_SIGMA + MEL_MEAN
         return mel.astype(np.float32)
 
-    def _run_estimator_trt(self, step: int, feeds: dict[str, np.ndarray]) -> np.ndarray:
-        pool = self._cuda_pool
-        ctx = self._split_estimator_ctxs[step]
+    def _run_estimator_trt(
+        self,
+        step: int,
+        feeds: dict[str, np.ndarray],
+        *,
+        pool: "CudaMemoryPool",
+        ctx,
+    ) -> np.ndarray:
 
         def alloc_input(name: str, arr: np.ndarray) -> int:
             arr = np.ascontiguousarray(arr.astype(np.float32, copy=False))

--- a/app/backends/jetson/matcha_trt.py
+++ b/app/backends/jetson/matcha_trt.py
@@ -227,6 +227,38 @@ class MatchaTRTBackend(TTSBackend):
     # matcha_trt_unload_vram_release (orin-nx N-round swap test).
     supports_hot_reload: bool = True
 
+    @classmethod
+    def concurrency_capability(cls, profile=None):
+        from app.core.concurrency_capability import ConcurrencyCapability
+
+        # K = OVS_TTS_STREAM_MAX_WORKERS (default 2), matching _build_ctx_pool().
+        # Profile may override via tts_stream_max_workers (or nested
+        # tts_backend_config.stream_max_workers). Engines (weights) are shared;
+        # each slot holds its own pre-allocated TRT execution contexts so K
+        # concurrent synthesize() calls never share a context.
+        env_val = os.environ.get("OVS_TTS_STREAM_MAX_WORKERS")
+        profile_val = None
+        if isinstance(profile, dict):
+            profile_val = profile.get("tts_stream_max_workers")
+            if profile_val is None:
+                cfg = profile.get("tts_backend_config")
+                if isinstance(cfg, dict):
+                    profile_val = cfg.get("stream_max_workers")
+        try:
+            k = int(env_val) if env_val is not None else (
+                int(profile_val) if profile_val is not None else 2
+            )
+        except (TypeError, ValueError):
+            k = 2
+        k = max(1, k)
+        return ConcurrencyCapability(
+            supports_parallel=k > 1,
+            max_concurrent=k,
+            is_stateful=True,
+            requires_exclusive_device=True,
+            scaling_mode="single_runtime_multiplex",
+        )
+
     def __init__(self):
         self._acoustic_ort = None
         self._split_encoder_ort = None

--- a/app/backends/jetson/matcha_trt.py
+++ b/app/backends/jetson/matcha_trt.py
@@ -12,6 +12,7 @@ import ctypes
 import io
 import logging
 import os
+import queue
 import struct
 import time
 import numpy as np
@@ -168,6 +169,49 @@ def _istft(mag: np.ndarray, x: np.ndarray, y: np.ndarray, length: Optional[int] 
     return audio
 
 
+class _MatchaCtxSlot:
+    """One pre-allocated set of TRT contexts + persistent CudaMemoryPool.
+
+    A pool of K slots is built at preload() time. Each synthesize() acquires
+    one slot, runs the inference, then releases it back. This amortizes the
+    expensive create_execution_context() call (~900ms each on Jetson Orin
+    Nano) across the service lifetime instead of paying it per request.
+
+    Concurrency safety: each slot owns its own CUDA stream + execution
+    contexts, and the queue-based acquire/release guarantees no two threads
+    share a slot at the same time. Engines (weights) remain shared and
+    read-only across slots.
+    """
+
+    def __init__(self, vocos_engine, split_estimator_engines):
+        self.pool = CudaMemoryPool()  # persistent stream
+        self.vocos_ctx = (
+            vocos_engine.create_execution_context() if vocos_engine is not None else None
+        )
+        self.split_estimator_ctxs = [
+            eng.create_execution_context() for eng in split_estimator_engines
+        ]
+
+    def reset_per_request(self):
+        """Release device allocations after each synthesize but keep stream + ctxs."""
+        try:
+            self.pool.free_all()
+        except Exception:
+            logger.exception("MatchaCtxSlot.reset_per_request: pool.free_all raised")
+
+    def destroy(self):
+        try:
+            self.pool.synchronize()
+        except Exception:
+            pass
+        try:
+            self.pool.destroy()
+        except Exception:
+            pass
+        self.vocos_ctx = None
+        self.split_estimator_ctxs = []
+
+
 class MatchaTRTBackend(TTSBackend):
     """Matcha TTS backend.
 
@@ -201,6 +245,15 @@ class MatchaTRTBackend(TTSBackend):
         self._lexicon = None
         self._token_to_id = None
         self._ready = False
+        # Pre-allocated context pool (built in preload()). N slots, each owning
+        # one CUDA stream + per-engine execution contexts. synthesize() borrows
+        # one slot from the queue, returns it in a finally block. Amortizes the
+        # ~900ms-per-context create_execution_context() cost on Jetson Orin
+        # Nano across the service lifetime — see commit msg / docs for the
+        # latency regression that drove this refactor.
+        self._ctx_pool: "queue.Queue[_MatchaCtxSlot]" = queue.Queue()
+        self._slots: list[_MatchaCtxSlot] = []
+        self._pool_size: int = 0
         # Snapshot artifact paths from the *current* os.environ. BackendManager
         # rebuilds this backend after every apply_profile(), so __init__ always
         # sees the latest profile-applied env. See trt_edge_llm_tts.py and
@@ -261,6 +314,7 @@ class MatchaTRTBackend(TTSBackend):
             and not self._split_estimator_engines
             and self._vocos_engine is None
             and self._cuda_pool is None
+            and not self._slots
         ):
             return
 
@@ -272,7 +326,24 @@ class MatchaTRTBackend(TTSBackend):
                 except Exception:
                     logger.exception("Matcha unload: pool.synchronize failed; continuing")
 
-            # 2. Execution contexts before engines
+            # 2. Execution contexts before engines.
+            # 2a. Drain per-slot ctxs + stream + remaining device buffers.
+            while True:
+                try:
+                    self._ctx_pool.get_nowait()
+                except queue.Empty:
+                    break
+            for i, slot in enumerate(self._slots):
+                try:
+                    slot.destroy()
+                except Exception:
+                    logger.exception("Matcha unload: slot[%d] destroy raised", i)
+            self._slots = []
+            self._pool_size = 0
+
+            # 2b. Back-compat: legacy shared ctx list (always empty after
+            # pre-allocated pool refactor) is still cleared so tests that
+            # manually populate it for unload-ordering assertions still pass.
             for i, ctx in enumerate(self._split_estimator_ctxs):
                 try:
                     del ctx
@@ -329,8 +400,32 @@ class MatchaTRTBackend(TTSBackend):
         self._load_lexicon()
         self._load_acoustic_ort()
         self._load_engines()
+        self._build_ctx_pool()
         self._warmup()
         self._ready = True
+
+    def _build_ctx_pool(self) -> None:
+        """Pre-allocate K context slots and seed the queue.
+
+        K = OVS_TTS_STREAM_MAX_WORKERS (default 2). K=1 still goes through the
+        queue path for code-path uniformity. Logs the slot count so deploy
+        verification can grep for it.
+        """
+        try:
+            k = int(os.environ.get("OVS_TTS_STREAM_MAX_WORKERS", "2"))
+        except ValueError:
+            k = 2
+        k = max(1, k)
+        self._pool_size = k
+        self._slots = []
+        t0 = time.time()
+        for _ in range(k):
+            slot = _MatchaCtxSlot(self._vocos_engine, self._split_estimator_engines)
+            self._slots.append(slot)
+            self._ctx_pool.put(slot)
+        logger.info(
+            "Matcha ctx pool: %d slots pre-allocated (%.2fs)", k, time.time() - t0
+        )
 
     def _load_acoustic_ort(self):
         """Load acoustic frontend.
@@ -610,15 +705,32 @@ class MatchaTRTBackend(TTSBackend):
             speed = 1.0
         detected_language = detect_zh_en(text, language)
 
-        # Per-call concurrency rework (N>=2 safety):
-        #   * fresh CudaMemoryPool (own stream + allocations) per request
-        #   * fresh execution context per request for each shared engine
-        # Engines (weights) stay shared and read-only. Cleanup in finally.
-        pool = CudaMemoryPool()
-        vocos_ctx = self._vocos_engine.create_execution_context()
-        split_estimator_ctxs = [
-            eng.create_execution_context() for eng in self._split_estimator_engines
-        ]
+        # Borrow a pre-allocated context slot. Blocks if all slots are in
+        # use. Each slot owns its own CUDA stream + execution contexts so
+        # concurrent callers never share TRT IExecutionContext (not
+        # thread-safe). free_all() between requests releases device buffers
+        # while keeping the stream + ctxs warm.
+        #
+        # No-slot path: when called from a unit test that builds the backend
+        # without preload() (e.g. _pad_mel_axis tests), _slots is empty. We
+        # fall back to a one-off per-call set in that case so tests don't
+        # block on an empty queue.
+        if self._slots:
+            slot = self._ctx_pool.get()
+            pool = slot.pool
+            vocos_ctx = slot.vocos_ctx
+            split_estimator_ctxs = slot.split_estimator_ctxs
+        else:
+            slot = None
+            pool = CudaMemoryPool()
+            vocos_ctx = (
+                self._vocos_engine.create_execution_context()
+                if self._vocos_engine is not None else None
+            )
+            split_estimator_ctxs = [
+                eng.create_execution_context()
+                for eng in self._split_estimator_engines
+            ]
 
         try:
             t_start = time.time()
@@ -724,21 +836,18 @@ class MatchaTRTBackend(TTSBackend):
             }
             return wav_bytes, meta
         finally:
-            try:
-                pool.free_all()
-            except Exception:
-                logger.exception("matcha synth: pool.free_all failed")
-            try:
-                pool.destroy()
-            except Exception:
-                logger.exception("matcha synth: pool.destroy failed")
-            try:
-                del vocos_ctx
-            except Exception:
-                pass
-            for c in split_estimator_ctxs:
+            if slot is not None:
                 try:
-                    del c
+                    slot.reset_per_request()
+                finally:
+                    self._ctx_pool.put(slot)
+            else:
+                try:
+                    pool.free_all()
+                except Exception:
+                    pass
+                try:
+                    pool.destroy()
                 except Exception:
                     pass
 

--- a/app/backends/jetson/paraformer_trt.py
+++ b/app/backends/jetson/paraformer_trt.py
@@ -746,6 +746,24 @@ class ParaformerTRTStream(ASRStream):
 
 class ParaformerTRTBackend(ASRBackend):
 
+    @classmethod
+    def concurrency_capability(cls, profile=None):
+        from app.core.concurrency_capability import ConcurrencyCapability
+
+        # Per-stream _ParaformerCtxBundle: each ASRStream owns its own enc/dec
+        # TRT execution contexts + buffer cache. Backend only holds shared
+        # engines (weights). There is no fixed pool — concurrency scales with
+        # the number of open streams, bounded only by VRAM. See spec Section 1
+        # row "paraformer_trt" and ASRStream.close()/__del__ in
+        # app/core/asr_backend.py for bundle lifetime.
+        return ConcurrencyCapability(
+            supports_parallel=True,
+            max_concurrent=None,
+            is_stateful=True,
+            requires_exclusive_device=True,
+            scaling_mode="multi_runtime_per_slot",
+        )
+
     def __init__(self):
         # Per-stream concurrency rework (N>=2 safety): TRT IExecutionContext
         # is not thread-safe. Backend keeps shared engines (weights) only;

--- a/app/backends/jetson/paraformer_trt.py
+++ b/app/backends/jetson/paraformer_trt.py
@@ -354,6 +354,72 @@ def _load_trt_engine(path: str):
 
 
 # ---------------------------------------------------------------------------
+# Per-stream context bundle (N>=2 concurrency safety)
+# ---------------------------------------------------------------------------
+
+
+class _ParaformerCtxBundle:
+    """Per-stream TRT execution contexts + device buffer cache.
+
+    TRT IExecutionContext is not thread-safe. Each ParaformerTRTStream owns
+    one bundle so concurrent streams never share a context or device
+    allocation. The encoder/decoder engines (weights) are still shared and
+    immutable on the backend.
+
+    Buffer cache is keyed by shape, reused across utterances within the same
+    stream (matches the pre-refactor self._bindings behaviour) — only the
+    cross-stream sharing is removed.
+    """
+
+    def __init__(self, enc_engine, dec_engine):
+        self.enc_ctx = enc_engine.create_execution_context() if enc_engine is not None else None
+        self.dec_ctx = dec_engine.create_execution_context() if dec_engine is not None else None
+        self.enc_bindings: dict[str, dict] = {}
+        self.dec_bindings: dict[str, dict] = {}
+        self.enc_active_profile: Optional[int] = None
+        self._allocations: list[int] = []
+        self._destroyed = False
+
+    def alloc(self, nbytes: int) -> int:
+        err, ptr = cudart.cudaMalloc(nbytes)
+        if int(err) != 0:
+            raise RuntimeError(f"cudaMalloc({nbytes}) failed: {err}")
+        self._allocations.append(int(ptr))
+        return int(ptr)
+
+    def destroy(self) -> None:
+        if self._destroyed:
+            return
+        self._destroyed = True
+        try:
+            cudart.cudaDeviceSynchronize()
+        except Exception:
+            pass
+        for ptr in self._allocations:
+            try:
+                cudart.cudaFree(ptr)
+            except Exception:
+                pass
+        self._allocations.clear()
+        self.enc_bindings.clear()
+        self.dec_bindings.clear()
+        try:
+            self.enc_ctx = None
+        except Exception:
+            pass
+        try:
+            self.dec_ctx = None
+        except Exception:
+            pass
+
+    def __del__(self):
+        try:
+            self.destroy()
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
 # ParaformerTRTStream
 # ---------------------------------------------------------------------------
 
@@ -398,6 +464,30 @@ class ParaformerTRTStream(ASRStream):
         # Barge-in cancel state
         self._cancelled = False
         self._final_text_cache = ""
+
+        # Per-stream TRT context + device buffer bundle (N>=2 safety).
+        # Engines stay shared on the backend; only contexts/buffers per stream.
+        self._ctx_bundle: Optional[_ParaformerCtxBundle] = backend.create_context_bundle()
+
+    def close(self) -> None:
+        """Release per-stream TRT contexts and device buffers.
+
+        Idempotent. Called by the upper layer when the WS session ends.
+        Stream is unusable after close().
+        """
+        bundle = self._ctx_bundle
+        self._ctx_bundle = None
+        if bundle is not None:
+            try:
+                bundle.destroy()
+            except Exception:
+                logger.exception("ParaformerTRTStream.close: bundle.destroy raised")
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
 
     def _reset_utterance_state(self) -> None:
         self._audio_buf = initial_preroll_audio()
@@ -470,7 +560,7 @@ class ParaformerTRTStream(ASRStream):
         new_stacked = new_lfr
 
         t1 = time.perf_counter()
-        enc, alphas = self._backend._run_encoder(feats)
+        enc, alphas = self._backend._run_encoder(feats, self._ctx_bundle)
         enc_time = (time.perf_counter() - t1) * 1000
         self._total_enc_ms += enc_time
 
@@ -519,6 +609,7 @@ class ParaformerTRTStream(ASRStream):
             enc, enc.shape[1],
             acoustic_embeds, len(acoustic_embeds),
             self._cache,
+            self._ctx_bundle,
         )
         dec_time = (time.perf_counter() - t2) * 1000
         self._total_dec_ms += dec_time
@@ -578,7 +669,7 @@ class ParaformerTRTStream(ASRStream):
             # cap) and drain ALL pending CIF frames (no right-defer — there's
             # no more future audio).
             feats = all_lfr if cur_total_lfr <= 400 else all_lfr[-400:]
-            enc, alphas = self._backend._run_encoder(feats)
+            enc, alphas = self._backend._run_encoder(feats, self._ctx_bundle)
             if enc is not None and alphas is not None:
                 # CIF from where streaming left off to the very end
                 cif_start = max(self._cif_processed_lfr,
@@ -600,6 +691,7 @@ class ParaformerTRTStream(ASRStream):
                         enc, enc.shape[1],
                         acoustic_embeds, len(acoustic_embeds),
                         self._cache,
+                        self._ctx_bundle,
                     )
                     if sample_ids is not None:
                         self._all_token_ids.extend(sample_ids.tolist())
@@ -632,6 +724,7 @@ class ParaformerTRTStream(ASRStream):
                 dummy_enc, 1,
                 acoustic_embeds, 1,
                 self._cache,
+                self._ctx_bundle,
             )
             if sample_ids is not None:
                 new_ids = sample_ids.tolist()
@@ -654,15 +747,35 @@ class ParaformerTRTStream(ASRStream):
 class ParaformerTRTBackend(ASRBackend):
 
     def __init__(self):
+        # Per-stream concurrency rework (N>=2 safety): TRT IExecutionContext
+        # is not thread-safe. Backend keeps shared engines (weights) only;
+        # contexts + device buffer cache live in a per-stream
+        # _ParaformerCtxBundle owned by ParaformerTRTStream. The legacy
+        # self._contexts / self._bindings / self._enc_active_profile attrs
+        # are removed entirely — callers must use create_context_bundle().
         self._engines: dict[str, trt.IEngine] = {}
-        self._contexts: dict[str, trt.IExecutionContext] = {}
-        self._bindings: dict[str, dict] = {}
         self._enc_ort_session = None  # ORT fallback for encoder
         self._enc_provider = "trt"  # "trt" or "ort_cuda"
         self._tokens: list[str] = []
         self._ready = False
-        self._enc_active_profile: Optional[int] = None
         self._enc_profile_ranges: list[tuple[int, int, int]] = []
+
+    def create_context_bundle(self) -> "_ParaformerCtxBundle":
+        """Build a fresh per-stream execution context + buffer cache.
+
+        Called by ParaformerTRTStream.__init__. Returns a bundle that owns
+        its own enc/dec contexts and a private device-buffer dict, so
+        concurrent streams never share TRT state. Bundle must be
+        destroy()ed via ParaformerTRTStream.close() / __del__ to release
+        device memory.
+        """
+        enc_eng = self._engines.get("enc")
+        dec_eng = self._engines.get("dec")
+        if dec_eng is None:
+            raise RuntimeError(
+                "Paraformer TRT decoder engine not loaded; call preload() first"
+            )
+        return _ParaformerCtxBundle(enc_eng, dec_eng)
 
     # -- Properties ----------------------------------------------------------
 
@@ -710,52 +823,58 @@ class ParaformerTRTBackend(ASRBackend):
         tensor_names = [eng.get_tensor_name(i) for i in range(eng.num_io_tensors)]
         logger.info("Encoder engine (%d I/O): %s", len(tensor_names), tensor_names)
         self._enc_profile_ranges = self._load_encoder_profile_ranges(eng)
-        self._contexts["enc"] = eng.create_execution_context()
 
-        # Validate encoder TRT engine with a warmup run. Use a low-level sine
-        # signal instead of zeros — zero audio causes LayerNorm division-by-zero
-        # in TRT's FP16/BF16 kernels (ORT adds epsilon, TRT may not).
+        # -- Load decoder TRT engine (needed to build the warmup bundle) --
+        self._engines["dec"] = _load_trt_engine(DEC_ENGINE_PATH)
+        dec_eng = self._engines["dec"]
+        dec_tensor_names = [dec_eng.get_tensor_name(i) for i in range(dec_eng.num_io_tensors)]
+        logger.info("Decoder engine (%d I/O): %s", len(dec_tensor_names), dec_tensor_names)
+
+        # Validate encoder TRT engine with a warmup run via a temporary bundle.
+        # Use a low-level sine signal instead of zeros — zero audio causes
+        # LayerNorm division-by-zero in TRT's FP16/BF16 kernels (ORT adds
+        # epsilon, TRT may not).
         warmup_audio = (np.sin(2 * np.pi * 440 * np.arange(SAMPLE_RATE) / SAMPLE_RATE) * 0.3).astype(np.float32)
         warmup_feats = compute_fbank(warmup_audio)
         warmup_feats = stack_frames(warmup_feats)
         n_warmup = min(warmup_feats.shape[0], 40)
         warmup_feats = warmup_feats[:n_warmup]
 
-        enc, alphas = self._run_encoder_trt(warmup_feats)
-        if enc is not None and alphas is not None and not np.isnan(alphas).any():
-            logger.info("Encoder TRT engine validated (no NaN)")
-            self._enc_provider = "trt"
-        else:
-            logger.warning(
-                "Encoder TRT engine produces NaN, falling back to ORT CUDA EP. "
-                "Rebuild the encoder in FP32 to restore TRT."
-            )
-            self._enc_provider = "ort_cuda"
-            import onnxruntime
-            enc_ort_opts = onnxruntime.SessionOptions()
-            enc_ort_opts.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_ALL
-            enc_ort_opts.log_severity_level = 3
-            self._enc_ort_session = onnxruntime.InferenceSession(
-                ENC_ONNX_PATH,
-                sess_options=enc_ort_opts,
-                providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
-            )
-            logger.info("Encoder ORT session loaded (providers: %s)", self._enc_ort_session.get_providers())
-            # Warmup ORT encoder
-            self._run_encoder_ort(warmup_feats)
+        warmup_bundle = self.create_context_bundle()
+        try:
+            enc, alphas = self._run_encoder_trt(warmup_feats, warmup_bundle)
+            if enc is not None and alphas is not None and not np.isnan(alphas).any():
+                logger.info("Encoder TRT engine validated (no NaN)")
+                self._enc_provider = "trt"
+            else:
+                logger.warning(
+                    "Encoder TRT engine produces NaN, falling back to ORT CUDA EP. "
+                    "Rebuild the encoder in FP32 to restore TRT."
+                )
+                self._enc_provider = "ort_cuda"
+                import onnxruntime
+                enc_ort_opts = onnxruntime.SessionOptions()
+                enc_ort_opts.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_ALL
+                enc_ort_opts.log_severity_level = 3
+                self._enc_ort_session = onnxruntime.InferenceSession(
+                    ENC_ONNX_PATH,
+                    sess_options=enc_ort_opts,
+                    providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
+                )
+                logger.info("Encoder ORT session loaded (providers: %s)", self._enc_ort_session.get_providers())
+                # Warmup ORT encoder
+                self._run_encoder_ort(warmup_feats)
 
-        # -- Load decoder TRT engine --
-        self._engines["dec"] = _load_trt_engine(DEC_ENGINE_PATH)
-        dec_eng = self._engines["dec"]
-        dec_tensor_names = [dec_eng.get_tensor_name(i) for i in range(dec_eng.num_io_tensors)]
-        logger.info("Decoder engine (%d I/O): %s", len(dec_tensor_names), dec_tensor_names)
-        self._contexts["dec"] = dec_eng.create_execution_context()
-
-        # Warmup decoder
-        dummy_enc = np.zeros((1, 1, 512), dtype=np.float32)
-        dummy_ae = np.zeros((1, 512), dtype=np.float32)
-        dummy_cache = [np.zeros((1, 512, 10), dtype=np.float32) for _ in range(16)]
-        self._run_decoder(dummy_enc, 1, dummy_ae, 1, dummy_cache)
+            # Warmup decoder via the same temp bundle
+            dummy_enc = np.zeros((1, 1, 512), dtype=np.float32)
+            dummy_ae = np.zeros((1, 512), dtype=np.float32)
+            dummy_cache = [np.zeros((1, 512, 10), dtype=np.float32) for _ in range(16)]
+            self._run_decoder(dummy_enc, 1, dummy_ae, 1, dummy_cache, warmup_bundle)
+        finally:
+            try:
+                warmup_bundle.destroy()
+            except Exception:
+                logger.exception("paraformer preload: warmup_bundle destroy raised")
 
         logger.info("Paraformer TRT backend ready (encoder=%s, decoder=trt)", self._enc_provider)
         self._ready = True
@@ -805,43 +924,53 @@ class ParaformerTRTBackend(ASRBackend):
         carry_e = np.zeros(512, dtype=np.float32)
         cache = [np.zeros((1, 512, 10), dtype=np.float32) for _ in range(16)]
 
-        for start in range(0, feats.shape[0], chunk_frames):
-            chunk = feats[start:start + chunk_frames]
-            if chunk.shape[0] < chunk_frames:
-                pad = np.zeros((chunk_frames - chunk.shape[0], 560), dtype=np.float32)
-                chunk = np.concatenate([chunk, pad], axis=0)
+        # Non-streaming path: own a transient per-call bundle so we never
+        # touch a stream's TRT state.
+        bundle = self.create_context_bundle()
+        try:
+            for start in range(0, feats.shape[0], chunk_frames):
+                chunk = feats[start:start + chunk_frames]
+                if chunk.shape[0] < chunk_frames:
+                    pad = np.zeros((chunk_frames - chunk.shape[0], 560), dtype=np.float32)
+                    chunk = np.concatenate([chunk, pad], axis=0)
 
-            enc, alphas = self._run_encoder(chunk)
-            if enc is None:
-                continue
+                enc, alphas = self._run_encoder(chunk, bundle)
+                if enc is None:
+                    continue
 
-            enc_t = enc[0]
-            alphas_t = alphas[0]
+                enc_t = enc[0]
+                alphas_t = alphas[0]
 
-            acoustic_embeds, carry_w, carry_e = cif(
-                enc_t, alphas_t, carry_weight=carry_w, carry_embed=carry_e,
-            )
+                acoustic_embeds, carry_w, carry_e = cif(
+                    enc_t, alphas_t, carry_weight=carry_w, carry_embed=carry_e,
+                )
 
-            if len(acoustic_embeds) == 0:
-                continue
+                if len(acoustic_embeds) == 0:
+                    continue
 
-            sample_ids = self._run_decoder(
-                enc, alphas.shape[1],
-                acoustic_embeds, len(acoustic_embeds),
-                cache,
-            )
-            if sample_ids is not None:
-                all_token_ids.extend(sample_ids.tolist())
+                sample_ids = self._run_decoder(
+                    enc, alphas.shape[1],
+                    acoustic_embeds, len(acoustic_embeds),
+                    cache,
+                    bundle,
+                )
+                if sample_ids is not None:
+                    all_token_ids.extend(sample_ids.tolist())
 
-        # Flush tail
-        if carry_w >= CIF_TAIL_THRESHOLD:
-            acoustic_embeds = (carry_e / carry_w)[np.newaxis, :]
-            dummy_enc = np.zeros((1, 1, 512), dtype=np.float32)
-            sample_ids = self._run_decoder(
-                dummy_enc, 1, acoustic_embeds, 1, cache,
-            )
-            if sample_ids is not None:
-                all_token_ids.extend(sample_ids.tolist())
+            # Flush tail
+            if carry_w >= CIF_TAIL_THRESHOLD:
+                acoustic_embeds = (carry_e / carry_w)[np.newaxis, :]
+                dummy_enc = np.zeros((1, 1, 512), dtype=np.float32)
+                sample_ids = self._run_decoder(
+                    dummy_enc, 1, acoustic_embeds, 1, cache, bundle,
+                )
+                if sample_ids is not None:
+                    all_token_ids.extend(sample_ids.tolist())
+        finally:
+            try:
+                bundle.destroy()
+            except Exception:
+                logger.exception("paraformer transcribe: bundle destroy raised")
 
         full_text = decode_ids(all_token_ids, self._tokens)
         return TranscriptionResult(text=full_text, language=language)
@@ -862,48 +991,56 @@ class ParaformerTRTBackend(ASRBackend):
         carry_e = np.zeros(512, dtype=np.float32)
         cache = [np.zeros((1, 512, 10), dtype=np.float32) for _ in range(16)]
 
-        for start in range(0, feats.shape[0], chunk_frames):
-            chunk = feats[start:start + chunk_frames]
-            if chunk.shape[0] < chunk_frames:
-                pad = np.zeros((chunk_frames - chunk.shape[0], 560), dtype=np.float32)
-                chunk = np.concatenate([chunk, pad], axis=0)
+        bundle = self.create_context_bundle()
+        try:
+            for start in range(0, feats.shape[0], chunk_frames):
+                chunk = feats[start:start + chunk_frames]
+                if chunk.shape[0] < chunk_frames:
+                    pad = np.zeros((chunk_frames - chunk.shape[0], 560), dtype=np.float32)
+                    chunk = np.concatenate([chunk, pad], axis=0)
 
-            enc, alphas = self._run_encoder(chunk)
-            if enc is None:
-                continue
+                enc, alphas = self._run_encoder(chunk, bundle)
+                if enc is None:
+                    continue
 
-            enc_t = enc[0]
-            alphas_t = alphas[0]
+                enc_t = enc[0]
+                alphas_t = alphas[0]
 
-            acoustic_embeds, carry_w, carry_e = cif(
-                enc_t, alphas_t, carry_weight=carry_w, carry_embed=carry_e,
-            )
+                acoustic_embeds, carry_w, carry_e = cif(
+                    enc_t, alphas_t, carry_weight=carry_w, carry_embed=carry_e,
+                )
 
-            if len(acoustic_embeds) == 0:
-                continue
+                if len(acoustic_embeds) == 0:
+                    continue
 
-            sample_ids = self._run_decoder(
-                enc, alphas.shape[1],
-                acoustic_embeds, len(acoustic_embeds),
-                cache,
-            )
-            if sample_ids is not None:
-                new_ids = sample_ids.tolist()
-                text = decode_ids(new_ids, self._tokens)
-                if text:
-                    all_text_parts.append(text)
+                sample_ids = self._run_decoder(
+                    enc, alphas.shape[1],
+                    acoustic_embeds, len(acoustic_embeds),
+                    cache,
+                    bundle,
+                )
+                if sample_ids is not None:
+                    new_ids = sample_ids.tolist()
+                    text = decode_ids(new_ids, self._tokens)
+                    if text:
+                        all_text_parts.append(text)
 
-        # Flush tail (mirror of transcribe() L674-684)
-        if carry_w >= CIF_TAIL_THRESHOLD:
-            acoustic_embeds = (carry_e / carry_w)[np.newaxis, :]
-            dummy_enc = np.zeros((1, 1, 512), dtype=np.float32)
-            sample_ids = self._run_decoder(
-                dummy_enc, 1, acoustic_embeds, 1, cache,
-            )
-            if sample_ids is not None:
-                text = decode_ids(sample_ids.tolist(), self._tokens)
-                if text:
-                    all_text_parts.append(text)
+            # Flush tail (mirror of transcribe() L674-684)
+            if carry_w >= CIF_TAIL_THRESHOLD:
+                acoustic_embeds = (carry_e / carry_w)[np.newaxis, :]
+                dummy_enc = np.zeros((1, 1, 512), dtype=np.float32)
+                sample_ids = self._run_decoder(
+                    dummy_enc, 1, acoustic_embeds, 1, cache, bundle,
+                )
+                if sample_ids is not None:
+                    text = decode_ids(sample_ids.tolist(), self._tokens)
+                    if text:
+                        all_text_parts.append(text)
+        finally:
+            try:
+                bundle.destroy()
+            except Exception:
+                logger.exception("paraformer transcribe_audio: bundle destroy raised")
 
         full_text = "".join(all_text_parts)
         return TranscriptionResult(text=full_text, language=language)
@@ -922,11 +1059,19 @@ class ParaformerTRTBackend(ASRBackend):
             return result[0]
         return result
 
-    def _run_encoder(self, feats: np.ndarray) -> tuple[Optional[np.ndarray], Optional[np.ndarray]]:
-        """Dispatch encoder to TRT or ORT based on runtime validation."""
+    def _run_encoder(
+        self,
+        feats: np.ndarray,
+        bundle: "_ParaformerCtxBundle",
+    ) -> tuple[Optional[np.ndarray], Optional[np.ndarray]]:
+        """Dispatch encoder to TRT or ORT based on runtime validation.
+
+        ``bundle`` is the per-stream TRT context + buffer cache. ORT path
+        ignores it (CPU/CUDA EP own their own session state).
+        """
         if self._enc_provider == "ort_cuda":
             return self._run_encoder_ort(feats)
-        return self._run_encoder_trt(feats)
+        return self._run_encoder_trt(feats, bundle)
 
     def _run_encoder_ort(self, feats: np.ndarray) -> tuple[Optional[np.ndarray], Optional[np.ndarray]]:
         """Run encoder via ONNX Runtime CUDA EP.
@@ -963,11 +1108,21 @@ class ParaformerTRTBackend(ASRBackend):
 
         return enc_out, alphas_out
 
-    def _run_encoder_trt(self, feats: np.ndarray) -> tuple[Optional[np.ndarray], Optional[np.ndarray]]:
+    def _run_encoder_trt(
+        self,
+        feats: np.ndarray,
+        bundle: "_ParaformerCtxBundle",
+    ) -> tuple[Optional[np.ndarray], Optional[np.ndarray]]:
         """Run encoder TRT inference via set_tensor_address + execute_async_v3.
 
         TRT 10.x requires explicit tensor address registration before execute_async_v3.
         execute_v2(bindings) does NOT work with dynamic shapes in TRT 10.3.
+
+        Per-stream concurrency: ``bundle`` owns the IExecutionContext, the
+        device-buffer cache (bundle.enc_bindings) and the
+        per-context active-profile state (bundle.enc_active_profile). Two
+        concurrent streams have independent bundles so they can't race on
+        TRT context state or stomp each other's buffers.
 
         Args:
             feats: [feats_length, 560] float32
@@ -976,7 +1131,7 @@ class ParaformerTRTBackend(ASRBackend):
             enc: [1, feats_length, 512] or None on failure
             alphas: [1, feats_length] or None on failure
         """
-        ctx = self._contexts["enc"]
+        ctx = bundle.enc_ctx
         n_frames = feats.shape[0]
         profile_idx, enc_min_frames, enc_max_frames = self._select_encoder_profile(n_frames)
         if n_frames > enc_max_frames:
@@ -994,10 +1149,10 @@ class ParaformerTRTBackend(ASRBackend):
             n_frames = enc_min_frames
 
         key = f"enc_p{profile_idx}_{n_frames}"
-        if key not in self._bindings:
-            self._bindings[key] = self._alloc_enc_buffers(n_frames)
+        if key not in bundle.enc_bindings:
+            bundle.enc_bindings[key] = self._alloc_enc_buffers(n_frames, bundle)
 
-        bufs = self._bindings[key]
+        bufs = bundle.enc_bindings[key]
 
         # Execute on a fresh CUDA stream. Profile changes are asynchronous in
         # TRT 10, so synchronize the previous work before switching and the
@@ -1007,7 +1162,7 @@ class ParaformerTRTBackend(ASRBackend):
             logger.error("cudaStreamCreate failed: %s", err)
             return None, None
 
-        if self._enc_active_profile != profile_idx:
+        if bundle.enc_active_profile != profile_idx:
             cudart.cudaDeviceSynchronize()
             if hasattr(ctx, "set_optimization_profile_async"):
                 success = ctx.set_optimization_profile_async(profile_idx, stream)
@@ -1022,7 +1177,7 @@ class ParaformerTRTBackend(ASRBackend):
                 cudart.cudaStreamSynchronize(stream)
             elif hasattr(ctx, "active_optimization_profile"):
                 ctx.active_optimization_profile = profile_idx
-            self._enc_active_profile = profile_idx
+            bundle.enc_active_profile = profile_idx
 
         # TRT 10.x: register tensor addresses
         ctx.set_tensor_address("speech", bufs["speech"])
@@ -1125,20 +1280,14 @@ class ParaformerTRTBackend(ASRBackend):
 
         return max(ranges, key=lambda item: item[2])
 
-    def _alloc_enc_buffers(self, n_frames: int) -> dict:
+    def _alloc_enc_buffers(self, n_frames: int, bundle: "_ParaformerCtxBundle") -> dict:
         bufs = {}
-        bufs["speech"] = self._cuda_malloc(1 * n_frames * 560 * 4)
-        bufs["speech_lengths"] = self._cuda_malloc(4)
-        bufs["enc"] = self._cuda_malloc(1 * n_frames * 512 * 4)
-        bufs["enc_len"] = self._cuda_malloc(4)
-        bufs["alphas"] = self._cuda_malloc(1 * n_frames * 4)
+        bufs["speech"] = bundle.alloc(1 * n_frames * 560 * 4)
+        bufs["speech_lengths"] = bundle.alloc(4)
+        bufs["enc"] = bundle.alloc(1 * n_frames * 512 * 4)
+        bufs["enc_len"] = bundle.alloc(4)
+        bufs["alphas"] = bundle.alloc(1 * n_frames * 4)
         return bufs
-
-    def _cuda_malloc(self, nbytes: int) -> int:
-        err, ptr = cudart.cudaMalloc(nbytes)
-        if err != 0:
-            raise RuntimeError(f"cudaMalloc({nbytes}) failed: {err}")
-        return int(ptr)
 
     # -- Internal: Decoder ORT-CUDA inference ------------------------------
 
@@ -1149,6 +1298,7 @@ class ParaformerTRTBackend(ASRBackend):
         acoustic_embeds: np.ndarray,
         acoustic_embeds_len: int,
         cache: list[np.ndarray],
+        bundle: "_ParaformerCtxBundle",
     ) -> Optional[np.ndarray]:
         """Run decoder via TensorRT engine.
 
@@ -1162,9 +1312,9 @@ class ParaformerTRTBackend(ASRBackend):
         Returns:
             sample_ids: [n_tokens] int64 token IDs, or None on failure
         """
-        ctx = self._contexts.get("dec")
+        ctx = bundle.dec_ctx if bundle is not None else None
         if ctx is None:
-            logger.error("Decoder TRT context not available")
+            logger.error("Decoder TRT context not available (bundle missing or destroyed)")
             return None
 
         n_tokens = acoustic_embeds.shape[0]
@@ -1174,9 +1324,9 @@ class ParaformerTRTBackend(ASRBackend):
         enc_nframes = enc.shape[1]
         key = f"dec_{enc_nframes}_{n_tokens}"
 
-        if key not in self._bindings:
-            self._bindings[key] = self._alloc_dec_buffers(enc_nframes, n_tokens)
-        bufs = self._bindings[key]
+        if key not in bundle.dec_bindings:
+            bundle.dec_bindings[key] = self._alloc_dec_buffers(enc_nframes, n_tokens, bundle)
+        bufs = bundle.dec_bindings[key]
 
         # Register tensor addresses (TRT 10.x requirement)
         ctx.set_tensor_address("enc", bufs["enc"])
@@ -1247,18 +1397,18 @@ class ParaformerTRTBackend(ASRBackend):
 
         return sample_ids[0]
 
-    def _alloc_dec_buffers(self, enc_nframes: int, n_tokens: int) -> dict:
+    def _alloc_dec_buffers(self, enc_nframes: int, n_tokens: int, bundle: "_ParaformerCtxBundle") -> dict:
         """Allocate device buffers for decoder TRT inference."""
         bufs = {}
-        bufs["enc"] = self._cuda_malloc(1 * enc_nframes * 512 * 4)
-        bufs["enc_len"] = self._cuda_malloc(4)
-        bufs["acoustic_embeds"] = self._cuda_malloc(1 * n_tokens * 512 * 4)
-        bufs["acoustic_embeds_len"] = self._cuda_malloc(4)
-        bufs["pad_mask"] = self._cuda_malloc(n_tokens * 4)
-        bufs["enc_pad_mask"] = self._cuda_malloc(enc_nframes * 4)
+        bufs["enc"] = bundle.alloc(1 * enc_nframes * 512 * 4)
+        bufs["enc_len"] = bundle.alloc(4)
+        bufs["acoustic_embeds"] = bundle.alloc(1 * n_tokens * 512 * 4)
+        bufs["acoustic_embeds_len"] = bundle.alloc(4)
+        bufs["pad_mask"] = bundle.alloc(n_tokens * 4)
+        bufs["enc_pad_mask"] = bundle.alloc(enc_nframes * 4)
         for i in range(16):
-            bufs[f"in_cache_{i}"] = self._cuda_malloc(1 * 512 * 10 * 4)
-            bufs[f"out_cache_{i}"] = self._cuda_malloc(1 * 512 * 10 * 4)
-        bufs["logits"] = self._cuda_malloc(1 * n_tokens * 8404 * 4)  # float32
-        bufs["sample_ids"] = self._cuda_malloc(1 * n_tokens * 8)  # int64
+            bufs[f"in_cache_{i}"] = bundle.alloc(1 * 512 * 10 * 4)
+            bufs[f"out_cache_{i}"] = bundle.alloc(1 * 512 * 10 * 4)
+        bufs["logits"] = bundle.alloc(1 * n_tokens * 8404 * 4)  # float32
+        bufs["sample_ids"] = bundle.alloc(1 * n_tokens * 8)  # int64
         return bufs

--- a/app/backends/jetson/trt_edge_llm_tts.py
+++ b/app/backends/jetson/trt_edge_llm_tts.py
@@ -631,6 +631,38 @@ class _WorkerIO:
 class TRTEdgeLLMTTSBackend(TTSBackend):
     """TTS via TRT-Edge-LLM qwen3_tts_inference subprocess."""
 
+    @classmethod
+    def concurrency_capability(cls, profile=None):
+        from app.core.concurrency_capability import ConcurrencyCapability
+
+        # _WorkerIO multiplexes N in-flight requests with a single subprocess
+        # (one stdin lock + one stdout reader + per-request queues). See
+        # spec Section 1 table row "trt_edge_llm_tts" and
+        # app/backends/jetson/trt_edge_llm_tts.py:486 (_WorkerIO).
+        env_val = os.environ.get("OVS_TTS_WORKER_CONCURRENCY")
+        profile_val = None
+        if isinstance(profile, dict):
+            # accept both top-level and nested under tts_backend_config
+            profile_val = profile.get("tts_worker_concurrency")
+            if profile_val is None:
+                cfg = profile.get("tts_backend_config")
+                if isinstance(cfg, dict):
+                    profile_val = cfg.get("worker_concurrency")
+        try:
+            n = int(env_val) if env_val is not None else (
+                int(profile_val) if profile_val is not None else 1
+            )
+        except (TypeError, ValueError):
+            n = 1
+        n = max(1, n)
+        return ConcurrencyCapability(
+            supports_parallel=n > 1,
+            max_concurrent=n,
+            is_stateful=True,
+            requires_exclusive_device=True,
+            scaling_mode="single_runtime_multiplex",
+        )
+
     # PR5b: supports_hot_reload is mode-dependent. The default
     # edgellm_worker / official modes spawn a TRT subprocess that can be
     # terminated to fully release GPU memory (safe to hot-reload). The

--- a/app/backends/jetson/trt_edge_llm_tts.py
+++ b/app/backends/jetson/trt_edge_llm_tts.py
@@ -26,6 +26,7 @@ import uuid
 
 from app.core.tts_backend import TTSBackend, TTSCapability
 from app.core.tts_speakers import resolve_speaker_kwargs
+from app.core.worker_io import WorkerIO, WorkerExitError
 
 from app.backends.jetson.trt_edge_llm_ipc import (
     TTS_BINARY,
@@ -479,154 +480,6 @@ _DEFAULT_CODEC_EOS_LOGIT_OFFSET = float(os.environ.get("TTS_CODEC_EOS_LOGIT_OFFS
 _DEFAULT_SEGMENT_TEXT = os.environ.get("EDGE_LLM_TTS_SEGMENT_TEXT", "1").lower() not in ("0", "false", "no")
 
 
-class WorkerExitError(RuntimeError):
-    """Raised when the TTS worker subprocess dies while a request is in flight."""
-
-
-class _WorkerIO:
-    """Per-worker stdin writer + stdout reader thread, multiplexing N in-flight requests.
-
-    Replaces the previous coarse ``_worker_lock`` (which serialized full
-    request→response cycles end-to-end) with:
-
-      * a single ``_stdin_lock`` that only protects the single-line JSON write,
-      * a daemon reader thread that demuxes stdout events to per-request
-        ``queue.Queue`` instances keyed by ``request_id``/``id``,
-      * a ``threading.Semaphore`` bounding in-flight requests to ``concurrency``.
-
-    When the worker subprocess EOFs (crash / restart), the reader thread wakes
-    every in-flight caller with a sentinel ``{"event": "_worker_exit"}`` so
-    they raise ``WorkerExitError`` instead of hanging on ``q.get(timeout=...)``.
-
-    A given ``_WorkerIO`` instance is bound to ONE subprocess. To restart the
-    worker, discard the old instance and create a new one (handled in
-    ``_ensure_worker`` / ``_restart_worker``).
-    """
-
-    # Class-level temporary instrumentation for Part D disconnect-watcher
-    # validation (spec docs/specs/tts-n2-throughput.md §3). Counts every
-    # cancel() invocation across all _WorkerIO instances since process
-    # start. Surfaced via the /health endpoint and via debug log. Remove
-    # once Part D is validated and stable.
-    _cancel_count: int = 0
-    _cancel_count_lock = threading.Lock()
-
-    def __init__(self, proc: subprocess.Popen, concurrency: int):
-        self._proc = proc
-        self._stdin_lock = threading.Lock()
-        self._inflight: dict[str, "queue.Queue"] = {}
-        self._inflight_lock = threading.Lock()
-        self._sem = threading.Semaphore(max(1, int(concurrency)))
-        self._reader_thread = threading.Thread(
-            target=self._reader_loop,
-            name="tts-worker-stdout",
-            daemon=True,
-        )
-        self._reader_thread.start()
-
-    def request(self, payload: dict) -> Iterator[dict]:
-        """Send ``payload`` to the worker and yield response events until ``done``.
-
-        Caller must include a unique ``id`` field in ``payload``. The generator
-        terminates when an ``event=="done"`` is received, or raises
-        ``WorkerExitError`` if the worker dies mid-request.
-        """
-        self._sem.acquire()
-        req_id = payload["id"]
-        q: "queue.Queue" = queue.Queue()
-        # CRITICAL ordering: insert the queue BEFORE writing stdin so the
-        # reader thread can never observe an event for ``req_id`` before
-        # the queue exists (would otherwise be dropped as "stale").
-        with self._inflight_lock:
-            self._inflight[req_id] = q
-        try:
-            assert self._proc.stdin is not None
-            try:
-                with self._stdin_lock:
-                    self._proc.stdin.write(json.dumps(payload, ensure_ascii=False) + "\n")
-                    self._proc.stdin.flush()
-            except Exception:
-                with self._inflight_lock:
-                    self._inflight.pop(req_id, None)
-                raise
-            while True:
-                try:
-                    event = q.get(timeout=60.0)
-                except Exception:
-                    raise
-                if event.get("event") == "_worker_exit":
-                    raise WorkerExitError("TTS worker died mid-request")
-                yield event
-                if event.get("event") in ("done", "cancelled"):
-                    return
-        finally:
-            with self._inflight_lock:
-                self._inflight.pop(req_id, None)
-            self._sem.release()
-
-    def cancel(self, req_id: str) -> None:
-        """Best-effort cancel for an in-flight request.
-
-        Writes a cancel JSON to the worker's stdin. The worker will check
-        its per-request atomic flag at the next chunk boundary and emit
-        a ``{"event":"cancelled", ...}`` terminal event in lieu of ``done``.
-
-        Safe to call from any thread. Safe to call after the request has
-        naturally completed (worker silently drops unknown cancels).
-        """
-        with _WorkerIO._cancel_count_lock:
-            _WorkerIO._cancel_count += 1
-            count_snapshot = _WorkerIO._cancel_count
-        logger.info(
-            "_WorkerIO.cancel: req_id=%s total_cancel_count=%d",
-            req_id,
-            count_snapshot,
-        )
-        try:
-            assert self._proc.stdin is not None
-            with self._stdin_lock:
-                self._proc.stdin.write(
-                    json.dumps({"type": "cancel", "id": req_id}) + "\n"
-                )
-                self._proc.stdin.flush()
-        except Exception:
-            # Worker may have already exited; the reader-loop sentinel
-            # will surface that via WorkerExitError on the next q.get().
-            logger.debug(
-                "cancel() write failed; worker may be exiting",
-                exc_info=True,
-            )
-
-    def _reader_loop(self) -> None:
-        """Drain worker stdout, dispatching events to per-request queues."""
-        try:
-            assert self._proc.stdout is not None
-            for line in self._proc.stdout:
-                if not line:
-                    continue
-                try:
-                    event = json.loads(line)
-                except Exception:
-                    logger.debug("TTS worker emitted non-JSON line: %r", line[:200])
-                    continue
-                rid = event.get("request_id") or event.get("id")
-                with self._inflight_lock:
-                    q = self._inflight.get(rid) if rid else None
-                if q is not None:
-                    q.put(event)
-                # else: stale / unsolicited (e.g. spurious "ready" replays
-                # or events after a restart). Drop silently.
-        except Exception:
-            logger.exception("TTS worker stdout reader crashed")
-        finally:
-            # Worker died (or stdout closed). Wake every in-flight caller
-            # with the sentinel so they raise WorkerExitError instead of
-            # hanging on q.get(timeout=60).
-            with self._inflight_lock:
-                for q in self._inflight.values():
-                    q.put({"event": "_worker_exit"})
-                self._inflight.clear()
-
 
 class TRTEdgeLLMTTSBackend(TTSBackend):
     """TTS via TRT-Edge-LLM qwen3_tts_inference subprocess."""
@@ -690,7 +543,7 @@ class TRTEdgeLLMTTSBackend(TTSBackend):
         # to _WorkerIO (see TTS worker concurrency spec §4.2). The fine-grained
         # stdin lock + reader thread live inside ``self._worker_io``.
         self._worker_lock = threading.Lock()
-        self._worker_io: Optional[_WorkerIO] = None
+        self._worker_io: Optional[WorkerIO] = None
         self._worker_concurrency: int = max(
             1, int(os.environ.get("OVS_TTS_WORKER_CONCURRENCY", "1"))
         )
@@ -967,7 +820,7 @@ class TRTEdgeLLMTTSBackend(TTSBackend):
         self._worker_concurrency = max(
             1, int(os.environ.get("OVS_TTS_WORKER_CONCURRENCY", str(self._worker_concurrency)))
         )
-        self._worker_io = _WorkerIO(self._worker, self._worker_concurrency)
+        self._worker_io = WorkerIO(self._worker, self._worker_concurrency)
 
     def _restart_worker_locked(self, reason: str) -> None:
         """Restart the resident TTS worker.

--- a/app/backends/rk/asr.py
+++ b/app/backends/rk/asr.py
@@ -318,6 +318,23 @@ class RKASRBackend(ASRBackend):
     ``ASR_BACKEND`` env var (set in the rk3576/rk3588 profile).
     """
 
+    @classmethod
+    def concurrency_capability(cls, profile=None):
+        """Declare concurrency for RK NPU ASR.
+
+        Spec §1 sample row "RK ASR/TTS": rkvoice-stream owns the NPU
+        lifecycle (see ``app/backends/rk/asr.py:380`` hot-reload note)
+        and runs single-session. NPU is an exclusive device.
+        """
+        from app.core.concurrency_capability import ConcurrencyCapability
+        return ConcurrencyCapability(
+            supports_parallel=False,
+            max_concurrent=1,
+            is_stateful=True,
+            requires_exclusive_device=True,
+            scaling_mode="external_managed",
+        )
+
     def __init__(self):
         from rkvoice_stream import create_asr
         self._inner = create_asr()

--- a/app/backends/rk/tts.py
+++ b/app/backends/rk/tts.py
@@ -32,6 +32,24 @@ class RKTTSBackend(TTSBackend):
     delegated to rkvoice-stream via the ``TTS_BACKEND`` env var (set in
     the rk3576/rk3588 profile)."""
 
+    @classmethod
+    def concurrency_capability(cls, profile=None):
+        """Declare concurrency for RK NPU TTS.
+
+        Spec §1 sample row "RK ASR/TTS": rkvoice-stream owns NPU lifecycle
+        (see ``app/backends/rk/tts.py:79`` for the unload-belongs-to-rkvoice
+        comment), serializes through one NPU device, and cannot be safely
+        multiplexed across slots. Single-session only.
+        """
+        from app.core.concurrency_capability import ConcurrencyCapability
+        return ConcurrencyCapability(
+            supports_parallel=False,
+            max_concurrent=1,
+            is_stateful=True,
+            requires_exclusive_device=True,
+            scaling_mode="external_managed",
+        )
+
     def __init__(self):
         from rkvoice_stream import create_tts
         self._inner = create_tts()

--- a/app/core/asr_backend.py
+++ b/app/core/asr_backend.py
@@ -79,6 +79,15 @@ class ASRStream(ABC):
         """
         self.cancel_and_finalize()
 
+    def close(self) -> None:
+        """Release per-stream resources (TRT exec contexts, device buffers).
+
+        Default: no-op. Backends whose stream owns per-instance GPU resources
+        (e.g. paraformer_trt's _ParaformerCtxBundle) override this to drop
+        them deterministically. Safe to call multiple times.
+        """
+        pass
+
 
 class ASRBackend(ABC):
 

--- a/app/core/asr_backend.py
+++ b/app/core/asr_backend.py
@@ -13,6 +13,8 @@ from typing import Dict, Optional, Tuple
 
 import numpy as np
 
+from app.core.concurrency_capability import ConcurrencyCapability
+
 logger = logging.getLogger(__name__)
 
 
@@ -130,6 +132,19 @@ class ASRBackend(ABC):
         an unload() stay resident, which is fine for 'concurrent' and
         'serialized' modes."""
         pass
+
+    @classmethod
+    def concurrency_capability(
+        cls, profile: Optional[dict] = None
+    ) -> ConcurrencyCapability:
+        """Describe runtime concurrency properties.
+
+        Classmethod (not instance property) so the scheduler can read the
+        ceiling before ``preload()``. Default is conservative (N=1,
+        serialized) — backends opt in by overriding. See
+        ``docs/specs/concurrency-capability-framework.md`` Section 2.
+        """
+        return ConcurrencyCapability.default()
 
 
 _ASR_REGISTRY: Dict[str, Tuple[str, str]] = {

--- a/app/core/asr_session_manager.py
+++ b/app/core/asr_session_manager.py
@@ -62,6 +62,25 @@ def _is_worker_protocol_error(exc: BaseException) -> bool:
     return False
 
 
+def _safe_close_stream(stream: Any) -> None:
+    """Release per-stream backend resources (TRT contexts, device buffers).
+
+    Default ASRStream.close() is a no-op; backends like paraformer_trt
+    override it to drop per-stream TRT IExecutionContext + cudaMalloc'd
+    buffers (added 2026-05-25 for N>=2 concurrency safety). We swallow any
+    exception so close() never breaks lifecycle teardown.
+    """
+    if stream is None:
+        return
+    close = getattr(stream, "close", None)
+    if close is None:
+        return
+    try:
+        close()
+    except Exception:
+        logger.exception("ASRSessionManager: stream.close raised; ignoring")
+
+
 class ASRSessionManager:
     """Async-safe per-utterance ASR session orchestrator.
 
@@ -275,6 +294,7 @@ class ASRSessionManager:
                     gen, self._generation,
                 )
                 return gen, "", False, None
+            _safe_close_stream(self._stream)
             self._stream = None
             self._state = SessionState.IDLE
             return gen, final_text or "", True, detected_language
@@ -310,6 +330,11 @@ class ASRSessionManager:
         self._state = SessionState.CANCELLING
         stream = self._stream
         self._stream = None
+        # close() is idempotent w.r.t. later cancel()/cancel_and_finalize() —
+        # for paraformer_trt, close() only releases per-stream TRT contexts
+        # and buffers, which are not needed for the cancel ack itself.
+        # We defer close() until *after* the cancel call below so the cancel
+        # path can still touch stream state if it needs to. See finally.
         if stream is None:
             self._state = SessionState.IDLE
             return
@@ -348,6 +373,7 @@ class ASRSessionManager:
                 await self._maybe_restart_worker()
             else:
                 logger.info("ASRSessionManager: cancel(%s) swallowed exc=%s", reason, exc)
+        _safe_close_stream(stream)
         self._state = SessionState.IDLE
 
     def mark_error(self, exc: BaseException) -> None:
@@ -406,6 +432,7 @@ class ASRSessionManager:
         if self._recovery_in_progress:
             return
         self._recovery_in_progress = True
+        _safe_close_stream(self._stream)
         self._stream = None
         self._state = SessionState.ERROR_REBUILD
         if not _is_worker_protocol_error(exc):
@@ -440,6 +467,7 @@ class ASRSessionManager:
             self._state = SessionState.ACTIVE
         except Exception as inner:
             logger.warning("ASRSessionManager: post-restart create_stream failed: %s", inner)
+            _safe_close_stream(self._stream)
             self._stream = None
             self._state = SessionState.IDLE
 

--- a/app/core/concurrency_capability.py
+++ b/app/core/concurrency_capability.py
@@ -1,0 +1,58 @@
+"""Concurrency capability descriptor for ASR/TTS backends.
+
+Describes runtime concurrency properties (separate from feature capabilities
+such as ``STREAMING``) so the session limiter and coordinator can derive
+ceilings from backend reality instead of profile-only defaults.
+
+See ``docs/specs/concurrency-capability-framework.md`` (Section 1) for the
+full field semantics. This module is P0 scope — pure framework, zero
+behavior change. The limiter does not yet read from these descriptors;
+P1 will wire them up.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+
+ScalingMode = Literal[
+    "single_runtime_multiplex",
+    "multi_runtime_per_slot",
+    "per_call_isolated",
+    "external_managed",
+]
+
+
+@dataclass(frozen=True)
+class ConcurrencyCapability:
+    """Runtime concurrency descriptor.
+
+    Fields match Section 1 of the spec:
+
+    - ``supports_parallel``: backend can serve >1 concurrent in-flight request.
+    - ``max_concurrent``: hard ceiling, ``>=1`` or ``None`` (no fixed cap;
+      treated as ``+inf`` when participating in a ``min()`` aggregate).
+    - ``is_stateful``: backend holds per-session/per-call state.
+    - ``requires_exclusive_device``: cross-backend mutex on the device;
+      *not* a within-backend single-slot constraint (that is expressed by
+      ``supports_parallel`` + ``max_concurrent``).
+    - ``scaling_mode``: how additional concurrency is realized.
+    - ``vram_mb_per_slot``: optional metadata for P2 VRAM budgeting.
+    """
+
+    supports_parallel: bool = False
+    max_concurrent: Optional[int] = 1
+    is_stateful: bool = True
+    requires_exclusive_device: bool = True
+    scaling_mode: ScalingMode = "single_runtime_multiplex"
+    vram_mb_per_slot: Optional[int] = None
+
+    @classmethod
+    def default(cls) -> "ConcurrencyCapability":
+        """Conservative default: serialized, single-slot, stateful, exclusive.
+
+        Backends that do not override the ABC classmethod resolve to this,
+        which preserves N=1 safety for legacy/untouched backends.
+        """
+        return cls()

--- a/app/core/coordinator.py
+++ b/app/core/coordinator.py
@@ -6,18 +6,91 @@ execution_policy in profile JSON drives this:
 - exclusive   : same lock + slot tracking; switching slot calls dormant
                 backend.unload() before yielding. Best-effort: backends not
                 overriding unload() stay resident.
+
+Spec docs/specs/concurrency-capability-framework.md §4: backend capability
+is the ceiling, profile.execution_policy is the floor. ``concurrent`` is
+permitted only when BOTH active backends declare
+``supports_parallel=True`` with ``max_concurrent > 1``. If either is
+``supports_parallel=False``, the mode is downgraded to ``serialized``.
+Profile ``exclusive`` is always honored as-is.
 """
 from __future__ import annotations
 import asyncio
+import logging
 from contextlib import asynccontextmanager
 from typing import AsyncIterator, Callable, Dict, Literal, Optional
+
+logger = logging.getLogger(__name__)
 
 Slot = Literal["asr", "tts"]
 
 
+def _resolve_mode(policy: dict, profile: Optional[dict]) -> str:
+    """Resolve the effective coordinator mode per spec §4.
+
+    ``exclusive`` is unconditional; otherwise we start from
+    ``policy.mode`` (default ``concurrent``) and downgrade to
+    ``serialized`` if either active backend declares
+    ``supports_parallel=False`` or ``max_concurrent <= 1``.
+
+    ``profile`` is optional; without it (legacy callers / tests) we
+    return the raw ``policy.mode`` to preserve behavior.
+    """
+    requested = (policy or {}).get("mode", "concurrent")
+    if requested == "exclusive":
+        return "exclusive"
+    if not isinstance(profile, dict):
+        return requested
+
+    try:
+        from app.core.asr_backend import _ASR_REGISTRY
+        from app.core.tts_backend import _TTS_REGISTRY
+        from app.core.concurrency_capability import ConcurrencyCapability
+    except Exception:
+        return requested
+
+    def _cap(key: str, registry: dict) -> ConcurrencyCapability:
+        spec = profile.get(key)
+        if not spec or spec not in registry:
+            return ConcurrencyCapability.default()
+        module_path, cls_name = registry[spec]
+        try:
+            import importlib
+            mod = importlib.import_module(module_path)
+            cls = getattr(mod, cls_name)
+            return cls.concurrency_capability(profile)
+        except Exception as exc:
+            logger.debug(
+                "coordinator: capability lookup failed for %s=%s: %s",
+                key, spec, exc,
+            )
+            return ConcurrencyCapability.default()
+
+    asr_cap = _cap("asr_backend", _ASR_REGISTRY)
+    tts_cap = _cap("tts_backend", _TTS_REGISTRY)
+
+    def _parallel_ok(cap: ConcurrencyCapability) -> bool:
+        if not cap.supports_parallel:
+            return False
+        # None means "no hard cap" (e.g. per-stream paraformer) -> parallel.
+        if cap.max_concurrent is None:
+            return True
+        return cap.max_concurrent > 1
+
+    if requested == "concurrent" and not (_parallel_ok(asr_cap) and _parallel_ok(tts_cap)):
+        logger.info(
+            "coordinator: downgrading concurrent -> serialized "
+            "(asr.supports_parallel=%s/max=%s, tts.supports_parallel=%s/max=%s)",
+            asr_cap.supports_parallel, asr_cap.max_concurrent,
+            tts_cap.supports_parallel, tts_cap.max_concurrent,
+        )
+        return "serialized"
+    return requested
+
+
 class BackendCoordinator:
-    def __init__(self, policy: dict):
-        self._mode = policy.get("mode", "concurrent")
+    def __init__(self, policy: dict, profile: Optional[dict] = None):
+        self._mode = _resolve_mode(policy, profile)
         self._lock: Optional[asyncio.Lock] = None
         if self._mode in ("serialized", "exclusive"):
             self._lock = asyncio.Lock()
@@ -54,9 +127,11 @@ class BackendCoordinator:
 _coordinator: Optional[BackendCoordinator] = None
 
 
-def init_coordinator(policy: dict) -> BackendCoordinator:
+def init_coordinator(
+    policy: dict, profile: Optional[dict] = None
+) -> BackendCoordinator:
     global _coordinator
-    _coordinator = BackendCoordinator(policy)
+    _coordinator = BackendCoordinator(policy, profile=profile)
     return _coordinator
 
 

--- a/app/core/model_downloader.py
+++ b/app/core/model_downloader.py
@@ -106,40 +106,68 @@ def _download_and_extract(url: str, dest_dir: str) -> None:
 
 
 def ensure_models(language_mode: str = "zh_en", model_dir: str = "/opt/models") -> None:
-    """Ensure all required models for the given language mode are present."""
+    """Ensure all required models for the given language mode are present.
+
+    Routing is profile-driven first, language_mode-driven second. When a
+    profile is loaded, its ``asr_backend`` / ``tts_backend`` fields decide
+    which backend-specific artifacts to fetch (Qwen3 ASR, Matcha TTS,
+    Kokoro TTS). Profile-triggered requirements are UNIONED with the
+    legacy language_mode requirements so callers without a profile keep
+    working unchanged (e.g. plain ``LANGUAGE_MODE=en``).
+    """
     try:
         from app.core.profile_loader import current_profile
-        tts_backend = (current_profile() or {}).get("tts_backend")
+        profile = current_profile() or {}
     except Exception:
-        tts_backend = None
+        profile = {}
 
-    if tts_backend == "jetson.kokoro_trt":
-        kokoro = MODELS.get("en", {}).get("kokoro-multi-lang-v1_0")
-        required = {"kokoro-multi-lang-v1_0": kokoro} if kokoro else {}
+    asr_backend = profile.get("asr_backend")
+    tts_backend = profile.get("tts_backend")
 
-    elif language_mode == "rk":
+    # Profile-driven extras (UNIONed with language_mode-driven requirements
+    # further down). Pure profile users (no LANGUAGE_MODE set) end up with
+    # only the entries triggered here.
+    extra_required: dict = {}
+    matcha = MODELS.get("zh_en", {}).get("matcha-icefall-zh-en")
+    kokoro = MODELS.get("en", {}).get("kokoro-multi-lang-v1_0")
+    if tts_backend == "jetson.matcha_trt" and matcha:
+        extra_required["matcha-icefall-zh-en"] = matcha
+    if tts_backend == "jetson.kokoro_trt" and kokoro:
+        extra_required["kokoro-multi-lang-v1_0"] = kokoro
+    if asr_backend == "jetson.trt_edge_llm":
+        # Qwen3 artifacts are deployed via an external script, not via the
+        # MODELS/CDN tarball mechanism — fire it as a side-effect here.
+        _ensure_qwen3_artifacts()
+
+    if language_mode == "rk":
         _ensure_rk_artifacts()
         if os.environ.get("RK_ENSURE_MATCHA_RESOURCES", "1").lower() in ("0", "false", "no"):
             return
-        matcha = MODELS.get("zh_en", {}).get("matcha-icefall-zh-en")
         required = {"matcha-icefall-zh-en": matcha} if matcha else {}
+        required.update(extra_required)
         model_dir = os.environ.get("TTS_MODEL_DIR") or model_dir
 
     elif language_mode == "multilanguage":
+        # Preserve legacy behavior: multilanguage mode triggers Qwen3
+        # artifacts even when no profile is loaded. When a profile is
+        # active, _ensure_qwen3_artifacts may have already run above —
+        # the second call is cheap (re-verify) but harmless.
         _ensure_qwen3_artifacts()
+        required: dict = {}
         # Some multilanguage profiles pair Qwen3 ASR with Matcha TTS. Only
         # those need the Matcha acoustic ONNX + lexicon; pure Qwen3 profiles
         # should not download or validate Matcha assets during startup.
-        matcha = MODELS.get("zh_en", {}).get("matcha-icefall-zh-en")
         if tts_backend == "jetson.matcha_trt" and matcha:
-            required = {"matcha-icefall-zh-en": matcha}
-        else:
+            required["matcha-icefall-zh-en"] = matcha
+        required.update(extra_required)
+        if not required:
             return
     else:
         required = {}
         required.update(MODELS.get(language_mode, {}))
         if os.environ.get("ENSURE_OFFLINE_ASR", "").lower() in ("1", "true", "yes"):
             required.update(MODELS.get("shared", {}))
+        required.update(extra_required)
     if not required:
         return
 

--- a/app/core/profile_loader.py
+++ b/app/core/profile_loader.py
@@ -52,6 +52,16 @@ def _snapshot_operator_keys() -> frozenset[str]:
 # Snapshot taken exactly once at module import.
 _OPERATOR_KEYS: frozenset[str] = _snapshot_operator_keys()
 
+# Keys for which an operator/profile mismatch is a hard failure (not a soft
+# "operator wins" silent override). These keys steer downstream backend
+# selection AND model-download routing; a silent mismatch produces
+# misleading runtime failures (e.g. profile picks Qwen3 ASR but
+# LANGUAGE_MODE=zh_en in env shadows it, so the Qwen3 artifacts never
+# download). Fail loud at startup instead.
+CRITICAL_KEYS: frozenset[str] = frozenset({
+    "LANGUAGE_MODE", "ASR_BACKEND", "TTS_BACKEND",
+})
+
 # Keys written by the most recent ``apply_profile`` call. Used to clear stale
 # values when reloading a different profile.
 _APPLIED_KEYS: set[str] = set()
@@ -246,6 +256,20 @@ def apply_profile(
         # 2. Write new values, unconditionally overwriting unless operator-owned.
         for k, v in merged.items():
             if k in _OPERATOR_KEYS:
+                existing = os.environ.get(k)
+                if existing != v:
+                    if k in CRITICAL_KEYS:
+                        raise RuntimeError(
+                            f"Profile {derived['OVS_PROFILE_NAME']} requires "
+                            f"{k}={v}, but environment has {k}={existing}. "
+                            f"Remove {k} from your environment "
+                            f"(compose/.env/shell) or change OVS_PROFILE to "
+                            f"one that matches."
+                        )
+                    logger.warning(
+                        "Profile %s wants %s=%s but env overrides to %s",
+                        derived["OVS_PROFILE_NAME"], k, v, existing,
+                    )
                 continue
             os.environ[k] = v
 

--- a/app/core/session_limiter.py
+++ b/app/core/session_limiter.py
@@ -79,35 +79,138 @@ def _parse_int(value: str | int | None, *, label: str) -> int | None:
         raise ValueError(f"{label} must be an integer, got {value!r}") from exc
 
 
+def _backend_class(profile: dict | None, key: str, registry: dict):
+    """Resolve a backend class from a profile registry-key without instantiating.
+
+    Returns ``None`` if the profile is missing the key, the registry lookup
+    fails, or the lazy import errors out. Callers must fall back to the
+    conservative default (``ConcurrencyCapability.default()``).
+    """
+    if not isinstance(profile, dict):
+        return None
+    spec = profile.get(key)
+    if not spec or spec not in registry:
+        return None
+    module_path, cls_name = registry[spec]
+    try:
+        import importlib
+        mod = importlib.import_module(module_path)
+        return getattr(mod, cls_name)
+    except Exception as exc:
+        logger.debug("session_limiter: %s import failed for %r: %s", key, spec, exc)
+        return None
+
+
+def _capability_ceiling(profile: dict | None) -> tuple[int | None, str]:
+    """Compute the aggregated backend ceiling.
+
+    Returns ``(ceiling, source)`` where ``ceiling`` is ``None`` if neither
+    backend declares a hard cap (treated as +inf), else the integer min.
+    ``source`` is a short label for logging.
+    """
+    from app.core.asr_backend import _ASR_REGISTRY
+    from app.core.tts_backend import _TTS_REGISTRY
+    from app.core.concurrency_capability import ConcurrencyCapability
+
+    asr_cls = _backend_class(profile, "asr_backend", _ASR_REGISTRY)
+    tts_cls = _backend_class(profile, "tts_backend", _TTS_REGISTRY)
+
+    def _cap(cls) -> ConcurrencyCapability:
+        if cls is None:
+            return ConcurrencyCapability.default()
+        try:
+            return cls.concurrency_capability(profile)
+        except Exception as exc:
+            logger.debug(
+                "session_limiter: concurrency_capability() raised for %s: %s",
+                getattr(cls, "__name__", cls), exc,
+            )
+            return ConcurrencyCapability.default()
+
+    asr_cap = _cap(asr_cls)
+    tts_cap = _cap(tts_cls)
+
+    asr_n = asr_cap.max_concurrent  # may be None == +inf
+    tts_n = tts_cap.max_concurrent
+    if asr_n is None and tts_n is None:
+        return None, "asr=inf,tts=inf"
+    if asr_n is None:
+        return tts_n, f"asr=inf,tts={tts_n}"
+    if tts_n is None:
+        return asr_n, f"asr={asr_n},tts=inf"
+    return min(asr_n, tts_n), f"asr={asr_n},tts={tts_n}"
+
+
 def resolve_limit(profile: dict | None = None) -> int:
     """Resolve the effective session limit.
 
-    Precedence: env override > profile field > target default > unknown
-    fallback. Raises ``ValueError`` for non-int, zero, or negative values.
+    Spec §3 + §7: ceiling comes from
+    ``min(asr.max_concurrent, tts.max_concurrent)`` (``None`` treated as
+    ``+inf``). Profile and env overrides MAY ONLY DOWNGRADE; any attempt
+    to exceed the ceiling is warn-logged and silently clamped. If the
+    backend ceiling cannot be determined (no profile, import failure),
+    fall back to the legacy ``_TARGET_DEFAULTS`` table.
+
+    Precedence (after clamping): env override > profile field > ceiling.
+    Raises ``ValueError`` for non-int, zero, or negative values.
     """
+    profile = profile or {}
+
     env_raw = os.environ.get("OVS_MAX_CONCURRENT_SESSIONS")
     env_val = _parse_int(env_raw, label="OVS_MAX_CONCURRENT_SESSIONS")
-    if env_val is not None:
-        if env_val <= 0:
-            raise ValueError(
-                f"OVS_MAX_CONCURRENT_SESSIONS must be > 0, got {env_val}"
-            )
-        return env_val
+    if env_val is not None and env_val <= 0:
+        raise ValueError(
+            f"OVS_MAX_CONCURRENT_SESSIONS must be > 0, got {env_val}"
+        )
 
-    profile = profile or {}
     profile_val = _parse_int(
         profile.get("max_concurrent_sessions"),
         label="profile.max_concurrent_sessions",
     )
-    if profile_val is not None:
-        if profile_val <= 0:
-            raise ValueError(
-                f"profile.max_concurrent_sessions must be > 0, got {profile_val}"
+    if profile_val is not None and profile_val <= 0:
+        raise ValueError(
+            f"profile.max_concurrent_sessions must be > 0, got {profile_val}"
+        )
+
+    # Only consult capability aggregation when the profile names a backend.
+    # Otherwise (e.g. mac dev-shell), fall back to the legacy target table
+    # so undeclared environments keep working.
+    if profile.get("asr_backend") or profile.get("tts_backend"):
+        ceiling, ceiling_src = _capability_ceiling(profile)
+    else:
+        target = _infer_target(profile)
+        ceiling = _TARGET_DEFAULTS.get(target, _UNKNOWN_DEFAULT)
+        ceiling_src = f"target_default={target}"
+
+    # Clamp env override to ceiling.
+    if env_val is not None:
+        if ceiling is not None and env_val > ceiling:
+            logger.warning(
+                "session_limiter: OVS_MAX_CONCURRENT_SESSIONS=%d exceeds backend"
+                " ceiling (%s) → clamping to %d",
+                env_val, ceiling_src, ceiling,
             )
+            return ceiling
+        return env_val
+
+    # Clamp profile override to ceiling.
+    if profile_val is not None:
+        if ceiling is not None and profile_val > ceiling:
+            logger.warning(
+                "session_limiter: profile.max_concurrent_sessions=%d exceeds"
+                " backend ceiling (%s) → clamping to %d",
+                profile_val, ceiling_src, ceiling,
+            )
+            return ceiling
         return profile_val
 
-    target = _infer_target(profile)
-    return _TARGET_DEFAULTS.get(target, _UNKNOWN_DEFAULT)
+    # No explicit override. If ceiling is +inf, fall back to a sane default
+    # (target table, then UNKNOWN_DEFAULT) so we don't admit unbounded
+    # sessions.
+    if ceiling is None:
+        target = _infer_target(profile)
+        return _TARGET_DEFAULTS.get(target, _UNKNOWN_DEFAULT)
+    return ceiling
 
 
 # ---------------------------------------------------------------------------

--- a/app/core/tts_backend.py
+++ b/app/core/tts_backend.py
@@ -13,6 +13,8 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Dict, Optional, Tuple
 
+from app.core.concurrency_capability import ConcurrencyCapability
+
 logger = logging.getLogger(__name__)
 
 
@@ -125,6 +127,19 @@ class TTSBackend(ABC):
     def unload(self) -> None:
         """Release GPU/NPU resources. See ASRBackend.unload() for semantics."""
         pass
+
+    @classmethod
+    def concurrency_capability(
+        cls, profile: Optional[dict] = None
+    ) -> ConcurrencyCapability:
+        """Describe runtime concurrency properties.
+
+        Classmethod (not instance property) so the scheduler can read the
+        ceiling before ``preload()``. Default is conservative (N=1,
+        serialized) — backends opt in by overriding. See
+        ``docs/specs/concurrency-capability-framework.md`` Section 2.
+        """
+        return ConcurrencyCapability.default()
 
 
 _TTS_REGISTRY: Dict[str, Tuple[str, str]] = {

--- a/app/core/worker_io.py
+++ b/app/core/worker_io.py
@@ -9,24 +9,36 @@ subprocess (one stdin / one stdout) into N in-flight per-request streams,
 keyed by ``request_id`` / ``id``. Used today by the TRT-Edge-LLM TTS
 backend. Future ASR worker backends (spec P1+) will reuse this.
 
-Public API (P1a, sync — unchanged from the original `_WorkerIO`):
+Public API per spec Section 5:
 
     wio = WorkerIO(proc, concurrency)
-    for event in wio.request(payload): ...   # generator, terminates on done/cancelled
-    wio.cancel(request_id)                   # best-effort, any thread
-    # No explicit close(): the reader thread is daemon and exits on stdout EOF.
 
-P1b will migrate ``request()`` -> ``async send_request()`` per spec Section 5.
+    # Async (spec target — preferred for new code, e.g. future ASR worker)
+    async for event in wio.send_request(rid, payload):
+        ...
+    wio.cancel(rid)
+    wio.close()
+
+    # Sync (legacy shim retained for existing TTS path that runs inside a
+    # ThreadPoolExecutor; the surrounding generator-of-PCM-chunks pipeline
+    # cannot trivially flip to async without restructuring app/main.py's
+    # streaming response wiring. Will be removed once that migration lands).
+    for event in wio.request(payload):
+        ...
+
+Both APIs share the same underlying ``_inflight`` map, ``_stdin_lock``,
+reader thread, and semaphore, so they coexist safely on the same instance.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import queue
 import subprocess
 import threading
-from typing import Iterator
+from typing import AsyncIterator, Iterator
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +87,98 @@ class WorkerIO:
             daemon=True,
         )
         self._reader_thread.start()
+
+    async def send_request(
+        self, request_id: str, payload: dict
+    ) -> AsyncIterator[dict]:
+        """Async-iterate worker events for one request.
+
+        Spec section 5 target API. The semaphore + per-request queue +
+        sentinel-on-worker-exit semantics match ``request()`` exactly; the
+        only difference is awaitable ``q.get`` (offloaded to the default
+        thread executor) so callers integrate into an asyncio event loop
+        without blocking it.
+
+        If the consumer breaks out of the ``async for`` (or ``aclose()`` is
+        invoked), the ``finally`` arm fires ``cancel(request_id)`` so the
+        worker emits a terminal ``cancelled`` event. This mirrors the
+        ``GeneratorExit`` arm in the sync streaming caller at
+        ``trt_edge_llm_tts.py``.
+        """
+        # Ensure payload carries the request_id the caller passed in.
+        payload = dict(payload)
+        payload.setdefault("id", request_id)
+        if payload.get("id") != request_id:
+            raise ValueError(
+                f"payload['id']={payload.get('id')!r} != request_id={request_id!r}"
+            )
+
+        loop = asyncio.get_running_loop()
+        # Run the blocking semaphore acquire off the loop. The semaphore is
+        # a back-pressure gate; it can block when concurrency is saturated.
+        await loop.run_in_executor(None, self._sem.acquire)
+
+        q: "queue.Queue" = queue.Queue()
+        with self._inflight_lock:
+            self._inflight[request_id] = q
+
+        cancelled_by_consumer = False
+        try:
+            assert self._proc.stdin is not None
+            try:
+                with self._stdin_lock:
+                    self._proc.stdin.write(
+                        json.dumps(payload, ensure_ascii=False) + "\n"
+                    )
+                    self._proc.stdin.flush()
+            except Exception:
+                with self._inflight_lock:
+                    self._inflight.pop(request_id, None)
+                raise
+
+            while True:
+                try:
+                    event = await loop.run_in_executor(None, q.get, True, 60.0)
+                except queue.Empty:
+                    raise TimeoutError(
+                        f"WorkerIO.send_request: no event for {request_id} in 60s"
+                    )
+                if event.get("event") == "_worker_exit":
+                    raise WorkerExitError("worker subprocess died mid-request")
+                try:
+                    yield event
+                except (GeneratorExit, asyncio.CancelledError):
+                    cancelled_by_consumer = True
+                    raise
+                if event.get("event") in ("done", "cancelled"):
+                    return
+        finally:
+            with self._inflight_lock:
+                self._inflight.pop(request_id, None)
+            self._sem.release()
+            if cancelled_by_consumer:
+                try:
+                    self.cancel(request_id)
+                except Exception:
+                    logger.debug(
+                        "cancel() during async cleanup failed", exc_info=True
+                    )
+
+    def close(self) -> None:
+        """Tear down: wake every in-flight caller and stop the reader.
+
+        After ``close()``, in-flight ``send_request``/``request`` generators
+        observe a ``_worker_exit`` sentinel and surface ``WorkerExitError``.
+        The reader thread itself is daemon and will exit naturally when
+        the subprocess stdout EOFs; ``close()`` does not kill the
+        subprocess — that is the owning backend's responsibility (proc
+        lifecycle stays where it is today).
+        """
+        with self._inflight_lock:
+            queues = list(self._inflight.values())
+            self._inflight.clear()
+        for q in queues:
+            q.put({"event": "_worker_exit"})
 
     def request(self, payload: dict) -> Iterator[dict]:
         """Send ``payload`` to the worker and yield response events until ``done``.

--- a/app/core/worker_io.py
+++ b/app/core/worker_io.py
@@ -144,6 +144,10 @@ class WorkerIO:
         # Hold semaphore from here. If close() ran while we were waiting,
         # abort immediately and release the slot back; do not register
         # inflight and do not write to dead worker stdin.
+        # NB: this is a fast-path check. The authoritative gate is the
+        # `_closed` re-check inside `_stdin_lock` below — close() also
+        # sets `_closed` under `_stdin_lock`, so any stdin write and
+        # any close() call are strictly ordered.
         if self._closed:
             self._sem.release()
             raise WorkerExitError("WorkerIO closed before request could start")
@@ -163,6 +167,13 @@ class WorkerIO:
             assert self._proc.stdin is not None
             try:
                 with self._stdin_lock:
+                    # Re-check under the same lock that close() uses to set
+                    # the flag; this closes the TOCTOU window between the
+                    # fast-path check above and the actual write.
+                    if self._closed:
+                        raise WorkerExitError(
+                            "WorkerIO closed between acquire and stdin write"
+                        )
                     self._proc.stdin.write(
                         json.dumps(payload, ensure_ascii=False) + "\n"
                     )
@@ -210,7 +221,12 @@ class WorkerIO:
         subprocess — that is the owning backend's responsibility (proc
         lifecycle stays where it is today).
         """
-        self._closed = True
+        # Set _closed under _stdin_lock so any in-flight stdin write that
+        # holds the lock observes the flag before the next acquirer can.
+        # Combined with the re-check inside send_request/request under
+        # the same lock, this guarantees no write happens after close().
+        with self._stdin_lock:
+            self._closed = True
         with self._inflight_lock:
             queues = list(self._inflight.values())
             self._inflight.clear()
@@ -243,6 +259,13 @@ class WorkerIO:
                 self._inflight[req_id] = q
             assert self._proc.stdin is not None
             with self._stdin_lock:
+                # Re-check _closed under stdin_lock — close() also sets
+                # the flag under the same lock, so this closes the TOCTOU
+                # gap between the fast-path check above and the write.
+                if self._closed:
+                    raise WorkerExitError(
+                        "WorkerIO closed between acquire and stdin write"
+                    )
                 self._proc.stdin.write(json.dumps(payload, ensure_ascii=False) + "\n")
                 self._proc.stdin.flush()
             while True:

--- a/app/core/worker_io.py
+++ b/app/core/worker_io.py
@@ -122,7 +122,13 @@ class WorkerIO:
         with self._inflight_lock:
             self._inflight[request_id] = q
 
-        cancelled_by_consumer = False
+        # Track whether the request reached a natural terminal event
+        # (``done``/``cancelled``). Any other exit path — task cancel while
+        # awaiting q.get, GeneratorExit at yield, TimeoutError, WorkerExitError,
+        # arbitrary exception — must send a cancel JSON to the worker so it
+        # stops producing chunks for an abandoned slot. The cancel call itself
+        # is best-effort (worker may already be dead).
+        finished_naturally = False
         try:
             assert self._proc.stdin is not None
             try:
@@ -145,18 +151,15 @@ class WorkerIO:
                     )
                 if event.get("event") == "_worker_exit":
                     raise WorkerExitError("worker subprocess died mid-request")
-                try:
-                    yield event
-                except (GeneratorExit, asyncio.CancelledError):
-                    cancelled_by_consumer = True
-                    raise
+                yield event
                 if event.get("event") in ("done", "cancelled"):
+                    finished_naturally = True
                     return
         finally:
             with self._inflight_lock:
                 self._inflight.pop(request_id, None)
             self._sem.release()
-            if cancelled_by_consumer:
+            if not finished_naturally:
                 try:
                     self.cancel(request_id)
                 except Exception:

--- a/app/core/worker_io.py
+++ b/app/core/worker_io.py
@@ -116,7 +116,23 @@ class WorkerIO:
         loop = asyncio.get_running_loop()
         # Run the blocking semaphore acquire off the loop. The semaphore is
         # a back-pressure gate; it can block when concurrency is saturated.
-        await loop.run_in_executor(None, self._sem.acquire)
+        # If the awaiting task is cancelled while the executor thread is
+        # still blocked in self._sem.acquire(), the thread cannot be
+        # interrupted — it may eventually grab the token after we're gone.
+        # Attach a done-callback so the late-acquired token is released
+        # back to the pool instead of leaking the slot.
+        _fut = loop.run_in_executor(None, self._sem.acquire)
+        try:
+            await _fut
+        except BaseException:
+            def _release_if_late_acquire(f: "asyncio.Future") -> None:
+                try:
+                    if f.result() is True:
+                        self._sem.release()
+                except Exception:
+                    pass
+            _fut.add_done_callback(_release_if_late_acquire)
+            raise
 
         q: "queue.Queue" = queue.Queue()
         with self._inflight_lock:

--- a/app/core/worker_io.py
+++ b/app/core/worker_io.py
@@ -1,0 +1,185 @@
+"""Generic subprocess-worker IO multiplexer.
+
+Extracted from ``app/backends/jetson/trt_edge_llm_tts.py`` (commit `64185fa`
+cooperative cancel protocol; spec ``docs/specs/concurrency-capability-framework.md``
+Section 5).
+
+This is the framework-layer abstraction that demuxes a single JSON-line
+subprocess (one stdin / one stdout) into N in-flight per-request streams,
+keyed by ``request_id`` / ``id``. Used today by the TRT-Edge-LLM TTS
+backend. Future ASR worker backends (spec P1+) will reuse this.
+
+Public API (P1a, sync — unchanged from the original `_WorkerIO`):
+
+    wio = WorkerIO(proc, concurrency)
+    for event in wio.request(payload): ...   # generator, terminates on done/cancelled
+    wio.cancel(request_id)                   # best-effort, any thread
+    # No explicit close(): the reader thread is daemon and exits on stdout EOF.
+
+P1b will migrate ``request()`` -> ``async send_request()`` per spec Section 5.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import queue
+import subprocess
+import threading
+from typing import Iterator
+
+logger = logging.getLogger(__name__)
+
+
+class WorkerExitError(RuntimeError):
+    """Raised when the worker subprocess dies while a request is in flight."""
+
+
+class WorkerIO:
+    """Per-worker stdin writer + stdout reader thread, multiplexing N in-flight requests.
+
+    Replaces a coarse per-request lock (which would serialize full
+    request→response cycles end-to-end) with:
+
+      * a single ``_stdin_lock`` that only protects the single-line JSON write,
+      * a daemon reader thread that demuxes stdout events to per-request
+        ``queue.Queue`` instances keyed by ``request_id``/``id``,
+      * a ``threading.Semaphore`` bounding in-flight requests to ``concurrency``.
+
+    When the worker subprocess EOFs (crash / restart), the reader thread wakes
+    every in-flight caller with a sentinel ``{"event": "_worker_exit"}`` so
+    they raise ``WorkerExitError`` instead of hanging on ``q.get(timeout=...)``.
+
+    A given ``WorkerIO`` instance is bound to ONE subprocess. To restart the
+    worker, discard the old instance and create a new one (handled by the
+    owning backend, e.g. ``_ensure_worker`` / ``_restart_worker``).
+    """
+
+    # Class-level temporary instrumentation for Part D disconnect-watcher
+    # validation (spec docs/specs/tts-n2-throughput.md §3). Counts every
+    # cancel() invocation across all WorkerIO instances since process
+    # start. Surfaced via the /health endpoint and via debug log. Remove
+    # once Part D is validated and stable.
+    _cancel_count: int = 0
+    _cancel_count_lock = threading.Lock()
+
+    def __init__(self, proc: subprocess.Popen, concurrency: int):
+        self._proc = proc
+        self._stdin_lock = threading.Lock()
+        self._inflight: dict[str, "queue.Queue"] = {}
+        self._inflight_lock = threading.Lock()
+        self._sem = threading.Semaphore(max(1, int(concurrency)))
+        self._reader_thread = threading.Thread(
+            target=self._reader_loop,
+            name="worker-io-stdout",
+            daemon=True,
+        )
+        self._reader_thread.start()
+
+    def request(self, payload: dict) -> Iterator[dict]:
+        """Send ``payload`` to the worker and yield response events until ``done``.
+
+        Caller must include a unique ``id`` field in ``payload``. The generator
+        terminates when an ``event=="done"`` or ``event=="cancelled"`` is
+        received, or raises ``WorkerExitError`` if the worker dies mid-request.
+        """
+        self._sem.acquire()
+        req_id = payload["id"]
+        q: "queue.Queue" = queue.Queue()
+        # CRITICAL ordering: insert the queue BEFORE writing stdin so the
+        # reader thread can never observe an event for ``req_id`` before
+        # the queue exists (would otherwise be dropped as "stale").
+        with self._inflight_lock:
+            self._inflight[req_id] = q
+        try:
+            assert self._proc.stdin is not None
+            try:
+                with self._stdin_lock:
+                    self._proc.stdin.write(json.dumps(payload, ensure_ascii=False) + "\n")
+                    self._proc.stdin.flush()
+            except Exception:
+                with self._inflight_lock:
+                    self._inflight.pop(req_id, None)
+                raise
+            while True:
+                try:
+                    event = q.get(timeout=60.0)
+                except Exception:
+                    raise
+                if event.get("event") == "_worker_exit":
+                    raise WorkerExitError("worker subprocess died mid-request")
+                yield event
+                if event.get("event") in ("done", "cancelled"):
+                    return
+        finally:
+            with self._inflight_lock:
+                self._inflight.pop(req_id, None)
+            self._sem.release()
+
+    def cancel(self, req_id: str) -> None:
+        """Best-effort cancel for an in-flight request.
+
+        Writes a cancel JSON to the worker's stdin. The worker will check
+        its per-request atomic flag at the next chunk boundary and emit
+        a ``{"event":"cancelled", ...}`` terminal event in lieu of ``done``.
+
+        Safe to call from any thread. Safe to call after the request has
+        naturally completed (worker silently drops unknown cancels).
+        """
+        with WorkerIO._cancel_count_lock:
+            WorkerIO._cancel_count += 1
+            count_snapshot = WorkerIO._cancel_count
+        logger.info(
+            "WorkerIO.cancel: req_id=%s total_cancel_count=%d",
+            req_id,
+            count_snapshot,
+        )
+        try:
+            assert self._proc.stdin is not None
+            with self._stdin_lock:
+                self._proc.stdin.write(
+                    json.dumps({"type": "cancel", "id": req_id}) + "\n"
+                )
+                self._proc.stdin.flush()
+        except Exception:
+            # Worker may have already exited; the reader-loop sentinel
+            # will surface that via WorkerExitError on the next q.get().
+            logger.debug(
+                "cancel() write failed; worker may be exiting",
+                exc_info=True,
+            )
+
+    def _reader_loop(self) -> None:
+        """Drain worker stdout, dispatching events to per-request queues."""
+        try:
+            assert self._proc.stdout is not None
+            for line in self._proc.stdout:
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except Exception:
+                    logger.debug("worker emitted non-JSON line: %r", line[:200])
+                    continue
+                rid = event.get("request_id") or event.get("id")
+                with self._inflight_lock:
+                    q = self._inflight.get(rid) if rid else None
+                if q is not None:
+                    q.put(event)
+                # else: stale / unsolicited (e.g. spurious "ready" replays
+                # or events after a restart). Drop silently.
+        except Exception:
+            logger.exception("worker stdout reader crashed")
+        finally:
+            # Worker died (or stdout closed). Wake every in-flight caller
+            # with the sentinel so they raise WorkerExitError instead of
+            # hanging on q.get(timeout=60).
+            with self._inflight_lock:
+                for q in self._inflight.values():
+                    q.put({"event": "_worker_exit"})
+                self._inflight.clear()
+
+
+# Backwards-compat alias for callers still referencing the old private name.
+# Will be removed once all internal references migrate to ``WorkerIO``.
+_WorkerIO = WorkerIO

--- a/app/core/worker_io.py
+++ b/app/core/worker_io.py
@@ -81,6 +81,9 @@ class WorkerIO:
         self._inflight: dict[str, "queue.Queue"] = {}
         self._inflight_lock = threading.Lock()
         self._sem = threading.Semaphore(max(1, int(concurrency)))
+        # Set by close(); requests that acquire the semaphore after this
+        # is True must abort instead of writing to a dead worker stdin.
+        self._closed = False
         self._reader_thread = threading.Thread(
             target=self._reader_loop,
             name="worker-io-stdout",
@@ -126,13 +129,24 @@ class WorkerIO:
             await _fut
         except BaseException:
             def _release_if_late_acquire(f: "asyncio.Future") -> None:
+                # f.result() can raise CancelledError if the wrapper
+                # future itself was cancelled before the executor thread
+                # ran. Catch BaseException (not Exception) so we don't
+                # propagate a cancel-trace out of a done-callback.
                 try:
                     if f.result() is True:
                         self._sem.release()
-                except Exception:
+                except BaseException:
                     pass
             _fut.add_done_callback(_release_if_late_acquire)
             raise
+
+        # Hold semaphore from here. If close() ran while we were waiting,
+        # abort immediately and release the slot back; do not register
+        # inflight and do not write to dead worker stdin.
+        if self._closed:
+            self._sem.release()
+            raise WorkerExitError("WorkerIO closed before request could start")
 
         q: "queue.Queue" = queue.Queue()
         with self._inflight_lock:
@@ -188,11 +202,15 @@ class WorkerIO:
 
         After ``close()``, in-flight ``send_request``/``request`` generators
         observe a ``_worker_exit`` sentinel and surface ``WorkerExitError``.
-        The reader thread itself is daemon and will exit naturally when
+        Sets a closed flag so that any request currently blocked in
+        ``self._sem.acquire()`` (saturation back-pressure) will abort
+        on wake-up instead of writing to a dead worker's stdin. The
+        reader thread itself is daemon and will exit naturally when
         the subprocess stdout EOFs; ``close()`` does not kill the
         subprocess — that is the owning backend's responsibility (proc
         lifecycle stays where it is today).
         """
+        self._closed = True
         with self._inflight_lock:
             queues = list(self._inflight.values())
             self._inflight.clear()
@@ -206,37 +224,38 @@ class WorkerIO:
         terminates when an ``event=="done"`` or ``event=="cancelled"`` is
         received, or raises ``WorkerExitError`` if the worker dies mid-request.
         """
+        # Wrap the entire body in try/finally so the semaphore is always
+        # released regardless of where we exit (including failures in
+        # setup between acquire and the inner try).
         self._sem.acquire()
-        req_id = payload["id"]
-        q: "queue.Queue" = queue.Queue()
-        # CRITICAL ordering: insert the queue BEFORE writing stdin so the
-        # reader thread can never observe an event for ``req_id`` before
-        # the queue exists (would otherwise be dropped as "stale").
-        with self._inflight_lock:
-            self._inflight[req_id] = q
+        req_id: str | None = None
         try:
+            # Mirror the async path: if close() ran while we waited on
+            # the semaphore, abort instead of writing to a dead worker.
+            if self._closed:
+                raise WorkerExitError("WorkerIO closed before request could start")
+            req_id = payload["id"]
+            q: "queue.Queue" = queue.Queue()
+            # CRITICAL ordering: insert the queue BEFORE writing stdin so
+            # the reader thread can never observe an event for ``req_id``
+            # before the queue exists (would otherwise be dropped as "stale").
+            with self._inflight_lock:
+                self._inflight[req_id] = q
             assert self._proc.stdin is not None
-            try:
-                with self._stdin_lock:
-                    self._proc.stdin.write(json.dumps(payload, ensure_ascii=False) + "\n")
-                    self._proc.stdin.flush()
-            except Exception:
-                with self._inflight_lock:
-                    self._inflight.pop(req_id, None)
-                raise
+            with self._stdin_lock:
+                self._proc.stdin.write(json.dumps(payload, ensure_ascii=False) + "\n")
+                self._proc.stdin.flush()
             while True:
-                try:
-                    event = q.get(timeout=60.0)
-                except Exception:
-                    raise
+                event = q.get(timeout=60.0)
                 if event.get("event") == "_worker_exit":
                     raise WorkerExitError("worker subprocess died mid-request")
                 yield event
                 if event.get("event") in ("done", "cancelled"):
                     return
         finally:
-            with self._inflight_lock:
-                self._inflight.pop(req_id, None)
+            if req_id is not None:
+                with self._inflight_lock:
+                    self._inflight.pop(req_id, None)
             self._sem.release()
 
     def cancel(self, req_id: str) -> None:

--- a/app/main.py
+++ b/app/main.py
@@ -2035,6 +2035,14 @@ async def _asr_stream_backend(
                 except (ValueError, TypeError):
                     continue
                 if cmd.get("command") == "reset":
+                    # Release per-stream GPU resources from the old stream
+                    # before swapping (no-op for backends without close()).
+                    try:
+                        _old_close = getattr(stream, "close", None)
+                        if _old_close is not None:
+                            _old_close()
+                    except Exception:
+                        logger.exception("ASR reset: old stream close raised")
                     stream = asr_be.create_stream(language=language)
                     await ws.send_json({
                         "type": "reset",
@@ -2158,6 +2166,14 @@ async def _asr_stream_backend(
         except Exception:
             pass
     finally:
+        # Release per-stream TRT contexts and device buffers (no-op for
+        # backends without per-stream GPU resources).
+        try:
+            close = getattr(stream, "close", None)
+            if close is not None:
+                close()
+        except Exception:
+            logger.exception("ASR stream close raised")
         try:
             await ws.close()
         except Exception:

--- a/app/main.py
+++ b/app/main.py
@@ -295,19 +295,24 @@ def _try_asr_manager():
 
 def _resolve_tts_stream_max_workers() -> tuple[int, str | None, str]:
     """Resolve the TTS stream executor `max_workers` from env + the
-    currently-loaded backend name. Returns `(workers, backend_name_or_None,
-    env_var_used)`. Extracted so a one-shot post-startup refresh can
-    replace the executor when the backend-specific env didn't apply at
-    first call (TTS service not yet ready → backend_name() == "").
+    currently-loaded backend's concurrency_capability. Returns
+    `(workers, backend_name_or_None, source_label)`.
 
-    Codex Week 3 BLOCKER 4: if `_get_tts_stream_executor()` is called
-    before TTS service is ready (e.g. lazy startup, first /v2v/stream
-    warming up), backend_name() returns "" and the
-    OVS_TTS_STREAM_MAX_WORKERS_{KOKORO,MATCHA,QWEN3,MOSS} envs never
-    activate — the executor sticks at the global default forever.
+    Spec docs/specs/concurrency-capability-framework.md §5: executor cap
+    and the WorkerIO semaphore must derive from the same capability
+    source. Resolution precedence:
+
+      1. backend-specific env (OVS_TTS_STREAM_MAX_WORKERS_{KOKORO,MATCHA,
+         QWEN3,MOSS}) if matching, then global OVS_TTS_STREAM_MAX_WORKERS
+         — env values are CLAMPED to the backend ceiling.
+      2. backend.concurrency_capability(profile).max_concurrent (None ->
+         legacy global default of 2 since the executor needs a finite N).
+      3. legacy default ``2``.
+
+    Codex Week 3 BLOCKER 4 lazy-startup workflow is preserved: the
+    one-shot post-ready refresh still applies because we re-read both
+    backend name and capability each call until the flag flips.
     """
-    max_workers_str = os.environ.get("OVS_TTS_STREAM_MAX_WORKERS", "2")
-    env_used = "OVS_TTS_STREAM_MAX_WORKERS"
     try:
         from app.core import tts_service as _tts_svc
         backend_name = (
@@ -317,6 +322,10 @@ def _resolve_tts_stream_max_workers() -> tuple[int, str | None, str]:
         )
     except Exception:
         backend_name = ""
+
+    # Pull explicit env (back-compat with codex Week 3 BLOCKER 4).
+    env_used = None
+    env_str: str | None = None
     for suffix, env_name in (
         ("kokoro", "OVS_TTS_STREAM_MAX_WORKERS_KOKORO"),
         ("matcha", "OVS_TTS_STREAM_MAX_WORKERS_MATCHA"),
@@ -324,10 +333,47 @@ def _resolve_tts_stream_max_workers() -> tuple[int, str | None, str]:
         ("moss", "OVS_TTS_STREAM_MAX_WORKERS_MOSS"),
     ):
         if suffix in backend_name and os.environ.get(env_name):
-            max_workers_str = os.environ[env_name]
+            env_str = os.environ[env_name]
             env_used = env_name
             break
-    return int(max_workers_str), backend_name or None, env_used
+    if env_str is None and os.environ.get("OVS_TTS_STREAM_MAX_WORKERS"):
+        env_str = os.environ["OVS_TTS_STREAM_MAX_WORKERS"]
+        env_used = "OVS_TTS_STREAM_MAX_WORKERS"
+
+    # Capability-driven default (spec §5 alignment with WorkerIO).
+    cap_max: int | None = None
+    try:
+        from app.core.profile_loader import current_profile
+        from app.core.tts_backend import _TTS_REGISTRY
+        prof = current_profile()
+        spec = prof.get("tts_backend")
+        if spec and spec in _TTS_REGISTRY:
+            module_path, cls_name = _TTS_REGISTRY[spec]
+            import importlib as _il
+            cls = getattr(_il.import_module(module_path), cls_name)
+            cap = cls.concurrency_capability(prof)
+            cap_max = cap.max_concurrent  # may be None (unbounded)
+    except Exception:
+        cap_max = None
+
+    if env_str is not None:
+        try:
+            n = int(env_str)
+        except (TypeError, ValueError):
+            n = 2
+        if cap_max is not None and n > cap_max:
+            logger.warning(
+                "TTS executor: %s=%d exceeds backend ceiling %d; clamping",
+                env_used, n, cap_max,
+            )
+            n = cap_max
+        return max(1, n), backend_name or None, env_used or "OVS_TTS_STREAM_MAX_WORKERS"
+
+    if cap_max is not None:
+        return max(1, cap_max), backend_name or None, "concurrency_capability"
+
+    # No env, no capability resolvable — legacy default.
+    return 2, backend_name or None, "default"
 
 
 # Tracks whether the cached executor was created BEFORE the TTS backend

--- a/app/main.py
+++ b/app/main.py
@@ -882,12 +882,12 @@ async def health():
         "tts_capabilities": [c.value for c in tts_service.capabilities()] if tts_service.is_ready() else [],
     }
 
-    # Part D disconnect-watcher instrumentation: expose _WorkerIO cancel
+    # Part D disconnect-watcher instrumentation: expose WorkerIO cancel
     # counter so stress harness can read it. Temporary; remove once stable.
     try:
-        from app.backends.jetson.trt_edge_llm_tts import _WorkerIO
-        with _WorkerIO._cancel_count_lock:
-            result["tts_worker_cancel_count"] = _WorkerIO._cancel_count
+        from app.core.worker_io import WorkerIO
+        with WorkerIO._cancel_count_lock:
+            result["tts_worker_cancel_count"] = WorkerIO._cancel_count
     except Exception:
         pass
 

--- a/app/main.py
+++ b/app/main.py
@@ -508,7 +508,11 @@ async def startup():
     # execution_policy block. Default to concurrent (no lock) when the
     # profile does not declare one — matches the previous behaviour.
     from app.core.coordinator import init_coordinator, get_coordinator
-    init_coordinator(current_profile().get("execution_policy", {"mode": "concurrent"}))
+    _prof = current_profile()
+    init_coordinator(
+        _prof.get("execution_policy", {"mode": "concurrent"}),
+        profile=_prof,
+    )
 
     # Week 2: launch the GPU/NPU watchdog background task. Failures here
     # never block startup — the task is purely diagnostic.

--- a/app/tests/test_concurrency_capability.py
+++ b/app/tests/test_concurrency_capability.py
@@ -227,3 +227,45 @@ def test_qwen3_trt_falls_back_to_default():
     cap = Qwen3TRTBackend.concurrency_capability()
     assert cap == ConcurrencyCapability.default()
     assert cap.max_concurrent == 1
+
+
+# ---------- CPU / desktop backends: parallel 4, non-exclusive ----------
+
+
+def test_sherpa_tts_cpu_capability():
+    from app.backends.cpu.sherpa import SherpaBackend
+    cap = SherpaBackend.concurrency_capability()
+    assert cap.supports_parallel is True
+    assert cap.max_concurrent == 4
+    assert cap.requires_exclusive_device is False
+    assert cap.scaling_mode == "external_managed"
+
+
+def test_sherpa_asr_cpu_capability():
+    from app.backends.cpu.sherpa_asr import SherpaASRBackend
+    cap = SherpaASRBackend.concurrency_capability()
+    assert cap.supports_parallel is True
+    assert cap.max_concurrent == 4
+    assert cap.requires_exclusive_device is False
+    assert cap.scaling_mode == "external_managed"
+
+
+# ---------- RK NPU backends: serial, exclusive, max 1 ----------
+
+
+def test_rk_asr_capability():
+    from app.backends.rk.asr import RKASRBackend
+    cap = RKASRBackend.concurrency_capability()
+    assert cap.supports_parallel is False
+    assert cap.max_concurrent == 1
+    assert cap.requires_exclusive_device is True
+    assert cap.scaling_mode == "external_managed"
+
+
+def test_rk_tts_capability():
+    from app.backends.rk.tts import RKTTSBackend
+    cap = RKTTSBackend.concurrency_capability()
+    assert cap.supports_parallel is False
+    assert cap.max_concurrent == 1
+    assert cap.requires_exclusive_device is True
+    assert cap.scaling_mode == "external_managed"

--- a/app/tests/test_concurrency_capability.py
+++ b/app/tests/test_concurrency_capability.py
@@ -1,0 +1,213 @@
+"""Unit tests for ConcurrencyCapability and backend declarations.
+
+Covers spec docs/specs/concurrency-capability-framework.md P0:
+- dataclass shape + conservative defaults
+- ABC default returns conservative capability
+- 4 N>=2-safe backends declare correctly
+- env / profile pool-size overrides are honored
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+
+import pytest
+
+
+def _reload(modpath: str):
+    mod = importlib.import_module(modpath)
+    return importlib.reload(mod)
+
+
+# ---------- Dataclass ---------------------------------------------------------
+
+
+def test_default_is_conservative():
+    from app.core.concurrency_capability import ConcurrencyCapability
+
+    cap = ConcurrencyCapability.default()
+    assert cap.supports_parallel is False
+    assert cap.max_concurrent == 1
+    assert cap.is_stateful is True
+    assert cap.requires_exclusive_device is True
+    assert cap.scaling_mode == "single_runtime_multiplex"
+    assert cap.vram_mb_per_slot is None
+
+
+def test_dataclass_is_frozen():
+    from app.core.concurrency_capability import ConcurrencyCapability
+
+    cap = ConcurrencyCapability.default()
+    with pytest.raises(Exception):
+        cap.max_concurrent = 99  # type: ignore[misc]
+
+
+def test_dataclass_max_concurrent_none_allowed():
+    from app.core.concurrency_capability import ConcurrencyCapability
+
+    cap = ConcurrencyCapability(
+        supports_parallel=True,
+        max_concurrent=None,
+        scaling_mode="multi_runtime_per_slot",
+    )
+    assert cap.max_concurrent is None
+
+
+# ---------- ABC defaults ------------------------------------------------------
+
+
+def test_abc_asr_default_capability():
+    from app.core.asr_backend import ASRBackend
+    from app.core.concurrency_capability import ConcurrencyCapability
+
+    cap = ASRBackend.concurrency_capability()
+    assert cap == ConcurrencyCapability.default()
+
+
+def test_abc_tts_default_capability():
+    from app.core.tts_backend import TTSBackend
+    from app.core.concurrency_capability import ConcurrencyCapability
+
+    cap = TTSBackend.concurrency_capability()
+    assert cap == ConcurrencyCapability.default()
+
+
+# ---------- Backend declarations ---------------------------------------------
+
+
+def test_trt_edge_llm_tts_default_n1(monkeypatch):
+    monkeypatch.delenv("OVS_TTS_WORKER_CONCURRENCY", raising=False)
+    from app.backends.jetson.trt_edge_llm_tts import TRTEdgeLLMTTSBackend
+
+    cap = TRTEdgeLLMTTSBackend.concurrency_capability()
+    assert cap.max_concurrent == 1
+    assert cap.supports_parallel is False
+    assert cap.scaling_mode == "single_runtime_multiplex"
+    assert cap.requires_exclusive_device is True
+
+
+def test_trt_edge_llm_tts_env_override(monkeypatch):
+    monkeypatch.setenv("OVS_TTS_WORKER_CONCURRENCY", "3")
+    from app.backends.jetson.trt_edge_llm_tts import TRTEdgeLLMTTSBackend
+
+    cap = TRTEdgeLLMTTSBackend.concurrency_capability()
+    assert cap.max_concurrent == 3
+    assert cap.supports_parallel is True
+
+
+def test_trt_edge_llm_tts_profile_override(monkeypatch):
+    monkeypatch.delenv("OVS_TTS_WORKER_CONCURRENCY", raising=False)
+    from app.backends.jetson.trt_edge_llm_tts import TRTEdgeLLMTTSBackend
+
+    cap = TRTEdgeLLMTTSBackend.concurrency_capability(
+        profile={"tts_worker_concurrency": 4}
+    )
+    assert cap.max_concurrent == 4
+    assert cap.supports_parallel is True
+
+
+def test_trt_edge_llm_tts_env_beats_profile(monkeypatch):
+    monkeypatch.setenv("OVS_TTS_WORKER_CONCURRENCY", "2")
+    from app.backends.jetson.trt_edge_llm_tts import TRTEdgeLLMTTSBackend
+
+    cap = TRTEdgeLLMTTSBackend.concurrency_capability(
+        profile={"tts_worker_concurrency": 8}
+    )
+    # env takes precedence (matches existing __init__ behavior)
+    assert cap.max_concurrent == 2
+
+
+def test_matcha_default_k2(monkeypatch):
+    monkeypatch.delenv("OVS_TTS_STREAM_MAX_WORKERS", raising=False)
+    from app.backends.jetson.matcha_trt import MatchaTRTBackend
+
+    cap = MatchaTRTBackend.concurrency_capability()
+    assert cap.max_concurrent == 2
+    assert cap.supports_parallel is True
+    assert cap.scaling_mode == "single_runtime_multiplex"
+
+
+def test_matcha_env_override(monkeypatch):
+    monkeypatch.setenv("OVS_TTS_STREAM_MAX_WORKERS", "4")
+    from app.backends.jetson.matcha_trt import MatchaTRTBackend
+
+    cap = MatchaTRTBackend.concurrency_capability()
+    assert cap.max_concurrent == 4
+
+
+def test_matcha_profile_override(monkeypatch):
+    monkeypatch.delenv("OVS_TTS_STREAM_MAX_WORKERS", raising=False)
+    from app.backends.jetson.matcha_trt import MatchaTRTBackend
+
+    cap = MatchaTRTBackend.concurrency_capability(
+        profile={"tts_stream_max_workers": 3}
+    )
+    assert cap.max_concurrent == 3
+
+
+def test_matcha_invalid_env_falls_back(monkeypatch):
+    monkeypatch.setenv("OVS_TTS_STREAM_MAX_WORKERS", "not-an-int")
+    from app.backends.jetson.matcha_trt import MatchaTRTBackend
+
+    cap = MatchaTRTBackend.concurrency_capability()
+    assert cap.max_concurrent == 2  # fallback
+
+
+def test_matcha_k1_serialized(monkeypatch):
+    monkeypatch.setenv("OVS_TTS_STREAM_MAX_WORKERS", "1")
+    from app.backends.jetson.matcha_trt import MatchaTRTBackend
+
+    cap = MatchaTRTBackend.concurrency_capability()
+    assert cap.max_concurrent == 1
+    assert cap.supports_parallel is False
+
+
+def test_kokoro_default_k2(monkeypatch):
+    monkeypatch.delenv("OVS_TTS_STREAM_MAX_WORKERS", raising=False)
+    from app.backends.jetson.kokoro_trt import KokoroTRTBackend
+
+    cap = KokoroTRTBackend.concurrency_capability()
+    assert cap.max_concurrent == 2
+    assert cap.supports_parallel is True
+
+
+def test_kokoro_env_override(monkeypatch):
+    monkeypatch.setenv("OVS_TTS_STREAM_MAX_WORKERS", "6")
+    from app.backends.jetson.kokoro_trt import KokoroTRTBackend
+
+    cap = KokoroTRTBackend.concurrency_capability()
+    assert cap.max_concurrent == 6
+
+
+def test_kokoro_profile_override(monkeypatch):
+    monkeypatch.delenv("OVS_TTS_STREAM_MAX_WORKERS", raising=False)
+    from app.backends.jetson.kokoro_trt import KokoroTRTBackend
+
+    cap = KokoroTRTBackend.concurrency_capability(
+        profile={"tts_backend_config": {"stream_max_workers": 5}}
+    )
+    assert cap.max_concurrent == 5
+
+
+def test_paraformer_unbounded():
+    from app.backends.jetson.paraformer_trt import ParaformerTRTBackend
+
+    cap = ParaformerTRTBackend.concurrency_capability()
+    assert cap.supports_parallel is True
+    assert cap.max_concurrent is None
+    assert cap.scaling_mode == "multi_runtime_per_slot"
+    assert cap.requires_exclusive_device is True
+
+
+# ---------- Non-declared backends fall back to conservative default ----------
+
+
+def test_qwen3_trt_falls_back_to_default():
+    """qwen3_trt does not override concurrency_capability (per spec, kept N=1)."""
+    from app.backends.jetson.qwen3_trt import Qwen3TRTBackend
+    from app.core.concurrency_capability import ConcurrencyCapability
+
+    cap = Qwen3TRTBackend.concurrency_capability()
+    assert cap == ConcurrencyCapability.default()
+    assert cap.max_concurrent == 1

--- a/app/tests/test_concurrency_capability.py
+++ b/app/tests/test_concurrency_capability.py
@@ -154,6 +154,22 @@ def test_matcha_invalid_env_falls_back(monkeypatch):
     assert cap.max_concurrent == 2  # fallback
 
 
+def test_kokoro_invalid_env_falls_back(monkeypatch):
+    monkeypatch.setenv("OVS_TTS_STREAM_MAX_WORKERS", "not-an-int")
+    from app.backends.jetson.kokoro_trt import KokoroTRTBackend
+
+    cap = KokoroTRTBackend.concurrency_capability()
+    assert cap.max_concurrent == 2  # fallback
+
+
+def test_trt_edge_llm_tts_invalid_env_falls_back(monkeypatch):
+    monkeypatch.setenv("OVS_TTS_WORKER_CONCURRENCY", "not-an-int")
+    from app.backends.jetson.trt_edge_llm_tts import TRTEdgeLLMTTSBackend
+
+    cap = TRTEdgeLLMTTSBackend.concurrency_capability()
+    assert cap.max_concurrent == 1  # conservative fallback
+
+
 def test_matcha_k1_serialized(monkeypatch):
     monkeypatch.setenv("OVS_TTS_STREAM_MAX_WORKERS", "1")
     from app.backends.jetson.matcha_trt import MatchaTRTBackend

--- a/app/tests/test_coordinator.py
+++ b/app/tests/test_coordinator.py
@@ -1,0 +1,111 @@
+"""Coordinator mode-resolution tests (spec §4).
+
+`concurrent` is permitted only when both ASR + TTS declare
+``supports_parallel=True`` with effective max > 1. Otherwise downgrade
+to ``serialized``. Profile ``exclusive`` is always honored as-is.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.coordinator import BackendCoordinator, _resolve_mode
+
+
+# ---------- _resolve_mode unit table ----------
+
+
+def test_concurrent_jetson_pair_stays_concurrent():
+    """matcha (parallel, K=2) + paraformer (parallel, max=None) -> concurrent."""
+    policy = {"mode": "concurrent"}
+    profile = {
+        "asr_backend": "jetson.paraformer_trt",
+        "tts_backend": "jetson.matcha_trt",
+    }
+    assert _resolve_mode(policy, profile) == "concurrent"
+
+
+def test_concurrent_with_rk_downgrades_to_serialized():
+    """rk asr/tts declare supports_parallel=False -> downgrade."""
+    policy = {"mode": "concurrent"}
+    profile = {
+        "asr_backend": "rk.asr",
+        "tts_backend": "rk.tts",
+    }
+    assert _resolve_mode(policy, profile) == "serialized"
+
+
+def test_concurrent_with_cpu_pair_stays_concurrent():
+    """sherpa CPU (parallel, 4) on both sides -> concurrent."""
+    policy = {"mode": "concurrent"}
+    profile = {
+        "asr_backend": "cpu.sherpa_asr",
+        "tts_backend": "cpu.sherpa",
+    }
+    assert _resolve_mode(policy, profile) == "concurrent"
+
+
+def test_concurrent_mixed_rk_asr_jetson_tts_downgrades():
+    """Any single non-parallel backend downgrades the pair."""
+    policy = {"mode": "concurrent"}
+    profile = {
+        "asr_backend": "rk.asr",
+        "tts_backend": "jetson.matcha_trt",
+    }
+    assert _resolve_mode(policy, profile) == "serialized"
+
+
+def test_profile_serialized_stays_serialized():
+    policy = {"mode": "serialized"}
+    profile = {
+        "asr_backend": "jetson.paraformer_trt",
+        "tts_backend": "jetson.matcha_trt",
+    }
+    assert _resolve_mode(policy, profile) == "serialized"
+
+
+def test_profile_exclusive_always_honored():
+    """``exclusive`` is never auto-resolved away."""
+    policy = {"mode": "exclusive"}
+    # even with backends that could run concurrent
+    profile = {
+        "asr_backend": "jetson.paraformer_trt",
+        "tts_backend": "jetson.matcha_trt",
+    }
+    assert _resolve_mode(policy, profile) == "exclusive"
+
+
+def test_no_profile_uses_raw_policy():
+    """Legacy callers without profile argument retain old behavior."""
+    assert _resolve_mode({"mode": "concurrent"}, None) == "concurrent"
+    assert _resolve_mode({"mode": "serialized"}, None) == "serialized"
+    assert _resolve_mode({}, None) == "concurrent"  # default
+
+
+# ---------- Integration with BackendCoordinator ----------
+
+
+def test_coordinator_downgrade_creates_lock():
+    policy = {"mode": "concurrent"}
+    profile = {"asr_backend": "rk.asr", "tts_backend": "rk.tts"}
+    c = BackendCoordinator(policy, profile=profile)
+    assert c.mode == "serialized"
+    assert c._lock is not None
+
+
+def test_coordinator_concurrent_jetson_no_lock():
+    policy = {"mode": "concurrent"}
+    profile = {
+        "asr_backend": "jetson.paraformer_trt",
+        "tts_backend": "jetson.matcha_trt",
+    }
+    c = BackendCoordinator(policy, profile=profile)
+    assert c.mode == "concurrent"
+    assert c._lock is None
+
+
+def test_coordinator_back_compat_no_profile():
+    """Old call signature (no profile) still works."""
+    c = BackendCoordinator({"mode": "serialized"})
+    assert c.mode == "serialized"
+    assert c._lock is not None

--- a/app/tests/test_kokoro_trt.py
+++ b/app/tests/test_kokoro_trt.py
@@ -57,18 +57,27 @@ def test_kokoro_bucket_selection():
 
     backend = KokoroTRTBackend.__new__(KokoroTRTBackend)
     backend._split_engines = {"decoder": object()}
-    backend._split_ctxs = {"decoder": object()}
     backend._split_long_engines = {"decoder": object()}
-    backend._split_long_ctxs = {"decoder": object()}
+    # Per-call ctx rework: ctxs are passed in as kwargs instead of being
+    # backend state; tests pass empty dicts (engine identity is what matters).
+    split_ctxs = {"decoder": object()}
+    split_long_ctxs = {"decoder": object()}
 
-    assert backend._select_split_bucket(256)[0] is backend._split_engines
-    assert backend._select_split_bucket(257)[0] is backend._split_long_engines
-    assert backend._select_split_bucket(512)[0] is backend._split_long_engines
+    assert backend._select_split_bucket(
+        256, split_ctxs=split_ctxs, split_long_ctxs=split_long_ctxs
+    )[0] is backend._split_engines
+    assert backend._select_split_bucket(
+        257, split_ctxs=split_ctxs, split_long_ctxs=split_long_ctxs
+    )[0] is backend._split_long_engines
+    assert backend._select_split_bucket(
+        512, split_ctxs=split_ctxs, split_long_ctxs=split_long_ctxs
+    )[0] is backend._split_long_engines
 
     backend._split_long_engines = {}
-    backend._split_long_ctxs = {}
     try:
-        backend._select_split_bucket(257)
+        backend._select_split_bucket(
+            257, split_ctxs=split_ctxs, split_long_ctxs={}
+        )
     except ValueError as exc:
         assert "outside available TRT buckets" in str(exc)
     else:

--- a/app/tests/test_kokoro_trt_padding.py
+++ b/app/tests/test_kokoro_trt_padding.py
@@ -29,7 +29,9 @@ def _build_backend(mode: str, *, fixed_len=None, min_len=None, max_len=128):
 def _patched_synth(backend, token_ids, capture):
     """Run _synthesize_one with token + downstream stubs and capture input_ids."""
 
-    def fake_run_split_generator(input_ids, style, speed_arr):
+    def fake_run_split_generator(input_ids, style, speed_arr, **_kwargs):
+        # _kwargs absorbs pool / split_ctxs / split_long_ctxs added by the
+        # per-call concurrency rework (2026-05-25).
         capture["input_ids"] = input_ids
         # Return a small fake audio buffer.
         return np.zeros(1024, dtype=np.float32)

--- a/app/tests/test_model_downloader_routing.py
+++ b/app/tests/test_model_downloader_routing.py
@@ -1,0 +1,87 @@
+"""Tests for app.core.model_downloader profile-driven routing.
+
+Regression: orin-nano 2026-05-25 silent Qwen3-skip bug. When OVS_PROFILE
+selected a Qwen3 ASR profile but the environment had LANGUAGE_MODE=zh_en
+pre-set, ensure_models() routed by language_mode and skipped
+_ensure_qwen3_artifacts(). After fix, routing is profile-driven first
+(asr_backend/tts_backend) and language_mode-driven second; both UNION.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from app.core import model_downloader
+
+
+def _no_op_download(url, dest_dir):  # pragma: no cover - safety net
+    raise AssertionError(
+        f"unexpected real download attempt: {url} -> {dest_dir}"
+    )
+
+
+def test_profile_with_trt_edge_llm_triggers_qwen3_even_when_lang_mode_zh_en(
+    tmp_path, monkeypatch,
+):
+    """Profile asr_backend=jetson.trt_edge_llm must call _ensure_qwen3_artifacts
+    even when language_mode='zh_en' (the legacy zh_en path would otherwise
+    never call it). This is the core orin-nano regression fix."""
+    from app.core import profile_loader
+    monkeypatch.setattr(
+        profile_loader,
+        "current_profile",
+        lambda: {
+            "asr_backend": "jetson.trt_edge_llm",
+            "tts_backend": "jetson.matcha_trt",
+        },
+    )
+    # Patch the symbol the function actually calls (module-level lookup).
+    with patch.object(
+        model_downloader, "_ensure_qwen3_artifacts"
+    ) as mock_qwen3, patch.object(
+        model_downloader, "_download_and_extract", side_effect=_no_op_download,
+    ):
+        # Pretend zh_en assets (matcha + paraformer) are already present
+        # so no actual download fires. language_mode='zh_en' unions in
+        # the legacy zh_en requirements alongside profile-driven matcha.
+        for sub, files in (
+            ("matcha-icefall-zh-en", ("model-steps-3.onnx", "tokens.txt", "lexicon.txt")),
+            ("paraformer-streaming", ("encoder.onnx", "tokens.txt")),
+        ):
+            d = tmp_path / sub
+            d.mkdir()
+            for f in files:
+                (d / f).write_text("x")
+
+        model_downloader.ensure_models(
+            language_mode="zh_en", model_dir=str(tmp_path),
+        )
+
+    mock_qwen3.assert_called_once()
+
+
+def test_no_profile_zh_en_legacy_path_does_not_call_qwen3(tmp_path, monkeypatch):
+    """Backward-compat: no profile + LANGUAGE_MODE=zh_en must NOT trigger
+    Qwen3 (legacy behaviour for users who never opted into profiles)."""
+    from app.core import profile_loader
+    monkeypatch.setattr(profile_loader, "current_profile", lambda: {})
+    with patch.object(
+        model_downloader, "_ensure_qwen3_artifacts"
+    ) as mock_qwen3, patch.object(
+        model_downloader, "_download_and_extract", side_effect=_no_op_download,
+    ):
+        # Pretend both zh_en models exist so we don't trip the downloader.
+        for sub, files in (
+            ("matcha-icefall-zh-en", ("model-steps-3.onnx", "tokens.txt", "lexicon.txt")),
+            ("paraformer-streaming", ("encoder.onnx", "tokens.txt")),
+        ):
+            d = tmp_path / sub
+            d.mkdir()
+            for f in files:
+                (d / f).write_text("x")
+
+        model_downloader.ensure_models(
+            language_mode="zh_en", model_dir=str(tmp_path),
+        )
+
+    mock_qwen3.assert_not_called()

--- a/app/tests/test_profile_loader.py
+++ b/app/tests/test_profile_loader.py
@@ -376,6 +376,41 @@ def test_apply_profile_two_pass_expansion_writes_env(tmp_path, monkeypatch):
     assert os.environ["EDGE_LLM_ASR_ENGINE_DIR"] == "/opt/X/engines/asr"
 
 
+def test_critical_key_conflict_raises(tmp_path, monkeypatch):
+    """LANGUAGE_MODE pre-set to a different value than the profile must
+    hard-fail (root cause of orin-nano Qwen3 silent-skip bug 2026-05-25)."""
+    monkeypatch.setenv("LANGUAGE_MODE", "zh_en")
+    monkeypatch.setattr(
+        profile_loader, "_OPERATOR_KEYS", frozenset({"LANGUAGE_MODE"})
+    )
+
+    p = _write_profile(
+        tmp_path, "needs-multilang",
+        {"env": {"LANGUAGE_MODE": "multilanguage"}},
+    )
+    with pytest.raises(RuntimeError, match="Remove LANGUAGE_MODE"):
+        profile_loader.apply_profile(str(p))
+
+
+def test_critical_key_matching_value_does_not_raise(tmp_path, monkeypatch):
+    """If the operator env matches the profile-declared value, no conflict."""
+    import os
+
+    monkeypatch.setenv("LANGUAGE_MODE", "multilanguage")
+    monkeypatch.setattr(
+        profile_loader, "_OPERATOR_KEYS", frozenset({"LANGUAGE_MODE"})
+    )
+
+    p = _write_profile(
+        tmp_path, "agrees",
+        {"env": {"LANGUAGE_MODE": "multilanguage"}},
+    )
+    # Must not raise.
+    profile = profile_loader.apply_profile(str(p))
+    assert profile["name"] == "agrees"
+    assert os.environ["LANGUAGE_MODE"] == "multilanguage"
+
+
 def test_apply_profile_returns_empty_when_no_ref(monkeypatch):
     """No env hints + no explicit ref → returns {} without touching state."""
     for k in ("OVS_PROFILE_JSON", "OVS_PROFILE", "OVS_PROFILE_DEFAULT",

--- a/app/tests/test_session_limiter.py
+++ b/app/tests/test_session_limiter.py
@@ -1,0 +1,139 @@
+"""Unit tests for session_limiter.resolve_limit() capability aggregation.
+
+Spec docs/specs/concurrency-capability-framework.md §3 + §7. The limiter
+ceiling now derives from ``min(asr.max_concurrent, tts.max_concurrent)``
+(``None`` is treated as +inf). Profile/env overrides may only downgrade;
+exceeding the ceiling is warn + silent clamp.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from app.core.session_limiter import resolve_limit
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    monkeypatch.delenv("OVS_MAX_CONCURRENT_SESSIONS", raising=False)
+    monkeypatch.delenv("OVS_TTS_WORKER_CONCURRENCY", raising=False)
+    monkeypatch.delenv("OVS_TTS_STREAM_MAX_WORKERS", raising=False)
+
+
+# ---------- Aggregation math ----------
+
+
+def test_jetson_matcha_plus_paraformer_takes_min_finite():
+    """matcha (tts max=2) + paraformer (asr max=None=+inf) -> min = 2."""
+    profile = {
+        "asr_backend": "jetson.paraformer_trt",
+        "tts_backend": "jetson.matcha_trt",
+    }
+    assert resolve_limit(profile) == 2
+
+
+def test_cpu_pair_yields_desktop_default():
+    """CPU sherpa pair -> min(4, 4) = 4."""
+    profile = {
+        "asr_backend": "cpu.sherpa_asr",
+        "tts_backend": "cpu.sherpa",
+    }
+    assert resolve_limit(profile) == 4
+
+
+def test_rk_pair_yields_serial():
+    """RK pair -> min(1, 1) = 1."""
+    profile = {
+        "asr_backend": "rk.asr",
+        "tts_backend": "rk.tts",
+    }
+    assert resolve_limit(profile) == 1
+
+
+# ---------- Profile override semantics ----------
+
+
+def test_profile_downgrade_honored():
+    """Setting profile.max_concurrent_sessions BELOW ceiling downgrades."""
+    profile = {
+        "asr_backend": "jetson.paraformer_trt",
+        "tts_backend": "jetson.matcha_trt",
+        "max_concurrent_sessions": 1,
+    }
+    assert resolve_limit(profile) == 1
+
+
+def test_profile_upgrade_clamped_with_warning(caplog):
+    """Trying to lift profile above the ceiling is clamped + warn."""
+    profile = {
+        "asr_backend": "rk.asr",
+        "tts_backend": "rk.tts",
+        "max_concurrent_sessions": 99,
+    }
+    with caplog.at_level(logging.WARNING, logger="app.core.session_limiter"):
+        assert resolve_limit(profile) == 1
+    assert any("exceeds backend ceiling" in r.message for r in caplog.records)
+
+
+# ---------- Env override semantics ----------
+
+
+def test_env_downgrade_honored(monkeypatch):
+    monkeypatch.setenv("OVS_MAX_CONCURRENT_SESSIONS", "1")
+    profile = {
+        "asr_backend": "cpu.sherpa_asr",
+        "tts_backend": "cpu.sherpa",
+    }
+    assert resolve_limit(profile) == 1
+
+
+def test_env_upgrade_clamped_with_warning(monkeypatch, caplog):
+    monkeypatch.setenv("OVS_MAX_CONCURRENT_SESSIONS", "16")
+    profile = {
+        "asr_backend": "jetson.paraformer_trt",
+        "tts_backend": "jetson.matcha_trt",
+    }
+    with caplog.at_level(logging.WARNING, logger="app.core.session_limiter"):
+        assert resolve_limit(profile) == 2
+    assert any("OVS_MAX_CONCURRENT_SESSIONS" in r.message for r in caplog.records)
+
+
+def test_env_bad_value_raises(monkeypatch):
+    monkeypatch.setenv("OVS_MAX_CONCURRENT_SESSIONS", "0")
+    with pytest.raises(ValueError):
+        resolve_limit({})
+
+
+def test_profile_bad_value_raises():
+    with pytest.raises(ValueError):
+        resolve_limit({"max_concurrent_sessions": -1})
+
+
+# ---------- Fallback to target defaults when capability unresolvable ----------
+
+
+def test_unknown_backend_falls_back_to_target_default():
+    """Profile without resolvable asr/tts -> legacy _TARGET_DEFAULTS path."""
+    profile = {"name": "desktop-mac"}
+    # No asr_backend / tts_backend keys => ceiling unknown, target_default
+    # for "desktop" is 4.
+    assert resolve_limit(profile) == 4
+
+
+def test_no_profile_uses_unknown_default():
+    assert resolve_limit(None) == 1
+
+
+# ---------- Env beats profile (downgrade path) ----------
+
+
+def test_env_overrides_profile(monkeypatch):
+    monkeypatch.setenv("OVS_MAX_CONCURRENT_SESSIONS", "1")
+    profile = {
+        "asr_backend": "cpu.sherpa_asr",
+        "tts_backend": "cpu.sherpa",
+        "max_concurrent_sessions": 3,
+    }
+    assert resolve_limit(profile) == 1

--- a/app/tests/test_worker_io.py
+++ b/app/tests/test_worker_io.py
@@ -1,0 +1,264 @@
+"""Unit tests for WorkerIO (spec docs/specs/concurrency-capability-framework.md §5).
+
+Covers:
+  * sync ``request()`` legacy shim still works (commit 1a contract)
+  * async ``send_request()`` demuxes events keyed by request_id
+  * EOF on stdout -> in-flight callers get WorkerExitError
+  * semaphore release on success AND on exception path
+  * cancel() writes a cancel JSON to worker stdin
+  * close() wakes in-flight callers with the _worker_exit sentinel
+  * async iterator cancellation (consumer breaks early -> cancel() fired)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import threading
+import time
+from typing import Iterable
+
+import pytest
+
+from app.core.worker_io import WorkerIO, WorkerExitError
+
+
+def asynctest(fn):
+    """Decorator turning an async test fn into a sync one (no pytest-asyncio)."""
+    def wrapper(*args, **kwargs):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(fn(*args, **kwargs))
+        finally:
+            loop.close()
+    wrapper.__name__ = fn.__name__
+    return wrapper
+
+
+class _FakeStdin:
+    def __init__(self) -> None:
+        self.writes: list[str] = []
+        self.closed = False
+        self._lock = threading.Lock()
+
+    def write(self, s: str) -> int:
+        with self._lock:
+            self.writes.append(s)
+        return len(s)
+
+    def flush(self) -> None:
+        pass
+
+
+class _FakeStdoutQueue:
+    """Iterable stdout fed by a queue.Queue; closes on None sentinel."""
+
+    def __init__(self) -> None:
+        import queue as _q
+        self._q: "_q.Queue[str | None]" = _q.Queue()
+
+    def feed(self, line: str) -> None:
+        self._q.put(line if line.endswith("\n") else line + "\n")
+
+    def eof(self) -> None:
+        self._q.put(None)
+
+    def __iter__(self):
+        while True:
+            item = self._q.get()
+            if item is None:
+                return
+            yield item
+
+
+class _FakeProc:
+    def __init__(self) -> None:
+        self.stdin = _FakeStdin()
+        self.stdout = _FakeStdoutQueue()
+
+
+# ---------------------------------------------------------------------------
+# Sync request() — preserved legacy shim
+# ---------------------------------------------------------------------------
+
+def test_sync_request_demuxes_by_request_id():
+    proc = _FakeProc()
+    wio = WorkerIO(proc, concurrency=2)
+    payload = {"id": "req-A", "text": "hi"}
+
+    def _feeder():
+        time.sleep(0.05)
+        proc.stdout.feed(json.dumps({"id": "req-B", "event": "chunk", "audio": "ignore"}))
+        proc.stdout.feed(json.dumps({"id": "req-A", "event": "chunk", "audio": "a1"}))
+        proc.stdout.feed(json.dumps({"id": "req-A", "event": "done", "ok": True}))
+
+    threading.Thread(target=_feeder, daemon=True).start()
+    events = list(wio.request(payload))
+    kinds = [e["event"] for e in events]
+    assert kinds == ["chunk", "done"]
+    assert events[0]["audio"] == "a1"
+    # stdin saw the JSON line for req-A
+    assert any("req-A" in w for w in proc.stdin.writes)
+
+
+def test_sync_request_worker_exit_sentinel_raises():
+    proc = _FakeProc()
+    wio = WorkerIO(proc, concurrency=1)
+
+    def _kill():
+        time.sleep(0.05)
+        proc.stdout.eof()
+
+    threading.Thread(target=_kill, daemon=True).start()
+    with pytest.raises(WorkerExitError):
+        for _ in wio.request({"id": "req-1"}):
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Async send_request()
+# ---------------------------------------------------------------------------
+
+@asynctest
+async def test_async_send_request_basic():
+    proc = _FakeProc()
+    wio = WorkerIO(proc, concurrency=2)
+
+    def _feeder():
+        time.sleep(0.02)
+        proc.stdout.feed(json.dumps({"id": "rid-1", "event": "chunk", "audio": "x"}))
+        proc.stdout.feed(json.dumps({"id": "rid-1", "event": "done", "ok": True}))
+
+    threading.Thread(target=_feeder, daemon=True).start()
+    events = []
+    async for ev in wio.send_request("rid-1", {"id": "rid-1", "text": "hello"}):
+        events.append(ev)
+    assert [e["event"] for e in events] == ["chunk", "done"]
+
+
+@asynctest
+async def test_async_send_request_id_mismatch_rejected():
+    proc = _FakeProc()
+    wio = WorkerIO(proc, concurrency=1)
+    with pytest.raises(ValueError):
+        async for _ in wio.send_request("rid-A", {"id": "rid-B"}):
+            break
+
+
+@asynctest
+async def test_async_send_request_consumer_break_fires_cancel():
+    proc = _FakeProc()
+    wio = WorkerIO(proc, concurrency=1)
+
+    def _feeder():
+        time.sleep(0.02)
+        proc.stdout.feed(json.dumps({"id": "rid-X", "event": "chunk", "audio": "a"}))
+        # NOTE: never send done — simulates ongoing stream.
+
+    threading.Thread(target=_feeder, daemon=True).start()
+    gen = wio.send_request("rid-X", {"id": "rid-X"})
+    first = await gen.__anext__()
+    assert first["event"] == "chunk"
+    await gen.aclose()
+    # cancel() should have written a {"type":"cancel","id":"rid-X"} to stdin.
+    cancel_writes = [w for w in proc.stdin.writes if '"type": "cancel"' in w or '"type":"cancel"' in w]
+    assert cancel_writes, f"expected a cancel write, got {proc.stdin.writes!r}"
+    assert "rid-X" in cancel_writes[-1]
+
+
+@asynctest
+async def test_async_send_request_worker_exit():
+    proc = _FakeProc()
+    wio = WorkerIO(proc, concurrency=1)
+
+    def _kill():
+        time.sleep(0.02)
+        proc.stdout.eof()
+
+    threading.Thread(target=_kill, daemon=True).start()
+    with pytest.raises(WorkerExitError):
+        async for _ in wio.send_request("rid-K", {"id": "rid-K"}):
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Semaphore release semantics
+# ---------------------------------------------------------------------------
+
+@asynctest
+async def test_semaphore_released_on_success():
+    proc = _FakeProc()
+    wio = WorkerIO(proc, concurrency=1)
+
+    async def run_one(rid: str):
+        def _feeder():
+            time.sleep(0.01)
+            proc.stdout.feed(json.dumps({"id": rid, "event": "done", "ok": True}))
+        threading.Thread(target=_feeder, daemon=True).start()
+        async for _ in wio.send_request(rid, {"id": rid}):
+            pass
+
+    # Sequential successes must not deadlock — sem must be released.
+    await asyncio.wait_for(run_one("a"), timeout=2.0)
+    await asyncio.wait_for(run_one("b"), timeout=2.0)
+    await asyncio.wait_for(run_one("c"), timeout=2.0)
+
+
+@asynctest
+async def test_semaphore_released_on_worker_exit():
+    proc = _FakeProc()
+    wio = WorkerIO(proc, concurrency=1)
+
+    def _kill():
+        time.sleep(0.02)
+        proc.stdout.eof()
+    threading.Thread(target=_kill, daemon=True).start()
+
+    with pytest.raises(WorkerExitError):
+        async for _ in wio.send_request("rid-1", {"id": "rid-1"}):
+            pass
+
+    # If semaphore had leaked, a second request would hang. Use a tight
+    # timeout to assert no leak; we expect the second request to ALSO
+    # raise WorkerExitError quickly (sentinel already drained).
+    # Fresh inflight insertion + write would race with closed pipe; we
+    # simply confirm the acquire returns quickly.
+    acquired = await asyncio.wait_for(
+        asyncio.get_running_loop().run_in_executor(None, wio._sem.acquire),
+        timeout=1.0,
+    )
+    assert acquired is True
+
+
+# ---------------------------------------------------------------------------
+# close()
+# ---------------------------------------------------------------------------
+
+@asynctest
+async def test_close_wakes_inflight_with_worker_exit():
+    proc = _FakeProc()
+    wio = WorkerIO(proc, concurrency=2)
+
+    async def run():
+        with pytest.raises(WorkerExitError):
+            async for _ in wio.send_request("rid-close", {"id": "rid-close"}):
+                pass
+
+    task = asyncio.create_task(run())
+    # give it time to register inflight
+    await asyncio.sleep(0.05)
+    wio.close()
+    await asyncio.wait_for(task, timeout=2.0)
+
+
+# ---------------------------------------------------------------------------
+# cancel()
+# ---------------------------------------------------------------------------
+
+def test_cancel_writes_cancel_json():
+    proc = _FakeProc()
+    wio = WorkerIO(proc, concurrency=1)
+    wio.cancel("rid-Z")
+    matching = [w for w in proc.stdin.writes if "cancel" in w and "rid-Z" in w]
+    assert matching, proc.stdin.writes

--- a/app/tests/test_worker_io.py
+++ b/app/tests/test_worker_io.py
@@ -168,6 +168,89 @@ async def test_async_send_request_consumer_break_fires_cancel():
 
 
 @asynctest
+async def test_async_send_request_cancel_while_awaiting_fires_cancel():
+    """Task cancellation during q.get() must also send cancel JSON to worker.
+
+    Regression: prior `cancelled_by_consumer` flag was only set inside the
+    yield, so cancellation while blocked on q.get (no event ready) would
+    leak the worker slot — worker keeps producing chunks for an abandoned
+    request. Per Codex P1 review MUST_FIX.
+    """
+    proc = _FakeProc()
+    wio = WorkerIO(proc, concurrency=1)
+
+    async def consume():
+        # Worker never feeds any event for this rid — generator stays
+        # blocked on q.get. We cancel the surrounding task externally.
+        async for _ in wio.send_request("rid-W", {"id": "rid-W"}):
+            pass
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0.05)  # let task enter q.get
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    cancel_writes = [
+        w for w in proc.stdin.writes
+        if '"type": "cancel"' in w or '"type":"cancel"' in w
+    ]
+    assert cancel_writes, f"expected a cancel write, got {proc.stdin.writes!r}"
+    assert "rid-W" in cancel_writes[-1]
+    # Semaphore must also be released.
+    assert wio._sem._value == 1, "semaphore leaked after await-cancel"
+
+
+@asynctest
+async def test_async_two_concurrent_streams_aclose_simultaneously():
+    """N=2 concurrent streams both aclose at the same time release both slots.
+
+    Models the production case where two WS clients drop mid-stream. Both
+    cancel JSONs must reach worker stdin and the semaphore must return to
+    its full count so a third request can proceed without deadlock.
+    """
+    proc = _FakeProc()
+    wio = WorkerIO(proc, concurrency=2)
+
+    # Use longer feeder delay so both generators have time to register
+    # in _inflight before chunks arrive — reader drops events for unknown
+    # rids silently (realistic behavior: worker only emits for known
+    # requests).
+    def _feeder(rid: str):
+        time.sleep(0.15)
+        proc.stdout.feed(json.dumps({"id": rid, "event": "chunk", "audio": "a"}))
+
+    gen_a = wio.send_request("rid-A", {"id": "rid-A"})
+    gen_b = wio.send_request("rid-B", {"id": "rid-B"})
+
+    # Kick off both anext concurrently so both register in _inflight
+    # before either feeder fires.
+    task_a = asyncio.create_task(gen_a.__anext__())
+    task_b = asyncio.create_task(gen_b.__anext__())
+    await asyncio.sleep(0.05)  # let both register inflight
+
+    threading.Thread(target=_feeder, args=("rid-A",), daemon=True).start()
+    threading.Thread(target=_feeder, args=("rid-B",), daemon=True).start()
+
+    first_a = await asyncio.wait_for(task_a, timeout=2.0)
+    first_b = await asyncio.wait_for(task_b, timeout=2.0)
+    assert first_a["event"] == "chunk" and first_b["event"] == "chunk"
+
+    await asyncio.gather(gen_a.aclose(), gen_b.aclose())
+
+    cancel_writes = [
+        w for w in proc.stdin.writes
+        if '"type": "cancel"' in w or '"type":"cancel"' in w
+    ]
+    cancelled_rids = {rid for rid in ("rid-A", "rid-B")
+                      if any(rid in w for w in cancel_writes)}
+    assert cancelled_rids == {"rid-A", "rid-B"}, (
+        f"expected cancel for both, got {cancel_writes!r}"
+    )
+    assert wio._sem._value == 2, "semaphore did not fully release after dual aclose"
+
+
+@asynctest
 async def test_async_send_request_worker_exit():
     proc = _FakeProc()
     wio = WorkerIO(proc, concurrency=1)

--- a/app/tests/test_worker_io.py
+++ b/app/tests/test_worker_io.py
@@ -305,6 +305,52 @@ async def test_async_cancel_during_saturated_acquire_does_not_leak_semaphore():
 
 
 @asynctest
+async def test_close_while_request_blocked_on_acquire_aborts_cleanly():
+    """close() while a request is waiting on saturated acquire must abort
+    the request with WorkerExitError, not write to dead worker stdin.
+
+    Per Codex P1 third-pass MUST_FIX: previously close() did not set a
+    closed flag, so the blocked request would wake up, register inflight,
+    and write payload JSON to a worker stdin that may already be closed.
+    """
+    proc = _FakeProc()
+    wio = WorkerIO(proc, concurrency=1)
+
+    # Saturate the only slot with a request that never completes.
+    gen_hold = wio.send_request("rid-hold", {"id": "rid-hold"})
+    task_hold = asyncio.create_task(gen_hold.__anext__())
+    await asyncio.sleep(0.05)
+
+    # Second request will block on acquire.
+    gen_wait = wio.send_request("rid-wait", {"id": "rid-wait"})
+
+    async def consume_wait():
+        with pytest.raises(WorkerExitError):
+            async for _ in gen_wait:
+                pass
+
+    task_wait = asyncio.create_task(consume_wait())
+    await asyncio.sleep(0.05)
+
+    # close() should cancel task_hold (worker_exit) AND signal task_wait
+    # to abort when its acquire wakes up.
+    wio.close()
+
+    # task_hold gets _worker_exit
+    with pytest.raises(WorkerExitError):
+        await asyncio.wait_for(task_hold, timeout=2.0)
+    # task_wait must also raise WorkerExitError (closed flag honored)
+    await asyncio.wait_for(task_wait, timeout=2.0)
+
+    # No stdin writes should reference rid-wait — closed flag must prevent
+    # the abandoned request from posting its payload.
+    rid_wait_writes = [w for w in proc.stdin.writes if "rid-wait" in w and "cancel" not in w]
+    assert not rid_wait_writes, (
+        f"closed WorkerIO still wrote payload for blocked request: {rid_wait_writes!r}"
+    )
+
+
+@asynctest
 async def test_async_send_request_worker_exit():
     proc = _FakeProc()
     wio = WorkerIO(proc, concurrency=1)

--- a/app/tests/test_worker_io.py
+++ b/app/tests/test_worker_io.py
@@ -251,6 +251,60 @@ async def test_async_two_concurrent_streams_aclose_simultaneously():
 
 
 @asynctest
+async def test_async_cancel_during_saturated_acquire_does_not_leak_semaphore():
+    """Cancellation during sem acquire (saturated) must not leak the slot.
+
+    Regression: prior code put `await loop.run_in_executor(None, sem.acquire)`
+    outside the try/finally. When N slots are saturated and a new
+    send_request awaits acquire, then is cancelled, the executor thread
+    cannot be interrupted and may eventually grab the token from a
+    coroutine that no longer exists -> permanent slot leak.
+
+    Per Codex P1 final-review MUST_FIX. Fix attaches a done-callback to
+    the acquire future that releases the late-acquired token.
+    """
+    proc = _FakeProc()
+    wio = WorkerIO(proc, concurrency=1)
+
+    # Hold the only slot with a long-running first request.
+    def _feeder_long():
+        time.sleep(0.5)
+        proc.stdout.feed(json.dumps({"id": "rid-hold", "event": "done", "ok": True}))
+
+    threading.Thread(target=_feeder_long, daemon=True).start()
+    gen1 = wio.send_request("rid-hold", {"id": "rid-hold"})
+    task1 = asyncio.create_task(gen1.__anext__())
+    await asyncio.sleep(0.05)  # let it acquire + register inflight
+    assert wio._sem._value == 0, "slot 1 should be taken"
+
+    # Second request blocks on acquire (saturated).
+    gen2 = wio.send_request("rid-wait", {"id": "rid-wait"})
+    task2 = asyncio.create_task(gen2.__anext__())
+    await asyncio.sleep(0.05)  # let it start waiting on acquire
+    task2.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task2
+
+    # Drain task1 to release its slot.
+    await asyncio.wait_for(task1, timeout=2.0)
+    try:
+        await gen1.__anext__()
+    except StopAsyncIteration:
+        pass
+
+    # Now wait for the executor thread to actually wake up + late-release.
+    # The blocked acquire() call can only return once a token becomes
+    # available, which is the moment task1's finally releases it.
+    deadline = time.time() + 2.0
+    while wio._sem._value < 1 and time.time() < deadline:
+        await asyncio.sleep(0.05)
+
+    assert wio._sem._value == 1, (
+        f"semaphore leaked after cancel-during-acquire (sem={wio._sem._value})"
+    )
+
+
+@asynctest
 async def test_async_send_request_worker_exit():
     proc = _FakeProc()
     wio = WorkerIO(proc, concurrency=1)

--- a/deploy/docker/entrypoint.jetson.sh
+++ b/deploy/docker/entrypoint.jetson.sh
@@ -26,6 +26,14 @@ if [[ -z "${OVS_PROFILE:-}" && -z "${OVS_PROFILE_JSON:-}" ]]; then
         ;;
     esac
   fi
+else
+  # When OVS_PROFILE is explicitly set (by user or OVS_PROFILE_DEFAULT),
+  # the profile is the single source of truth for LANGUAGE_MODE /
+  # ASR_BACKEND / TTS_BACKEND. Unset any image-baked or env-inherited
+  # values so profile_loader can inject the profile's intended values
+  # without tripping its CRITICAL_KEYS conflict guard (see
+  # app/core/profile_loader.py:CRITICAL_KEYS).
+  unset LANGUAGE_MODE ASR_BACKEND TTS_BACKEND
 fi
 
 exec "$@"

--- a/tests/test_tts_stream_executor_resolve.py
+++ b/tests/test_tts_stream_executor_resolve.py
@@ -94,6 +94,45 @@ def test_executor_resolves_at_init_when_backend_ready(monkeypatch):
     assert appmod._tts_stream_executor_resolved_backend is True
 
 
+def test_executor_falls_back_to_capability_when_no_env(monkeypatch):
+    """Spec §5: without env vars, executor cap aligns with backend
+    concurrency_capability so the WorkerIO semaphore and executor share
+    the same ceiling source."""
+    # Force the loaded profile to declare matcha_trt (cap default K=2).
+    monkeypatch.delenv("OVS_TTS_STREAM_MAX_WORKERS", raising=False)
+    monkeypatch.delenv("OVS_TTS_STREAM_MAX_WORKERS_MATCHA", raising=False)
+    from app.core import profile_loader
+    monkeypatch.setattr(
+        profile_loader,
+        "current_profile",
+        lambda: {
+            "tts_backend": "jetson.matcha_trt",
+            "asr_backend": "jetson.paraformer_trt",
+        },
+    )
+    _patch_tts_service(monkeypatch, is_ready=True, name="jetson.matcha_trt.fp16")
+    n, name, src = appmod._resolve_tts_stream_max_workers()
+    assert n == 2
+    assert src == "concurrency_capability"
+
+
+def test_executor_env_clamped_to_capability(monkeypatch, caplog):
+    """Spec §5: env-based override is clamped to the backend ceiling."""
+    monkeypatch.setenv("OVS_TTS_STREAM_MAX_WORKERS_MATCHA", "16")
+    from app.core import profile_loader
+    monkeypatch.setattr(
+        profile_loader,
+        "current_profile",
+        lambda: {
+            "tts_backend": "jetson.matcha_trt",
+            "asr_backend": "jetson.paraformer_trt",
+        },
+    )
+    _patch_tts_service(monkeypatch, is_ready=True, name="jetson.matcha_trt.fp16")
+    n, _, _ = appmod._resolve_tts_stream_max_workers()
+    assert n == 2, f"expected clamp to backend ceiling 2, got {n}"
+
+
 def test_executor_no_change_when_global_equals_backend_specific(monkeypatch):
     """Refresh path picks correct value even when values match — no
     spurious replacement, but flag flips so subsequent calls skip the


### PR DESCRIPTION
## Summary

Establishes a typed concurrency-capability declaration on every ASR/TTS backend and wires it into the framework's scheduling layer (session limiter, coordinator, TTS stream executor). Surfaces existing N≥2-safe work (matcha/kokoro/paraformer pool refactors) so orin-nano session ceiling can move from 1 → 2.

**Spec:** [`docs/specs/concurrency-capability-framework.md`](docs/specs/concurrency-capability-framework.md) (v4, codex-reviewed)

## Changes

### P0 — Capability declaration (5 commits)
- `app/core/concurrency_capability.py` — `ConcurrencyCapability` dataclass (frozen, `default()` conservative)
- `ASRBackend` / `TTSBackend` ABCs gain `concurrency_capability(profile) -> ConcurrencyCapability` classmethod (default N=1)
- Capability declarations on N≥2-safe Jetson backends:
  - `trt_edge_llm_tts`: `OVS_TTS_WORKER_CONCURRENCY` (single_runtime_multiplex)
  - `matcha_trt` / `kokoro_trt`: pool size K (single_runtime_multiplex)
  - `paraformer_trt`: `max_concurrent=None` (multi_runtime_per_slot)

### P1 — Wiring (10 commits)
- **`app/core/worker_io.py`** — extracted `WorkerIO` from `trt_edge_llm_tts.py` (commit 4403d60) plus async `send_request()` API per spec §5 (b0749f5). Sync `request()` shim retained — TTS callers run inside `tts_stream_executor` ThreadPoolExecutor; converting them async would cascade into the WS pipeline and risk regressing `4668e64` (multi-turn) and `5eb67e9` (N=2). Both APIs share `_inflight` / `_stdin_lock` / `_sem`.
- **`session_limiter`** — aggregates `min(asr.max_concurrent, tts.max_concurrent)` with `None`=+∞; profile/env may only downgrade (warn+clamp on upgrade attempt). `_TARGET_DEFAULTS` kept as fallback for undeclared backends.
- **`coordinator`** — `serialized` mode now triggered by `supports_parallel=False`, not `requires_exclusive_device` (the latter is now strictly "cross-backend mutex").
- **`tts_stream_executor`** — `max_workers` reads from capability instead of independent env path (closes `c704589` drift risk).
- **CPU + RK backend capability declarations** — prevents desktop session ceiling regression from 4 → 1 after limiter switch.

### Race / lifecycle fixes (4 commits, all from codex review)
- `eb467f6` — `send cancel JSON on any non-natural exit` (await-cancel, timeout, worker exit all now notify worker)
- `c0754b7` — `release late-acquired semaphore on cancel-during-acquire` (saturated-pool cancel no longer leaks slot)
- `b6dc47a` — `close() flag + sync acquire-leak + callback BaseException` (3 fixes)
- `920a7b3` — `close TOCTOU between _closed fast-path and stdin write`

## Behavior changes

| Target | Before (target-default) | After (capability-aggregated) |
| --- | --- | --- |
| **orin-nano** | 1 | **2** (matcha/kokoro N=2 verified at backend layer in `5eb67e9`) |
| orin-nx | 2 | 2 |
| desktop | 4 | 4 (explicit CPU N=4 declaration) |
| RK | 1 | 1 |

Profiles can still write `max_concurrent_sessions: 1` to force downgrade — passes through clamp path with warning log.

## Test plan

- [x] Unit: 67/67 PASS across `test_concurrency_capability` (25), `test_worker_io` (14), `test_session_limiter` (12), `test_coordinator` (10), `test_tts_stream_executor_resolve` (6)
- [x] Regression: 33 fail before / 31 fail after — all pre-existing Mac issues, no new failures (verified by stash+rerun)
- [ ] **Real-device orin-nano smoke** (`bench/perf/load_2client_tts.py` — N=2, CUDA error 0, audio MD5 byte-identical) — **deferred**: orin-nano is a deployed snapshot without a voice stack running; needs new Jetson image build via normal release flow. Backend-layer N=2 stability already verified at `5eb67e9`. P1 only exposes the existing ceiling, no new race introduced. Codex-reviewed deferral conditional on 2 mock-replay tests now landed (`test_async_send_request_cancel_while_awaiting_fires_cancel`, `test_async_two_concurrent_streams_aclose_simultaneously`, `test_close_while_request_blocked_on_acquire_aborts_cleanly`).

## Codex review

5 review passes, 6 MUST_FIX identified and resolved:
1. async cancel-while-awaiting → missing cancel JSON
2. cancel-during-saturated-acquire → late-acquired semaphore leak
3. close() missing flag → writes to dead worker after close
4. sync `request()` acquire outside try/finally
5. late-acquire callback caught only `Exception`, missing `CancelledError`
6. TOCTOU between `_closed` fast-path and stdin write

Final pass: **READY_TO_MERGE**. One benign NIT remaining (cancel() doesn't check `_closed`; failure swallowed) — left as follow-up.

## Follow-ups (out of scope for this PR)

- `cancel()` should check `_closed` to avoid silent write attempt to dead worker
- `executor / limiter / coordinator` each parse capability independently — abstract into single `capability_resolver` helper when adding 4th caller (rule-of-three)
- `trt_edge_llm_tts.py` comments still reference old `_WorkerIO` name (prose only)
- `_WorkerIO` module-level alias kept; remove after one release cycle
- ASR worker not migrated to `WorkerIO` (spec §5 says deferred — interface ready, no actual ASR N>1 change in this PR)
- P2: VRAM budget framework (`vram_mb_per_slot` is metadata-only in this PR)
- Real-device orin-nano N=2 smoke after Jetson image rebuilt + deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)