### PR TITLE
fix(provision): honor QWEN3_ARTIFACT_SET (completes #11 for highperf slim)

### DIFF
--- a/server/core/qwen3_artifact_downloader.py
+++ b/server/core/qwen3_artifact_downloader.py
@@ -61,6 +61,18 @@ def _detect_artifact_set(profile: str, manifest: dict) -> str | None:
     ``profile`` is the ``OVS_PROFILE`` name (e.g. ``jetson-qwen3asr-matcha-nx``).
     Returns ``None`` if no set matches (caller should log + skip download).
     """
+    sets = manifest.get("artifact_sets", {})
+
+    # Explicit override wins. Profiles set ``QWEN3_ARTIFACT_SET`` to the exact
+    # set (model_downloader uses the same env, deploy_paths defaults to it), so
+    # honor it before the profile-name family heuristic. The heuristic cannot
+    # disambiguate device-agnostic profile names like ``jetson-multilang-highperf``
+    # (no "nx"/"nano") and would otherwise return None → "auto-download skipped",
+    # leaving the talker engine unfetched on a slim first boot.
+    explicit = os.environ.get("QWEN3_ARTIFACT_SET")
+    if explicit and explicit in sets:
+        return explicit
+
     name = profile.lower()
     if "nx" in name:
         family = "orin-nx"


### PR DESCRIPTION
Second half of the orin-nano highperf customvoice-on-slim fix. `_detect_artifact_set` only mapped a profile→HF-set via a 'nx'/'nano' name heuristic; the device-agnostic `jetson-multilang-highperf` profile matched neither → auto-download skipped → talker engine never fetched (so #11's symlink was dead code on that path). Profiles already set `QWEN3_ARTIFACT_SET` to the exact set — honor it first. Verified: with this + #11, the highperf CustomVoice talker engine downloads + symlinks + TTS preloads (readyz 200) on orin-nano.

🤖 Generated with [Claude Code](https://claude.com/claude-code)