### PR TITLE
docs(v080): consolidation plan + verified N>1 benchmarks + N=2 deploy runbook + README N>1

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,146 @@
+# Benchmarks
+
+Measured performance for the v0.8.0 (TensorRT-Edge-LLM) voice stack, with a
+focus on **concurrent (N>1) sessions** and **zero-regression vs the v0.7.1
+baseline**. Every row names the device, date, and the gate that produced it so
+the numbers can be reproduced.
+
+> Single source of truth: `docs/plans/voxedge-v080-consolidation/benchmarks-dataset.md`
+> (with per-row `file` provenance + `repro` metadata). This file is the
+> outward-facing view of the N>1 / v0.8.0 subset of that dataset.
+
+For the broader cross-device matrix (RTF, TTFA, CER/WER across Jetson / Rockchip
+/ Raspberry Pi), see the [Performance section of the README](README.md#performance).
+
+---
+
+## v0.8.0 N>1 concurrency (verified 2026-06-21)
+
+All N=2 numbers come from real on-device burst tests gated on a **byte-identical
+audio/transcript** check (concurrent output == solo output) and **zero CUDA /
+race errors**. "N=2 verified" is the validated concurrency ceiling; N>2 is
+untested on every device.
+
+### ASR — N=2 streaming (Jetson Orin NX, gate v080-0023)
+
+| Metric | Value | Notes |
+|---|---|---|
+| Streaming partials → final | 9 partials → 1 final | single-session, full streaming path |
+| CER (streaming final) | **0.105** | offline-decode on the same clip is ~0.05 |
+| N=2 concurrent zh/en isolation | **no cross-talk** | two simultaneous sessions, one zh + one en |
+| Session admission (5 concurrent) | 2 admitted, 3 rejected `too_many_sessions` (4429) | `OVS_MAX_CONCURRENT_SESSIONS=2` enforced |
+| CUDA errors | **0** | through-service gate (not bare worker) |
+
+Device: Jetson Orin NX · Date: 2026-06-21 · Gate: **v080-0023** (through-service
+ASR N=2 streaming).
+Source: `~/project/edgellm-v080-migration/docs/plans/v080-0023-*.md` + task records.
+
+### TTS — N=2 slot-pool, int4 talker (Jetson Orin Nano, staggered gate)
+
+Production TTS concurrency is a **slot-pool** (independent lanes, staggered-friendly,
+same model as the ASR `SessionLaneManager`), not a lockstep batch-lane.
+
+| Gate | Result |
+|---|---|
+| **G1** staggered (B not blocked by in-flight A) | PASS |
+| **G2** byte-identical (concurrent output == solo) | PASS |
+| **G3** session admission (4429 over the limit) | PASS |
+
+| Resource | Value |
+|---|---|
+| System RAM at N=2 | **~4 GB** (tegrastats peak 5718 / 7620 MB; baseline 1703 MB) |
+| Worker RSS | 908 MB |
+| OOM | none — fits 8 GB and 16 GB Orin Nano |
+| int4 talker engine | **245.9 MB** vs **903 MB** fp16 (−73%) |
+
+Device: Jetson Orin Nano · Date: 2026-06-21 · Gate: TTS N=2 slot-pool int4
+staggered (G1/G2/G3).
+
+### TTS — N=2 shared-engine (Jetson Orin Nano, VRAM-saving)
+
+The shared-engine constructor lets the 2nd slot reuse the resident weights, so
+only context/KV (not a second copy of the weights) is added.
+
+| Metric | Value |
+|---|---|
+| N=1 peak | 3805 MB |
+| N=2 peak | 5385 MB |
+| 2nd slot cost | **+1.6 GB** (context/KV only, not quadratic weights) |
+| vs two independent instances | **~436 MB saved** |
+| byte-identical (concurrent == solo) | PASS — slot A `154f7880`, slot B `1a5324be` |
+| CUDA errors | **0** |
+
+Device: Jetson Orin Nano · Date: 2026-06-21 · Gate: TTS N=2 shared-engine.
+
+### TTS — M5 spike (Jetson Orin NX, phase 5b)
+
+| Check | Result |
+|---|---|
+| concurrent == solo (RVQ hash) | byte-exact |
+| audio md5 | byte-exact |
+| CUDA errors | 0 |
+
+Device: Jetson Orin NX · Date: 2026-06-21 · Gate: phase 5b M5 spike.
+
+---
+
+## v0.8.0 vs v0.7.1 baseline — zero regression (Jetson Orin NX)
+
+ASR `--check` regression gate against the v0.7.1 golden set:
+
+| Metric | Value |
+|---|---|
+| Overall | **17 / 20 PASS** |
+| English + clean Chinese | **all pass** |
+| Improvements over v0.7.1 golden | several clips better, e.g. `zh_long_01` CER **0.080 → 0.043** |
+| The 3 FAIL clips | high-baseline-CER clips where the abs-tolerance gate is brittle (hard-clip), **not a regression** |
+
+Device: Jetson Orin NX · Date: 2026-06-21 · Baseline:
+`bench/regression/baselines/v080-c2-before-20260621/`
+(artifacts live in `~/project/edgellm-v080-migration`).
+
+---
+
+## int4 vs fp16 talker (Qwen3-TTS 0.6B Base)
+
+| Precision | Talker engine size |
+|---|---|
+| fp16 | 903 MB |
+| int4-AWQ + fp8 | **245.9 MB** (−73%) |
+
+int4 is byte-stable and recommended by default for Orin Nano (fits 8 GB with
+N=2). fp16 stays available for accuracy-sensitive comparison. See the
+`repro` block in the source dataset for the full build recipe.
+
+---
+
+## Reproduction artifacts (2026-06-21)
+
+| Artifact | Anchor / hash |
+|---|---|
+| fork release tip | `port/qwen3-tts-base-v080-n1n2` @ `7142a30` |
+| rebake image | `seeed-local-voice:v0.8.0-n1n2-rebake` |
+| ASR worker | `5ebd436b` |
+| TTS shared-engine worker | `190178f6` |
+| int4 talker engine | HF `harvestsu/qwen3-tts-0.6b-base-jetson-trtllm-int4fp8` |
+| asr-b2 engine | `4122dfcc` (HF) |
+| talker-b2 engine | `f7339e02` |
+
+---
+
+## Methodology
+
+- **N=x verified** = real on-device burst test + MD5 audio gate + zero CUDA/race.
+  N=2 covers both the TTS talker batch-lane / slot-pool and the ASR streaming
+  slot-pool.
+- **ASR latency** = finalize (audio-end → final), VAD 400 ms wait excluded
+  (constant, overlaps decode). CER/WER use greedy decode (top_k=1, temp=0) +
+  force_language scaffold, replicating the production decode contract.
+- **TTS latency** = TTFA (warm: prefill + first chunk). RTF = wall-clock /
+  audio duration. The N=2 slow-client TTFA penalty (1.4–5×) is memory-bandwidth
+  bound, not a bug.
+- **Deployment scope:** these gates ran on `orin-nx` / `orin-nano` profiling
+  devices. The `seeed-orin-nx` production robot-arm stack was **not** touched.
+
+See [`docs/deploy-v080-n1n2.md`](docs/deploy-v080-n1n2.md) for the matching
+deployment runbook.

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Kokoro RKNN TTS.
 - **Reusable edge voice library** — the backends ship as the standalone, pip-installable [`voxedge`](https://github.com/suharvest/voxedge) package (`pip install --pre voxedge`); this repo is the product server + deploy on top of it.
 - **Stable backend contract** — clients keep the same `/asr/stream`, `/tts`, `/tts/stream`, and `/health` calls when profiles change.
 - **Measured low latency** — 58 ms EOS-to-first-audio on Jetson Orin NX with Paraformer + Matcha; 157 ms with Qwen3 ASR/TTS voice clone.
+- **Concurrent N=2 on v0.8.0** — verified 2-session ASR streaming (zh/en, no cross-talk) and N=2 Qwen3-TTS Base (int4 talker, ~4 GB RAM; or shared-engine with only +1.6 GB for the 2nd slot). See [BENCHMARKS.md](BENCHMARKS.md).
 - **Multilingual options** — Chinese+English, English-only, and 52-language Qwen3 paths are exposed through the same service.
 - **Container-first deploy** — prebuilt images, target-specific compose files, host checks, model downloads, and verification scripts are included.
 - **LLM-ready agent layer** — `agent/` streams ASR results into an OpenAI-compatible or EdgeLLM backend, then streams LLM tokens directly back to TTS.
@@ -374,6 +375,30 @@ Qwen3 ASR + Matcha split when low-latency concurrent dialogue matters. Full raw
 JSON paths and methodology are in
 [`docs/benchmarks/streaming-release-gate-2026-05-18.md`](docs/benchmarks/streaming-release-gate-2026-05-18.md).
 
+### v0.8.0 Concurrency (N>1) — verified 2026-06-21
+
+The TensorRT-Edge-LLM v0.8.0 stack adds **validated 2-session concurrency** on
+Jetson, with a byte-identical audio/transcript gate (concurrent output ==
+solo output) and zero CUDA/race errors. N=2 is the validated ceiling.
+
+- **ASR N=2 streaming** (Orin NX, gate v080-0023) — two concurrent sessions
+  (e.g. one Chinese + one English) with no cross-talk; a 3rd concurrent session
+  is rejected with `4429 too_many_sessions`. Streaming final CER 0.105 (offline
+  ~0.05 on the same clip); 0 CUDA errors.
+- **TTS N=2, int4 talker** (Orin Nano) — slot-pool concurrency (independent,
+  staggered-friendly lanes). ~4 GB system RAM at N=2 (fits 8 GB and 16 GB), no
+  OOM. int4-AWQ+fp8 talker engine is **245.9 MB vs 903 MB fp16 (−73%)**.
+- **TTS N=2, shared-engine** (Orin Nano) — the 2nd slot reuses resident weights,
+  so it adds **only +1.6 GB** (context/KV, not a 2nd weight copy) — ~436 MB
+  saved vs two independent instances. Concurrent output byte-identical to solo.
+- **Zero regression vs v0.7.1** (Orin NX) — ASR `--check` 17/20 PASS; English and
+  clean Chinese all pass, several clips improved (e.g. `zh_long_01` CER
+  0.080 → 0.043). The 3 FAILs are abs-tolerance gate brittleness on high-baseline
+  hard-clip clips, not a regression.
+
+Full tables, gates, and reproduction artifacts are in [BENCHMARKS.md](BENCHMARKS.md);
+the deployment runbook is [docs/deploy-v080-n1n2.md](docs/deploy-v080-n1n2.md).
+
 ### TTS Model Comparison
 
 The current release uses Matcha/Vocos for the bilingual path, Kokoro for
@@ -555,7 +580,41 @@ The **per-engine ASR/TTS backends live in the sibling [`voxedge`](https://github
 
 Clone with `--recurse-submodules` to pull `third_party/*`, or run `git submodule update --init --recursive` after cloning.
 
+### Unified backend structure (self-serve reproduce & publish)
+
+Every backend — Jetson (TensorRT-Edge-LLM), Rockchip (RKNN), and Raspberry Pi
+(sherpa-onnx) — follows the **same layout**, so any one of them can be
+reproduced, rebuilt, and published without insider knowledge:
+
+| Per-backend asset | Purpose |
+|---|---|
+| `recipes/` | the engine/model build + export steps (pin the upstream commit, run the export API) |
+| `HF_ARTIFACTS` | the published Hugging Face bundles end users pull (e.g. `harvestsu/qwen3-tts-0.6b-base-jetson-trtllm-int4fp8`) |
+| `docs/` (runbook) | deploy + verify steps for that backend (e.g. [docs/deploy-v080-n1n2.md](docs/deploy-v080-n1n2.md)) |
+| `AGENTS` | the agent/dispatch guardrails for working on that backend |
+
+Jetson, RK, and RPi are **first-class peers** — none is the "main" backend, and
+the same `recipes → HF_ARTIFACTS → docs → AGENTS` contract holds for each, so
+anyone can self-serve a reproduction or a release.
+
+> **DIVERGENCE — fork vs self-authored runtime.** The one structural difference
+> is the *source* of the runtime: the Jetson backend's runtime extensions live
+> in our **fork of TensorRT-Edge-LLM** (upstream-bug fixes + local runtime
+> extensions land in the fork; `jetson-voice-engine` only carries overlay /
+> recipes and regenerates patches from it). The RK and RPi runtimes are
+> **self-authored** (`rkvoice-stream`, patched sherpa-onnx). This is a deliberate
+> ownership boundary, not an inconsistency — every backend still exposes the same
+> recipes/artifacts/docs/agents surface above.
+
 ## Changelog
+
+### 2026-06 — v0.8.0 N>1 concurrency verified
+
+- **N=2 ASR streaming + N=2 Qwen3-TTS Base verified on Jetson** (2026-06-21).
+  Byte-identical concurrent==solo gate, 0 CUDA errors. int4 talker 245.9 MB
+  (−73% vs fp16); shared-engine 2nd slot only +1.6 GB. Zero regression vs v0.7.1
+  (ASR 17/20, several clips improved). See [BENCHMARKS.md](BENCHMARKS.md) and the
+  [deploy runbook](docs/deploy-v080-n1n2.md).
 
 ### 2026-06 — Open source & edge voice library split
 

--- a/docs/deploy-v080-n1n2.md
+++ b/docs/deploy-v080-n1n2.md
@@ -1,0 +1,169 @@
+# Deploy: v0.8.0 N=2 (Qwen3-TTS Base + streaming ASR)
+
+Runbook for deploying the **v0.8.0 N>1** voice stack (concurrent ASR streaming +
+concurrent Qwen3-TTS Base) on a Jetson Orin Nano / NX **profiling** device.
+
+> ⚠️ **Do NOT deploy this to `seeed-orin-nx`** (the production robot-arm stack)
+> or to the shared production `speech-models` volume. These instructions target
+> the `orin-nano` / `orin-nx` profiling devices only, using an isolated engine
+> volume. The N=2 gates in [`../BENCHMARKS.md`](../BENCHMARKS.md) were run this way.
+
+Verified 2026-06-21. Image `seeed-local-voice:v0.8.0-n1n2-rebake`. See
+[`../BENCHMARKS.md`](../BENCHMARKS.md) for the measured numbers and gates.
+
+---
+
+## 1. What you get
+
+- **ASR N=2 streaming** — two concurrent sessions (e.g. one zh + one en) with no
+  cross-talk; a 3rd concurrent session is rejected with `4429 too_many_sessions`.
+- **TTS N=2** — slot-pool concurrency (independent, staggered-friendly lanes).
+  Two variants:
+  - **int4 talker** (default for Orin Nano): 245.9 MB talker, ~4 GB system RAM at
+    N=2, fits 8 GB and 16 GB.
+  - **shared-engine**: 2nd slot adds only +1.6 GB (context/KV, not a 2nd weight
+    copy) — saves ~436 MB vs two independent instances.
+
+---
+
+## 2. Prerequisites
+
+- Jetson Orin Nano (8 GB or 16 GB) or Orin NX, JetPack with CUDA 12.6.
+- Docker with the NVIDIA runtime (`--gpus all` / `--runtime nvidia`).
+- Clocks locked to max (run once after boot):
+  ```bash
+  sudo ./scripts/setup-performance.sh   # MAXN power mode + locked clocks
+  ```
+- An **isolated** engine directory on the host, e.g. `/opt/edgellm-v080/engines`
+  (never the production `speech-models` volume).
+
+---
+
+## 3. Pull the image
+
+```bash
+docker pull seeed-local-voice:v0.8.0-n1n2-rebake
+```
+
+This image bundles the v0.8.0 workers + the `libNvInfer_edgellm_plugin.so`
+plugin. Reproduction anchors (see BENCHMARKS):
+
+| Artifact | Hash |
+|---|---|
+| fork tip | `port/qwen3-tts-base-v080-n1n2` @ `7142a30` |
+| ASR worker | `5ebd436b` |
+| TTS shared-engine worker | `190178f6` |
+
+---
+
+## 4. Get the engines
+
+Two options.
+
+### Option A — pull prebuilt engines from Hugging Face (recommended)
+
+```bash
+# int4+fp8 Base talker bundle (recommended on Orin Nano)
+hf download harvestsu/qwen3-tts-0.6b-base-jetson-trtllm-int4fp8 \
+  --local-dir /opt/edgellm-v080/engines/qwen3-tts-base
+
+# int4 ASR engine
+hf download harvestsu/qwen3-asr-0.6b-int4-v080 \
+  --local-dir /opt/edgellm-v080/engines/qwen3-asr
+```
+
+Engine hashes to expect: int4 talker (`harvestsu/...base...int4fp8`),
+asr-b2 `4122dfcc`, talker-b2 `f7339e02`.
+
+### Option B — mount engines built on-device
+
+If you built engines on the device (`ENABLE_CUTE_DSL=OFF`, KV capped at
+`maxKVCacheCapacity=1536` so N=2 fits 8 GB), mount their directory at
+`/opt/models/qwen3-tts-base/engines` in the run command below.
+
+---
+
+## 5. Profile: `jetson-edgellm-v080-n2`
+
+This profile is the N=1 `jetson-edgellm-v080-qwen3ttsbase` profile with the
+**session-gate triple** flipped so N=2 works out of the box:
+
+| Env key | N=1 | **N=2** | Meaning |
+|---|---|---|---|
+| `LAZY_TTS` | (unset) | **`1`** | lazy-load the TTS worker so both slots warm independently |
+| `OVS_TTS_WORKER_CONCURRENCY` | `1` | **`2`** | second TTS slot-pool lane |
+| `OVS_MAX_CONCURRENT_SESSIONS` | `1` | **`2`** | admit 2 sessions; 3rd → `4429 too_many_sessions` |
+
+Everything else (engine paths, plugin path, ASR worker config) is inherited from
+`jetson-edgellm-v080-qwen3ttsbase`. Keep `EDGE_LLM_ASR_MAX_CONCURRENT=2` so the
+ASR streaming slot-pool also admits 2.
+
+### int4 vs shared-engine
+
+- **int4 talker** (default): point `EDGE_LLM_TTS_TALKER_DIR` at the int4+fp8
+  talker engine (245.9 MB). Lowest RAM; recommended for 8 GB Orin Nano.
+- **shared-engine**: use the shared-engine worker (`190178f6`) so the 2nd slot
+  reuses resident weights (+1.6 GB instead of a full 2nd copy). Use this when you
+  want fp16 quality at N=2 on a 16 GB device, or to minimise the marginal cost of
+  the 2nd lane.
+
+---
+
+## 6. `docker run` example (N=2 out of the box)
+
+```bash
+docker run -d --name seeed-voice-v080-n2 \
+  --runtime nvidia --gpus all \
+  -p 8621:8000 \
+  -e OVS_PROFILE=jetson-edgellm-v080-n2 \
+  -e LAZY_TTS=1 \
+  -e OVS_TTS_WORKER_CONCURRENCY=2 \
+  -e OVS_MAX_CONCURRENT_SESSIONS=2 \
+  -e EDGE_LLM_ASR_MAX_CONCURRENT=2 \
+  -e HF_ENDPOINT=https://hf-mirror.com \
+  -v /opt/edgellm-v080/engines:/opt/models \
+  seeed-local-voice:v0.8.0-n1n2-rebake
+```
+
+Notes:
+- `-v .../engines:/opt/models` uses an **isolated** host directory — never the
+  production `speech-models` volume.
+- Drop `HF_ENDPOINT` if you have direct Hugging Face access; some images are not
+  compatible with the mirror endpoint.
+- This is a `docker run` (not `compose`) on purpose, matching the C7 / baseline
+  run command — `compose up` can drift the image tag.
+
+---
+
+## 7. Verify
+
+```bash
+# Health
+curl -s http://127.0.0.1:8621/health
+
+# Two concurrent ASR streams should both transcribe; a 3rd should get 4429.
+# Two concurrent TTS requests should each return audio (slot-pool, staggered).
+docker logs seeed-voice-v080-n2 2>&1 | grep -iE 'error|crash|fail|too_many_sessions'
+```
+
+Expected: 2 sessions admitted, the 3rd `4429 too_many_sessions`, **0** CUDA
+errors, and concurrent audio byte-identical to solo (the N=2 gate criterion).
+
+---
+
+## 8. Rollback
+
+Stop the N=2 container and start the prior N=1 profile:
+
+```bash
+docker stop seeed-voice-v080-n2 && docker rm seeed-voice-v080-n2
+# then re-run with OVS_PROFILE=jetson-edgellm-v080-qwen3ttsbase (N=1 defaults)
+```
+
+---
+
+## Scope reminder
+
+These steps run on `orin-nano` / `orin-nx` profiling devices with an isolated
+engine volume. **The `seeed-orin-nx` production robot-arm stack is not part of
+this runbook and must not be redeployed here.**

--- a/docs/plans/voxedge-v080-consolidation/INDEX.md
+++ b/docs/plans/voxedge-v080-consolidation/INDEX.md
@@ -1,0 +1,84 @@
+# VoxEdge v0.8.0 整合 — 执行入口 (INDEX)
+
+> 给**执行者**的总入口。本目录是 VoxEdge 边缘语音栈统一到 TensorRT-Edge-LLM **v0.8.0** + 开源传播的完整规划。
+> 经 3 轮 codex 独立审核 + 真机实证 + 多 agent 调研收敛。最后更新 **2026-06-21**。
+
+---
+
+## 0. 怎么读(顺序)
+
+| # | 文档 | 作用 | 谁先读 |
+|---|---|---|---|
+| 1 | **本 INDEX** | 状态 / 决策 / 环境 / 从哪开始 | 所有人 |
+| 2 | [consolidation-plan.md](consolidation-plan.md) | 主计划:现状图 A、目标架构 B(+B.1 五仓)、工作流 C0–C7 / D / E / F(测试 gate)/ G(清理)/ H(回归策略)+ dispatch 护栏 | 执行者必读 |
+| 3 | [c0-patch-ownership-manifest.md](c0-patch-ownership-manifest.md) | **迁移 day-1 依据**:20 项 runtime/patch 归属(C1/C2/C3)+ 双写风险 + 源vs封装边界 | 动 fork/jve 前必读 |
+| 4 | [benchmarks-dataset.md](benchmarks-dataset.md) | 性能/能力唯一真相(表A性能 + 表B最佳实践 + GAPS + repro 元数据) | 写 README/BENCHMARKS 前 |
+| 5 | [positioning-and-propagation.md](positioning-and-propagation.md) | 对外定位/分层/传播/license 矩阵 | 做发布/文档时 |
+| 6 | [competitor-research.md](competitor-research.md) | 10 个同类开源项目传播复盘 | 做发布时 |
+| 7 | [code-structure/](code-structure/) | 五仓 AST 结构分析(在正确分支 @ ref 上做的) | 需要代码定位时 |
+
+**角色分工(沿用 CTO/spec/executor 三段式):** 主线程定 spec 边界 + 串联 + 自验关键数字;codex 出设计/审核(只读带 file:line);general-purpose 照 spec 实施(build/deploy/test)。**执行体 prompt 必带护栏**(见 plan「DISPATCH NOTES」+ 「Preflight 防误触」)。
+
+---
+
+## 1. 当前状态(2026-06-21)
+
+### ✅ 已完成(执行者不要重做)
+- **数据丢失隐患全清零:**
+  - `tensorrt-edge-llm`(小写副本)的 4 个生产关键 commit(SlotPool 抽取 / ASR-assistant prefix / N-instance slot-pool worker / shared-engine ctor)→ 已 push 到 `suharvest/v071/customvoice-product`(FF `1668470..893ba2a`)。
+  - int4 export driver 分支:`wip/native-int4-talker`(ff2318e)+ `wip/asr-int4-decoder`(c80bcc0)**都在 suharvest fork**;未提交 working 文件(`quantize_talker_stage1_bigcalib.py` + `cv-int4-derisk/*`)已拉回 Mac。
+- **全仓本地备份**:`~/project-backups/20260621-133543/`(6.6GB,97 bundle 含全部未推送 + 35 diff + untracked 内容 + 本规划文档 + wsl2-recovered/ 的 int4 drivers)。
+- **stateful code2wav × N=2** 真机+源码定论:flag 是 no-op(没接线,非不安全),收益增量,**backlog**(详见 benchmarks-dataset GAPS#10 + c0 manifest W2 旁注)。
+- **模型 license 调研完成**(见 positioning §六 license 矩阵)。
+- 规划经 3 轮 codex 审 + must-fix 全闭合。
+
+### ⏳ 待执行(本计划的工作流,尚未开工)
+- C0 manifest 已产出(本目录);**C1–C7 / D / E / F / G / H 全部待执行**。
+- 两个外部确认:核 MOSS-TTS-Nano 仓库根 LICENSE 文件是否落地 Apache 全文;(CV license 已定=跟随 Qwen 官方不改)。
+
+---
+
+## 2. 决策记录(都已拍板,执行者按此办,勿再议)
+
+| 决策 | 结论 | 依据 |
+|---|---|---|
+| 最终仓库结构 | 3 层 **5 职责单元 / 6 物理仓**(RK=2 仓算 1 后端);对外只一个品牌 VoxEdge | plan B.1 |
+| fork vs jetson-voice-engine | 三类变更模型:C1 上游bug + C2 本地runtime扩展 → **源在 fork**;C3 overlay/recipes → jve。**任何 runtime 改动只在 fork 落地,jve patch 自动生成** | plan B.1 / c0 manifest |
+| int4/fp8 export drivers 归属 | **`jetson-voice-engine/recipes/`**(不放 fork),pin fork commit,只调 fork export API | plan C6 / c0 |
+| CustomVoice | **一等公民**(用户定):走 int4,移植 P5 9-row 条件到 v0.8.0,**DROP W1 w8a16**(EOS 破不可行);过 F4+F5-CV 后可进默认 | plan C1b/B / c0 §4 |
+| stateful code2wav N>1 | **backlog**(没接线,收益增量,RTF 已<1 性价比低) | benchmarks GAPS#10 |
+| 默认精度翻转 | **C1 只加 opt-in,C1b 才翻默认**,且挂 F-gate 全绿;CustomVoice 默认前过 F4+F5-CV | plan C1/C1b |
+| 开源 license | 主体 Apache/MIT 可开+商用;**NLLB=CC-BY-NC 剥成可选非商用**;FunASR(Paraformer/SenseVoice)需署名+附协议;**CV 跟随 Qwen 官方不加料**;MOSS 待核 LICENSE | positioning §六 |
+| N≤0 prefill guard | **尚未落地**(分支里只有 empty-fullText LOG_ERROR),需新写并提交 fork(C1) | plan C3(a) / c0 §4 |
+| stateful 等性能优化定性 | B2(M=1 GEMV)/A2(streaming worker)= C2(我们路线,可日后 PR) | c0 §4 |
+| qwen3asr_rk | 外部库(非我们),**移出整合范围,不删不并** | plan G |
+
+---
+
+## 3. 环境与访问(执行者必须遵守)
+
+### 设备(用 fleet,完整路径见下)
+- **可用(profiling,可 stop/测)**:`orin-nano`(v0.8.0 build 树 `~/project/edgellm-v080-build`,ENABLE_CUTE_DSL=OFF)、`orin-nx`、`wsl2-local`(RTX,有 modelopt,做 int4/fp8 导出;flap-prone,跑长任务先 mask 定时器+tmux)。
+- **🚫 绝对不碰**:`seeed-orin-nx`(生产机械臂栈)+ 生产 `speech-models` 卷。测试一律用隔离卷 `~/comp-e2e-models`。
+- Fleet 全路径(子 shell alias 不生效):`uv run --project ~/project/_hub python ~/project/_hub/fleet.py`。**flags(--sudo/--timeout/--json)放设备名之前**;`--sudo` 用于 apt/systemctl/docker/写 $HOME 外。坑:zsh 里别把 fleet 路径塞进带空格的变量(词分裂)。
+
+### fork remote(git push 高危,看清楚)
+- fork 工作区里 **`origin` = NVIDIA 官方仓**!推到我们 fork 必须用 **`suharvest`**(或 `origin-claude`,同 URL)。**绝不 `git push origin`**。
+- canonical fork = `https://github.com/suharvest/TensorRT-Edge-LLM.git`。v0.8.0 主分支 `port/qwen3-tts-base-v080`;int4 drivers `wip/native-int4-talker` + `wip/asr-int4-decoder`;CV/v071 在 `v071/customvoice-product`。
+
+### HF 预编译产物(终端用户消费的东西)
+`harvestsu/qwen3-asr-0.6b-int4-v080`、`harvestsu/qwen3-tts-0.6b-base-jetson-trtllm-int4fp8`、`harvestsu/qwen3-tts-0.6b-customvoice-jetson-trtllm-int4fp8`。
+
+### 备份与已恢复资产
+- 全仓备份:`~/project-backups/20260621-133543/`(bundles/ + uncommitted/ + untracked-content/ + scratch/ + planning-docs/ + wsl2-recovered/)。
+- 恢复方式见该目录 `MANIFEST.txt`。
+
+---
+
+## 4. 从哪开始(day-1,无破坏性)
+
+1. **建 C0 patch 清单的可执行版**:照 [c0-patch-ownership-manifest.md](c0-patch-ownership-manifest.md),逐个 v0.7.1 patch 对 v0.8.0 base 跑 `git apply --check`,确认哪些已被上游吸收(归零)、哪些需保留。
+2. **C6 收尾(recovery 已做)**:把已恢复的 int4 drivers 落进 `jetson-voice-engine/recipes/`,写 recipes README + pin fork commit。
+3. 之后按 plan 执行顺序:**C(统一 v0.8.0)→ D(一键部署)→ E(README/BENCHMARKS/Recipes)**,每步过对应 F-gate(H 节回归策略是硬约束:F 是各 workstream 的 exit-criteria,不是收尾)。
+
+**所有 build/deploy/test 派发必带**:EVIDENCE 段(md5 + 原始验证输出 + before/after + `docker logs|grep -iE error|crash|fail`)、Fleet 规则块、Preflight 防误触、禁破坏性操作(见 plan「DISPATCH NOTES」)。

--- a/docs/plans/voxedge-v080-consolidation/INDEX.md
+++ b/docs/plans/voxedge-v080-consolidation/INDEX.md
@@ -12,6 +12,7 @@
 | 1 | **本 INDEX** | 状态 / 决策 / 环境 / 从哪开始 | 所有人 |
 | 2 | [consolidation-plan.md](consolidation-plan.md) | 主计划:现状图 A、目标架构 B(+B.1 五仓)、工作流 C0–C7 / D / E / F(测试 gate)/ G(清理)/ H(回归策略)+ dispatch 护栏 | 执行者必读 |
 | 3 | [c0-patch-ownership-manifest.md](c0-patch-ownership-manifest.md) | **迁移 day-1 依据**:20 项 runtime/patch 归属(C1/C2/C3)+ 双写风险 + 源vs封装边界 | 动 fork/jve 前必读 |
+| 3b | [c2-repin-spec.md](c2-repin-spec.md) | **C2 可执行 spec**(codex 设计,带 file:line):逐 patch 处置 + 重生成命令 + md5 验收点 + prefix-multiturn 不可复现新发现 | 做 C2 时必读 |
 | 4 | [benchmarks-dataset.md](benchmarks-dataset.md) | 性能/能力唯一真相(表A性能 + 表B最佳实践 + GAPS + repro 元数据) | 写 README/BENCHMARKS 前 |
 | 5 | [positioning-and-propagation.md](positioning-and-propagation.md) | 对外定位/分层/传播/license 矩阵 | 做发布/文档时 |
 | 6 | [competitor-research.md](competitor-research.md) | 10 个同类开源项目传播复盘 | 做发布时 |
@@ -23,12 +24,29 @@
 
 ## 1. 当前状态(2026-06-21)
 
+### 🔑 重大状态修正(2026-06-21,执行中发现)
+> 本节 INDEX 原写「C1–H 全未开始」**已过时**。两轮只读侦察查清:**v0.8.0 迁移其实已在 `jetson-voice-engine` 的 `feat/edgellm-v080-migration` 分支(已 push,31 commits)做了约 80%** 并留完整验收链(到 v080-0026)+ 自带回归 harness。已落地且 orin-nx 实机验收过(2026-06-10):ASR streaming Phase1-5、CustomVoice 9-row(feat 3e0bb0b)、MOSS port(8e0dcf0)、TTS N=2 batch-lane(9002b04=maxBatchSize=2)、full ASR→LLM→TTS pipeline、**real serve gate PASS**、一键 compose。
+>
+> **但有三大真实缺口(=真正剩余工作的核心):**
+> 1. **C2 未做**:`engine-overlay/UPSTREAM_PIN` 至今仍 v0.7.1(连迁移分支也没改);feat 分支的 v0.8.0 工件是**绕过 overlay** 直接 build 的。C2=把 overlay 机制正式对齐 v0.8.0(见 [c2-repin-spec.md](c2-repin-spec.md)),是合并 main 的前置。
+> 2. **C3 未做**:fork 无 ASR worker 唯一源;N≤0 guard 从未落地(仅 LOG_ERROR)。
+> 3. **prefix-multiturn/N>1 streaming 路径不可复现**:依赖未发布的 `asr-b2` 引擎 → 当前可复现/可合并的 v0.8.0 = plain `asr`+accumulate(已发 HF + serve-gate 验证)。详见 c2-repin-spec §7。
+>
+> **执行策略(verify-first,零衰退):** 先在 orin-nx 用分支自带 harness(`~/project/seeed-local-voice/bench/regression/run_v080_regression.py` + goldens `v071-edgellm`)固化 canonical v0.8.0(plain asr+accumulate)为基线 → 再 C2 re-pin → 每改一处对基线复跑 harness + md5 对账(vs v080-0017 HF manifest)证明零衰退。RK 不在这条 Jetson 链(分支 Jetson-only)。
+
 ### ✅ 已完成(执行者不要重做)
+- **N>1 能力全实机验证(2026-06-21):** ASR N=2+streaming through-service gate PASS(orin-nx);TTS N=2 slot-pool int4 staggered gate PASS(orin-nano,~4GB fits 8G/16G);TTS N=2 shared-engine gate PASS(orin-nano,2nd slot +1.6GB 省~436MB)。fork 整合分支 `suharvest/port/qwen3-tts-base-v080-n1n2`(a361221)=Base+streaming worker+shared-engine。jve `feat/c2-repin-v080`(4a0b837)pin 指它,build.sh 编 shared worker。worker:c00a0752(独立)/190178f6(shared)。引擎:asr-b2 4122dfcc(HF)、talker-b2 f7339e02(已存 orin-nx)、int4 talker(HF base int4fp8 245.9MB)。
 - **数据丢失隐患全清零:**
   - `tensorrt-edge-llm`(小写副本)的 4 个生产关键 commit(SlotPool 抽取 / ASR-assistant prefix / N-instance slot-pool worker / shared-engine ctor)→ 已 push 到 `suharvest/v071/customvoice-product`(FF `1668470..893ba2a`)。
   - int4 export driver 分支:`wip/native-int4-talker`(ff2318e)+ `wip/asr-int4-decoder`(c80bcc0)**都在 suharvest fork**;未提交 working 文件(`quantize_talker_stage1_bigcalib.py` + `cv-int4-derisk/*`)已拉回 Mac。
 - **全仓本地备份**:`~/project-backups/20260621-133543/`(6.6GB,97 bundle 含全部未推送 + 35 diff + untracked 内容 + 本规划文档 + wsl2-recovered/ 的 int4 drivers)。
 - **stateful code2wav × N=2** 真机+源码定论:flag 是 no-op(没接线,非不安全),收益增量,**backlog**(详见 benchmarks-dataset GAPS#10 + c0 manifest W2 旁注)。
+- **E(README/BENCHMARKS/runbook 对外文档)= DONE(2026-06-21):** 用已验 N>1 数字落地对外文档 ——
+  - `BENCHMARKS.md`(repo 根,新建):v0.8.0 N>1 表(ASR N=2 streaming gate v080-0023、TTS N=2 int4 slot-pool + shared-engine VRAM、零衰退、int4 vs fp16 talker),每行带设备/日期/gate。
+  - `README.md`:加 Performance「v0.8.0 Concurrency (N>1)」段 + Key Features + Changelog 条目 + **统一后端结构**说明(recipes/HF_ARTIFACTS/docs/AGENTS 各后端平起,fork vs self-authored 已 DIVERGENCE 说明)。
+  - `docs/deploy-v080-n1n2.md`(新建,D 折入):拉镜像 `v0.8.0-n1n2-rebake` + 引擎(HF / 挂载隔离卷)+ profile `jetson-edgellm-v080-n2`(session-gate 三件套 LAZY_TTS=1 + OVS_TTS_WORKER_CONCURRENCY=2 + OVS_MAX_CONCURRENT_SESSIONS=2)+ `docker run` 示例 + int4/shared-engine 选用。明确**不部署 seeed-orin-nx 生产**。
+  - `benchmarks-dataset.md`:GAPS#1/#3(N=2 int4 待 gate)关闭 + 表 A 补 N=2 实测;详见该文件「v0.8.0 N>1 实测(2026-06-21)」段。
+  - 注:C7(镜像 bake)/D(compose 实改)/RK 链仍按各自 workstream 推进,本轮只交付 E 文档(纯 Mac,不 build/部署)。
 - **模型 license 调研完成**(见 positioning §六 license 矩阵)。
 - 规划经 3 轮 codex 审 + must-fix 全闭合。
 
@@ -42,6 +60,11 @@
 
 | 决策 | 结论 | 依据 |
 |---|---|---|
+| **迁移范围(2026-06-21)** | **含 N>1/streaming**(用户定):不止最小可复现 generic 路径,要把并发(N=2 ASR + maxBatchSize=2 TTS)+ 流式(prefix-rollback)纳入本次迁移并产线化。后果:**必须重建丢失的 asr-b2 引擎 + 发布到 HF(补可复现缺口) + 重证 maxBatchSize=2 共享 Talker 并发安全(F5) + 复活 C2a-cont 暂 drop 的 streaming 栈**。 | 用户 AskUserQuestion |
+| **shipped vs R&D 真相(2026-06-21)** | 已发布 v0.8.0(v080-0017 manifest)= 最小 generic 路径(base f9cc746 + v080-0007 customvoice + v080-0008 cutedsl + generic workers);N>1/streaming 当年是 R&D、未进 shipped 二进制、asr-b2 引擎已丢失。本次迁移要把 R&D 提升为产线。 | C2a-cont(v080-0016/0017/0019 + Dockerfile 实证) |
+| **Base vs CustomVoice 拆变体(2026-06-21)** | customvoice 9-row langId 与 Base speaker-encoder kernel 在 talker prefill 冲突(8-row vs 9-row,不能同一二进制)→**Base 与 CV 是两个 build 变体**。本次合 **Base TTS N>1**(已验证);**CV 作独立一等变体**(同 slot-pool/shared-engine N>1 worker + CV int4 引擎 + v080-0007 patch + 独立 build,后续)。 | 用户 AskUserQuestion |
+| **TTS N=2 = slot-pool(非 batch-lane)(2026-06-21)** | 生产走 slot-pool(独立 lane,staggered 友好,与 ASR SessionLaneManager 一致);batch-lane(lockstep,短等长)不做。shared-engine ctor 已实现(权重共享~1×)。 | 用户问 staggered + 实测 |
+| **shared-engine ctor(2026-06-21)** | 净新实现(commit a361221,v071 无有效版);N=2 2nd slot 仅 +1.6GB(context/KV 非二次权重),vs 独立省~436MB/slot。整合进 fork 分支 port/qwen3-tts-base-v080-n1n2。 | orin-nano gate 实测 |
 | 最终仓库结构 | 3 层 **5 职责单元 / 6 物理仓**(RK=2 仓算 1 后端);对外只一个品牌 VoxEdge | plan B.1 |
 | fork vs jetson-voice-engine | 三类变更模型:C1 上游bug + C2 本地runtime扩展 → **源在 fork**;C3 overlay/recipes → jve。**任何 runtime 改动只在 fork 落地,jve patch 自动生成** | plan B.1 / c0 manifest |
 | int4/fp8 export drivers 归属 | **`jetson-voice-engine/recipes/`**(不放 fork),pin fork commit,只调 fork export API | plan C6 / c0 |

--- a/docs/plans/voxedge-v080-consolidation/benchmarks-dataset.md
+++ b/docs/plans/voxedge-v080-consolidation/benchmarks-dataset.md
@@ -1,0 +1,123 @@
+# VoxEdge — 性能 & 能力数据集(single source of truth)
+
+> 这是把散落在 memory/specs/leaf 里的所有量化指标汇成的**唯一权威数据集**,带 `file` 出处。
+> 用途:渲染对外的 `BENCHMARKS.md`(全量矩阵)、Landing hero 数字、Recipes 选择器。
+> 扫描出处:`/Users/harvest/.claude/projects/.../memory/*.md` + `docs/specs/` + `configs/leaves`。
+> 口径见文末「方法论」。`—` = 该数尚未测(见 GAPS)。
+
+---
+
+## 表 A — 性能矩阵(设备 × 后端 × 模型 × 精度)
+
+| 设备 | 芯片 | 后端 | 模型 | 精度 | RTF | TTFA/TTFT | VRAM/引擎大小 | 准确率(CER/WER) | N(已验并发) | 出处 |
+|---|---|---|---|---|---|---|---|---|---|---|
+| Jetson Orin **Nano** | SM_87 | TRT-EdgeLLM | Qwen3-TTS-0.6B-Base | fp16 | 0.69 | 0.54s(warm) | talker 907MB;全链 ~1.3GB;N=2 需 5.6GB free | 可懂(ASR验) | **2**(fp16 实测 burst) | qwen3tts_base_v080_port |
+| Jetson Orin **Nano** | SM_87 | TRT-EdgeLLM | Qwen3-TTS-0.6B-Base | int4-AWQ+fp8 | **0.44** | **0.21s**(warm) | talker **245MB**;整体 −1.06GB/实例 | ZH CER 1.7% / EN WER 0% | 1(int4+fp8 **N=2 待 gate**,见 GAPS) | qwen3tts_base_v080_port |
+| Jetson Orin Nano | SM_87 | TRT-EdgeLLM | Qwen3-TTS-0.6B-CustomVoice ⚠️experimental | int4+fp8 | —(无记录,待 streaming-worker 实测) | — | talker 246MB;−960MB/实例 | 可懂(ASR smoke,CN+EN) | — | customvoice_talker_int4_eos_fail |
+| Jetson Orin NX | SM_87 | TRT-EdgeLLM | Qwen3-ASR-0.6B | int4-AWQ | — | finalize 68–125ms | LLM 550MB;encoder fp16 381MB | **ZH CER 0% / EN WER 11%**(单词声学近音;**裸 llm_inference 契约验,未过 production worker**) | —(int4 N≥2 **无记录**) | qwen3asr_int4_validation |
+| Jetson Orin NX | SM_87 | TRT-EdgeLLM | Qwen3.5-4B-AWQ | GDN+MTP | — | TTFT 2.28→**0.60s**(prefix-cache 3.8×) | 3.87GB 引擎 | bench 100%(p50 1.16s) | 1+ | qwen35_mtp_migration_prefix_cache |
+| Jetson Orin NX | SM_87 | TRT | MOSS-TTS-Nano | FP32 | — | **157ms**(19× vs ORT) | — | CER 0(3 prompt) | ≥1 | moss_tts_nano_trt |
+| Jetson Orin Nano | SM_87 | TRT | MOSS-TTS-Nano | FP32 | — | 290ms(N=1) | 5.53GB peak / 7.4GB 总 | CER 0 | **2**(30/30 byte-identical) | moss_tts_nano_trt / capability_framework_orin_nano |
+| Jetson Orin Nano | SM_87 | Matcha-TTS | Matcha | — | — | N=2 slow-client TTFA 1.4–2.2× | — | md5 byte-identical | 2 | tts_n2_phase_b_stability / capability_framework_orin_nano |
+| RK3588 | RK3588 NPU | RKNN | Kokoro(4-stage hybrid) | INT8/FP16 | **0.59**(HTTP) | bucket-8 0.79s / 16 1.62s / 32 3.1s | 41MB vocoder-front + 26MB tail(CPU) | — | 1 | kokoro_rk_perf_closure |
+| RK3588 | RK3588 NPU | RKNN | Paraformer hybrid + Matcha | — | — | — | — | — | — | leaf_config_refactor(注册项) |
+| RK3588 | RK3588 NPU | RKNN | Qwen3-RKNN-ASR | w8a8 | — | — | — | — | — | leaf_config_refactor(注册项) |
+| RK3576 | RK3576 NPU | RKNN | Paraformer(full-encoder) | fp16 | — | — | — | ⛔ NaN/Inf(block31 溢出,NOT VIABLE) | — | leaf_config_refactor |
+| RK3576 | RK3576 NPU | RKNN | Paraformer(hybrid, block30 split) | — | — | — | — | — | — | leaf_config_refactor |
+| Raspberry Pi 4/5 | Cortex-A | sherpa-onnx | Paraformer / SenseVoice | FP32(CPU) | — | — | — | — | ≥1 | sensevoice_offline_3platform |
+| Mac | CPU | sherpa-onnx | Paraformer / SenseVoice | FP32(CPU) | — | — | — | — | ≥1 | sensevoice_offline_3platform |
+| (任意 Jetson) | SM_87 | TRT-EdgeLLM | Qwen3-ASR v0.8.0 streaming | fp16 | — | decode 68–125ms/hop;长音频 10.4s→3.2s(6.1×) | — | CER 0.0000–0.025(final 0.0) | — | asr_incremental_kv_12 |
+
+---
+
+## 表 B — 最佳实践 / 能力矩阵(用例 × 推荐栈)
+
+| 用例 | 推荐设备 | ASR | TTS | LLM | 特殊能力 | 出处 |
+|---|---|---|---|---|---|---|
+| 实时本地语音对话(双语低延迟) | Orin NX | Paraformer(TRT)/ Qwen3-ASR(prefix) | Matcha(TRT 轻量) | Qwen3.5-4B-AWQ GDN+MTP(0.60s TTFT) | 双语自动识别、prefix-cache 3.8×、工具循环 | qwen35_mtp / qwen3asr_int4 |
+| 高质量多语 TTS(表现力语音) | Orin Nano/NX | Qwen3-ASR int4 | **Qwen3-TTS 0.6B Base**(int4+fp8;N=2 fp16 已验,int4+fp8 N=2 待 gate) | — | 零样本音色(speaker-encoder 预算嵌入)、int4 talker 245MB | qwen3tts_base_v080_port |
+| 语音克隆 / 自定义音色 | Orin NX | Qwen3-ASR | **Qwen3-TTS CustomVoice**(int4+fp8) | — | 9 内置说话人 + 自定义音色,−960MB/实例 | customvoice_talker_int4 |
+| 超轻量语音(预算边缘) | RPi 4/5 | Paraformer(sherpa CPU) | MOSS-TTS-Nano(ORT)/ Matcha(sherpa) | — | 纯 CPU ONNX,无需 GPU | sensevoice_offline_3platform |
+| NPU 加速多语(RK) | RK3588 | Paraformer hybrid / Qwen3-RKNN(w8a8) | **Kokoro**(4-stage hybrid,RTF 0.59) | — | NPU 加速 TTS、misaki ZH G2P、3-bucket 动态路由 | kokoro_rk_perf_closure |
+| 机械臂 / server-loop(工具调用) | Orin NX | Qwen3-ASR(streaming,CER 0%) | Matcha(N=1)/ Qwen3-TTS base talker(N=2 fp16 已验) | Qwen3.5-4B-AWQ(server-loop) | server-loop(LLM+工具在服务端,agent 执行)、voice_arm | qwen35_mtp / qwen3tts_base_v080_port |
+| 纯 ASR | 任意 Jetson/RK/RPi | Qwen3-ASR(TRT/RKNN/sherpa) | — | — | 增量 KV(长音 6.1×)、回滚最终 byte-exact、prefix-cache | asr_incremental_kv_12 |
+| 纯 TTS | Orin Nano | — | MOSS-TTS-Nano(TRT)/ Kokoro | — | MOSS N=2 8GB byte-identical | moss_tts_nano_trt |
+| 双语 ASR(中英) | Orin NX / RK3588 | Qwen3-ASR(auto detect) | — | — | force_language scaffold(贪婪解码 prime)、流式 partial+final | qwen3asr_int4_validation |
+| 标点 + 声纹(opt-in) | Orin NX | Qwen3-ASR | Matcha | — | CT-Transformer 标点 + CAM++ 声纹,关闭时零开销 | ovs_punct_speaker_capabilities |
+| 实时翻译 / 字幕 | Orin NX | Qwen3-ASR | (字幕路线不切 TTS) | NLLB(CT2,14–35× CPU) | live_caption / simul_interpret 双 app | nllb_translator_slim_cuda_jetson |
+
+---
+
+## GAPS(尚无数据,需补测)
+
+1. **Qwen3-TTS Base int4+fp8 N=2** — 只有 fp16 阶段做过 N=2 burst+5.6GB free 验证;int4+fp8 的 N=2 burst/MD5 gate **未单独跑**(对应 plan F5)。
+2. **Qwen3-ASR int4 过 production worker + N≥2** — 现仅裸 `llm_inference` 生产解码契约验证(CER 0% / WER 11%);未过真实 `qwen3_asr_worker` streaming 路径,也无 int4 N≥2 记录(对应 plan F2/F3)。
+3. **Qwen3-TTS CustomVoice int4 全链 perf** — 仅 ASR smoke 可懂 + talker 246MB;**无 RTF/TTFA 记录**,未过 streaming worker(对应 plan F4)。⚠️ experimental,不进默认/hero。
+4. **Jetson AGX Orin** — 整套 VRAM/N 上限全 TBD(leaf 注册标 TBD-measure)。
+5. **Orin Nano + LLM 同驻** — 真实显存争用场景未测。
+6. **Qwen3-TTS W8A16** — CustomVoice 确认不可行(EOS 破);base W8A16 从未成功(prior "success" = 反序列化失败的假阳性)。
+7. **SenseVoice RK/Jetson** — 只做了 RPi Phase1 适配,RTF/TTFA 未测。
+8. **RK3576 Kokoro / Qwen3-ASR(w4a16g128)** — 待启动,无可行性证据。
+9. **N>2 并发** — 任何设备都没测(N=2 是已验上限)。
+10. **stateful code2wav v0.8.0 — 已实机+源码定论(2026-06-21)。根因 = "没接线"(非"不安全")。** worker 里 `StatefulCode2WavRunner` 只被 `#include` + 作为 unused 形参传入,**从未实例化**;slot-pool 每 slot 只构造 stateless `Code2WavRunner`,flag 仅进 `ready` 元数据 → 实测 N=2 下 =1/=0 输出逐字节相同(md5 `cccc41a6…`,两 slot rc=0)。**hazard 澄清**:历史 concurrent-reset 崩溃只存在于"共享单实例",stateful runner 状态全实例私有(`reset` 只 memset 自己缓冲)→ **per-slot 各自独立 stateful 实例原理上安全**。**收益**:stateful 省掉 stateless 每 chunk 25 帧左上下文重算(Code2Wav 总耗时 ~81-87ms,export gate max_abs 5e-6),但 Talker/CP 生成才是延迟主项 → 收益**增量非量变**,只在 chunk 显著变小/超长流式时才显著。**结论:backlog**(当前 RTF<1 性价比低;要启用约 7 项小改,最大风险 = ConvTranspose 相位对齐 click)。真实 env 名 = `EDGE_LLM_TTS_STATEFUL_CODE2WAV`。详见 manifest W2。
+11. **35 leaf 组合 × 设备 的逐组合真机 e2e** — 仅 62 单测绿,无逐组合真机端到端。
+
+---
+
+## 方法论(口径,对外文档要附)
+
+- **ASR 延迟** = finalize(audio-end→final),不含 VAD 400ms 等待(常量,与 decode 重叠)。CER/WER 用贪婪(top_k=1, temp=0)+ force_language scaffold,复刻生产解码契约(top_k=50 采样是 harness bug)。
+- **TTS 延迟** = TTFA(warm,prefill+首 chunk)。RTF = wall-clock / 音频时长。N=2 slow-client TTFA 1.4–5× 惩罚是 memory-bandwidth-bound,非 bug。
+- **N=x verified** = 真机 burst 压测 + MD5 音频门 + 零 CUDA/race。N=2 同时覆盖 TTS talker batch-lane 与 ASR streaming slot-pool。
+- **prefix-cache TTFT** 2.28→0.60s 仅在 Qwen3.5-4B-AWQ GDN+MTP 实测,收益 per-model/per-prompt。
+
+### repro 元数据(对外 hero/README 数字的硬门槛 + 已填明细)
+
+规则:任何要进 Landing hero / README / Show HN 的数字,**必须**附下列 `repro` 块,否则不可对外。下面已为**当前 hero-eligible 行**逐行填好;非 hero 行标 `repro: pending`。
+
+**① Qwen3-TTS Base int4+fp8 — RTF 0.44 / TTFA 0.21s(hero-eligible,N=1)**
+```yaml
+repro:
+  metric: {RTF: 0.44, TTFA_s: 0.21, scope: N=1}   # N=2 待 F5,不在此 hero
+  device: jetson-orin-nano-8gb
+  chip: sm_87
+  power: {nvpmodel: MAXN_SUPER, jetson_clocks: locked}
+  build: {ENABLE_CUTE_DSL: OFF, kv: {maxInputLen: 1024, maxKVCacheCapacity: 1536}}
+  engines: {talker: int4-AWQ 245MB, code_predictor: int4-AWQ, text_embedding: fp8-e4m3 320MB, code2wav: fp16}
+  plugin_md5: 7d3fabe                # NvInfer_edgellm_plugin
+  worker_md5: 6bc2d7db               # qwen3_tts_streaming_worker(precision-agnostic;须 build 时复核)
+  profile: jetson-edgellm-v080-qwen3ttsbase
+  hf_bundle: harvestsu/qwen3-tts-0.6b-base-jetson-trtllm-int4fp8
+  input: precomputed speaker_embedding_b64;~12词中/英句
+  sampling: {temp: ref-embedding, note: "不可降 talker_temperature(EOS runaway)"}
+  accuracy_check: faster-whisper round-trip(NOT Groq=key过期);CER opencc t2s-normalize 后计
+  source: qwen3tts_base_v080_port_2026_06_19.md
+```
+
+**② MOSS-TTS-Nano — N=2 byte-identical / TTFA 157ms(hero-eligible)**
+```yaml
+repro:
+  metric: {TTFA_ms: 157(orin-nx) / 290(orin-nano N=1), N2: "30/30 byte-identical", peak_mb: 5530}
+  device: jetson-orin-nano-8gb / orin-nx
+  fork_commit: 3c6c263
+  profile: jetson-moss-tts-nano-trt
+  gate: MD5 音频门 + 零 CUDA/race
+  source: moss_tts_nano_trt_production_ready.md
+```
+
+**③ Qwen3-ASR int4 — ZH CER 0% / EN WER 11%(条件 hero:须注明"裸解码契约,未过 production worker")**
+```yaml
+repro:
+  metric: {ZH_CER: "0%", EN_WER: "~11%(1 acoustic word)", scope: "llm_inference 解码契约;F2b worker+N=2 PENDING"}
+  device: jetson-orin-nano
+  decode: {temp: 0, top_k: 1, top_p: 1, prime: "language <Lang><asr_text>", chat_template: applied}
+  engine: int4-AWQ LLM ~525MB + audio-encoder fp16(minchunk1 build)
+  clip_set: 6-clip(opencc t2s-normalized)
+  hf_bundle: harvestsu/qwen3-asr-0.6b-int4-v080
+  spec_commit: 1fce82e
+  source: qwen3asr_int4_validation_forcelanguage_2026_06_20.md
+```
+
+**未填(repro: pending,不得对外):** CustomVoice int4(experimental)、Kokoro RK、Matcha、Qwen3.5-4B GDN+MTP、所有 GAPS 行。
+
+→ **后续落地**:把本数据集转机器可读 YAML(每行带上述 `repro` 块),markdown 由脚本生成,CI 校验 README/HF/leaf 引用的 benchmark id 存在(plan E 节"single-source→多视图"的真正形态)。当前手写 markdown 为过渡,但 hero 行的 repro 已先行填齐。

--- a/docs/plans/voxedge-v080-consolidation/benchmarks-dataset.md
+++ b/docs/plans/voxedge-v080-consolidation/benchmarks-dataset.md
@@ -48,9 +48,27 @@
 
 ---
 
+## 表 C — v0.8.0 N>1 实测(2026-06-21,全部真机 + byte-identical gate + 0 CUDA)
+
+> 这是本轮迁移把「R&D 并发/流式」提升为产线后跑出的实测。N=2 = 已验上限。
+> 工件锚点:fork tip `port/qwen3-tts-base-v080-n1n2` @ `7142a30`;镜像 `seeed-local-voice:v0.8.0-n1n2-rebake`;
+> workers asr `5ebd436b` / tts shared `190178f6`;引擎 int4 talker(HF base int4fp8 245.9MB)/ asr-b2 `4122dfcc` / talker-b2 `f7339e02`。
+
+| 维度 | 设备 | gate | 结果 | 出处 |
+|---|---|---|---|---|
+| **ASR N=2 streaming** | Orin NX | v080-0023(through-service) | 单会话 9 partials→final CER **0.105**(offline 同 clip ~0.05);N=2 zh/en 隔离无串话;5 并发→2 进 3 拒 `4429 too_many_sessions`;**0 CUDA** | edgellm-v080-migration/docs/plans/v080-0023-* + 任务记录 |
+| **TTS N=2 int4 slot-pool** | Orin Nano | staggered(G1/G2/G3) | G1 staggered(B 不被 A 阻塞)/ G2 byte-identical(concurrent==solo)/ G3 4429 全 PASS;系统 RAM ~**4GB**(tegrastats peak 5718/7620,baseline 1703);worker RSS 908MB;无 OOM,fits 8G/16G;int4 talker **245.9MB** vs fp16 **903MB**(−73%) | 任务记录(staggered gate) |
+| **TTS N=2 shared-engine** | Orin Nano | shared-engine gate | N=1 peak 3805MB→N=2 **5385MB**,2nd slot 仅 **+1.6GB**(context/KV 非二次权重),vs 独立省 **~436MB**;byte-identical(A `154f7880` / B `1a5324be` concurrent==solo);**0 CUDA** | 任务记录 / INDEX §2 shared-engine ctor |
+| **TTS M5 spike** | Orin NX | phase5b | concurrent==solo RVQ hash byte-exact + audio md5 byte-exact + **0 CUDA** | 任务记录(phase5b M5) |
+| **v0.8.0 vs v0.7.1 baseline** | Orin NX | ASR `--check` | **17/20 PASS**;英文+干净中文全过;多条优于 golden(zh_long_01 0.080→0.043);3 FAIL = 高基线 CER 硬 clip 的 abs-tolerance gate 脆性(非衰退) | seeed-local-voice/bench/regression/baselines/v080-c2-before-20260621/(工件在 ~/project/edgellm-v080-migration) |
+
+对外视图:repo 根 `BENCHMARKS.md`(本表的外向子集)+ runbook `docs/deploy-v080-n1n2.md`。
+
+---
+
 ## GAPS(尚无数据,需补测)
 
-1. **Qwen3-TTS Base int4+fp8 N=2** — 只有 fp16 阶段做过 N=2 burst+5.6GB free 验证;int4+fp8 的 N=2 burst/MD5 gate **未单独跑**(对应 plan F5)。
+1. ~~**Qwen3-TTS Base int4+fp8 N=2**~~ — ✅ **CLOSED 2026-06-21**:int4 slot-pool N=2 staggered gate(G1/G2/G3)全 PASS,~4GB RAM fits 8G/16G;另有 shared-engine N=2(+1.6GB/省 436MB)byte-identical。见**表 C**。
 2. **Qwen3-ASR int4 过 production worker + N≥2** — 现仅裸 `llm_inference` 生产解码契约验证(CER 0% / WER 11%);未过真实 `qwen3_asr_worker` streaming 路径,也无 int4 N≥2 记录(对应 plan F2/F3)。
 3. **Qwen3-TTS CustomVoice int4 全链 perf** — 仅 ASR smoke 可懂 + talker 246MB;**无 RTF/TTFA 记录**,未过 streaming worker(对应 plan F4)。⚠️ experimental,不进默认/hero。
 4. **Jetson AGX Orin** — 整套 VRAM/N 上限全 TBD(leaf 注册标 TBD-measure)。

--- a/docs/plans/voxedge-v080-consolidation/c0-patch-ownership-manifest.md
+++ b/docs/plans/voxedge-v080-consolidation/c0-patch-ownership-manifest.md
@@ -1,0 +1,63 @@
+# C0 — Patch Ownership Manifest (v0.8.0 整合)
+
+> 整合计划 `consolidation-plan.md` workstream **C0** 的交付物。
+> 三类模型:C1 上游bug(源=fork,可上游,合并归零)/ C2 本地runtime扩展(源=fork,长期维护)/ C3 overlay·编排·recipes(源=jve)。
+> 原则:**任何 C++/CUDA runtime 改动的"源"都在 fork;jve overlay patch 是从 fork 自动生成的"封装",不是第二份手写源。**
+
+## 0. 最重要的总体判定(先读)
+
+- **jve 当前 pin 在 v0.7.1**(`UPSTREAM_PIN=364769…`=NVIDIA v0.7.1,`fork_branch=v071/customvoice-product`,90 commits ahead),**不是 v0.8.0**。
+- 目标 = fork `port/qwen3-tts-base-v080`(相对 `origin/release/0.8.0` 仅 **6 commit / 9 文件**)。
+- **本质:re-pin 到 v0.8.0 + 删除冗余封装,而非把 v0.7.1 的 8 个 patch 照搬过去。** v0.7.1 时代多数 patch 在 v0.8.0 base 已原生。
+- **int4 native kernels/plugin = 上游 v0.8.0 原生**;我们的 int4 工作只剩 **export drivers(C3)**,不需要任何 native int4 overlay。
+
+## 1. 归属清单主表
+
+| # | 改动 | owner | class | source (file) | packaging (jve) | 可上游 | removal cond | gate | engines | 证据 |
+|---|---|---|---|---|---|---|---|---|---|---|
+| A1 | Base speaker-encoder(external-embedding)移植 v0.8.0 | fork | C2 | `qwen3OmniTTSRuntime.{cpp,h}` | re-gen from port | 否 | 长期 | F-TTS e2e | tts-base | `ba9ecdb` |
+| A2 | streaming worker(base,N>1 slot-pool)移植 v0.8.0 | fork | C2 | `examples/omni/qwen3_tts_streaming_worker.cpp`+`slotPool.h`(md5 `fe7c0736`) | jve addon copy **md5 `0038bbd6`=v0.7.1 过期** | 否 | 长期 | F-N2 | tts-base | `10b338d` |
+| A3 | cutedsl cudart shim link 进 omni exes | fork | C1 | `examples/omni/CMakeLists.txt` | 0001 对应 hunk | 是 | 上游→删 | F-build | all sm_87 | `867b74d` |
+| B1 | **cuBLAS-free tiled FP16 GEMM fallback** | fork | **C1** | `talkerMLPKernels.cu:278-490` | N/A | **是**(上游 #else 仅 LOG_ERROR,平台正确性补全) | 上游→归零 | F-build+TTS | tts sm_87 | `26a4a69` |
+| B2 | M=1 warp-per-column GEMV | fork | C2 | `talkerMLPKernels.cu:330-401` | N/A | 偏否(可 PR) | 长期 | F-perf | tts sm_87 | `50b8670` |
+| B3 | **fp8 text_embedding wiring**(5 lookup 点) | fork | **C2** | `qwen3OmniTTSRuntime.cpp:172-199,753,1067,1988,1998,2172` | N/A | 否 | 长期 | F-TTS+VRAM | tts-base | `873ca22` |
+| B4 | fp8 embedding **export driver** | fork | **C3** | `scripts/quantize_text_embedding_fp8.py` | ⚠️ jve 异名 `scripts/quantize_embedding_safetensors_fp8.py`(§3 双写) | recipe | 随 model 重导 | F-export | tts-base | `873ca22` |
+| B5 | export.py 放开 non-CustomVoice(Base 导出) | fork | C3 | `tensorrt_edgellm/scripts/export.py:1665+` | recipe | 是 | 上游→删 | F-export | tts-base | port diff |
+| C-int4-rt | int4 native kernels/plugin | **上游原生** | — | `cpp/kernels/int4GroupwiseGemmKernels/*`,`plugins/int4{GroupwiseGemm,Moe}Plugin/*` | N/A | — | 不归我们 | — | all | base ls-tree |
+| C-int4-drv | int4 talker/CP 量化 **export drivers** | fork `wip/native-int4-talker` | **C3** | `quantize_talker_stage1.py`/`stage2_export.py`/`quantize_cp_stage1.py`/`cp_stage2_export.py` | **应迁 jve recipes** | recipe | 随 model 重导 | F8 | tts int4 | `ff2318e` |
+| D1 | **ASR stripLangTag 英文首词修复** | seeed(源)→**应回 fork** | **C1** | `seeed/deploy/asr-worker-v080/qwen3_asr_worker.cpp`(md5 `13b34dc`)+`.patch` | jve `native/.../qwen3_asr_worker.cpp`(异代 md5 `7885f2e`) | 是(纯字符串清洗 bug) | 落回 fork+上游→归零 | F-ASR | asr | seeed README+patch |
+| P1 | 0001 orin-tegra-build-compat | jve | C1+C2 混 | fork CMake | `patches/0001` | 部分 | hunk 拆 | F-build | all | DIVERGENCE |
+| P2 | 0002 weight-streaming-budget | jve | C1+C2 混 | fork builderUtils/llmRuntimeUtils | `patches/0002` | budget→PR;shared-engine ctor 留 | hunk 拆 | F-build+rt | all | DIVERGENCE |
+| P3 | 0003 asr-streaming-session | jve | C2 | fork audioRunner/specDecodeRuntime | `patches/0003` | 否 | 长期 | F-ASR | asr | DIVERGENCE |
+| P4 | 0004 tts-slotpool-concurrency | jve | C2 | fork qwen3OmniTTSRuntime+slotPool | `patches/0004` | 否(N=2 护城河) | 长期 | F-N2 | tts | DIVERGENCE |
+| P5 | 0005 customvoice-language-conditioning(9-row) | jve→**源回 fork** | C2 | fork talkerMLPKernels(9-row prefix) | `patches/0005`(re-gen) | 否 | **用户定 CV=一等公民 → 必须移植到 v0.8.0**;长期维护 | F4 + F5-CV | tts-CV | DIVERGENCE |
+| P6 | 0006 server-sse-disconnect + openai-api | jve | C1+C2 混 | fork api_server.py/engine.py | `patches/0006` | SSE-fix→PR(**禁止自动提交**);tool-call 留 | hunk 拆 | F-server | server | `0898b5f` |
+| P7 | 0007 server-openai-api-docs | jve | C3(doc) | fork docs | `patches/0007` | 是 | 随 P6 上游 | doc | — | DIVERGENCE |
+| P8 | 0008 build-misc-example-registration | jve | C3 | fork CMake 注册 | `patches/0008` | 否 | 长期 | F-build | all | DIVERGENCE |
+| W1 | w8a16 quant kernel+plugin(v0.7.1) | jve | C2 | jve addon `w8A16LinearKernels/*`,`w8A16LinearPlugin/*` | addon | 否 | **DROP:CV w8a16 已确认不可行(EOS 破),不进 v0.8.0;CV 走 int4 而非 w8a16** | — | tts W8A16 | DIVERGENCE |
+| W2 | MOSS runtime / stateful code2wav(v0.7.1) | jve | C2 | jve addon `mossTtsNanoRuntime.*`,`statefulCode2WavRunner.*` | addon | 否 | 长期 | — | moss-tts | addon ls + N=2 实测 md5 `cccc41a6` |
+
+> **W2 旁注 — stateful code2wav × N>1(2026-06-21 调研 closed,backlog):** 当前 N>1 不走 stateful 的根因是 **"没接线"**(`StatefulCode2WavRunner` 在 worker 里只 `#include`+unused 形参,从未实例化;slot-pool 每 slot 只构造 stateless `Code2WavRunner`;flag 仅进 ready 元数据)。**不是安全墙** —— 历史 concurrent-reset 崩溃只在"共享单实例",runner 状态全实例私有,**per-slot 独立 stateful 实例原理安全**。收益 = 省 stateless 每 chunk 25 帧左上下文重算(Code2Wav ~81-87ms,export gate max_abs 5e-6),但 Talker/CP 才是延迟主项 → 增量非量变,仅 chunk 显著变小/超长流式才显著。要启用约 7 项(接线 per-slot stateful+per-slot stream/per-req reset/增量喂码/禁 async/显存 gate/ConvTranspose 相位质量门/CMake GLOB rerun),最大风险=ConvTranspose 相位 click。**判定:incremental headroom,非 blocker,当前 RTF<1 性价比低 → 放 backlog**,等"更小 chunk / 更低 TTFA"成硬需求再启用(届时已铺好 ~80%)。
+
+## 2. v0.8.0 base 已原生 / 该删的冗余封装
+
+【事实】① int4 native runtime 在 `origin/release/0.8.0` 已原生(port 未改却存在)→ 不需任何 native int4 overlay,只留 export drivers。② jve addon `qwen3_tts_streaming_worker.cpp`(md5 `0038bbd6`)= fork v0.7.1 副本 ≠ port/v080(`fe7c0736`)→ re-pin 后此封装作废,必须从 port 重新生成。
+【推断,需 re-pin 后 `git apply --check` 逐 patch 验证】v0.7.1 的 `0001 build-compat`/`0002 weight-streaming`/`0006 SSE` 的部分 hunk 很可能已被 v0.8.0 吸收 → **整合执行体第一步 = 逐 patch 对 v0.8.0 tree base-apply,确认哪些归零**。
+
+## 3. 双写风险(只认 fork 为源)
+
+1. **ASR worker(最高危)**:≥5 个非 git 副本,三处并存且异代 —— seeed `deploy/asr-worker-v080`(md5 `13b34dc`,含 strip 修复)、jve `native/edgellm_voice_worker`(md5 `7885f2e`,异代用 runStreamingHop)、**fork 根本没有 asr_worker**。→ **必须先把 stripLangTag 修复落回 fork `examples/omni/qwen3_asr_worker.cpp` 建立唯一源**,seeed/jve 都降为封装。
+2. **streaming TTS worker**:fork port(`fe7c0736`)vs jve addon(`0038bbd6` v0.7.1)→ 只能从 fork 重新 vendor,禁手改 jve 副本。
+3. **fp8 embedding export driver 异名分叉**:fork `quantize_text_embedding_fp8.py` vs jve `quantize_embedding_safetensors_fp8.py` → diff 确认是否同逻辑;若是,删 jve 那份只认 fork。
+
+## 4. 需要拍板的归属(决策点)
+
+1. **N≤0 prefill guard**:【事实】port/v080 与 v071 分支里**都没有**显式 `N<=0` 守卫,只有 `empty fullText` 的 LOG_ERROR(`qwen3OmniTTSRuntime.cpp:1655`)→ **这是尚未落地的计划项,不是已存在的 patch**。判 C1(防垃圾音频正确性防御,源在 fork),需**新写**。
+2. **CustomVoice 在 v0.8.0 是否保留 → ✅ 已定(用户 2026-06-21):CV = 一等公民。** 走 int4(非 w8a16)。后果:**P5(9-row CV 条件)必须移植到 v0.8.0**(源回 fork,C2);**W1(w8a16)DROP**(EOS 破不可行);需补 **F4(CV streaming worker+EOS+perf)+ F5-CV(CV N=2)** gate;license 跟随 Qwen 官方 CV(我们不增不改,无额外门槛)。
+3. **B2(M=1 GEMV)/A2(streaming worker)定性**:技术上可上游(性能优化通用),按"我们路线/暂不上游"判 C2;若要上游改 C1。
+
+## 关键 EVIDENCE
+- v0.8.0 port delta(`git log origin/release/0.8.0..port/qwen3-tts-base-v080`)= 6 commit:`873ca22`(fp8 embed)/`50b8670`(M=1 GEMV)/`26a4a69`(cuBLAS-free GEMM)/`867b74d`(cutedsl shim)/`ba9ecdb`(Base speaker-encoder)/`10b338d`(streaming worker)。9 文件。
+- jve `UPSTREAM_PIN=364769…`=NVIDIA v0.7.1(**非 v0.8.0**);`fork_branch=v071/customvoice-product`(90 ahead);patches 0001–0008。
+- worker md5:fork port=`fe7c0736`;fork v071=`0038bbd6`;**jve addon=`0038bbd6`(过期)**;jve asr=`7885f2e`;seeed asr=`13b34dc`。
+- rkvoice-engine:DIVERGENCE 写 `self-authored, NO upstream fork` → 完全独立,不参与 fork↔jve 归属。

--- a/docs/plans/voxedge-v080-consolidation/code-structure/01-seeed-local-voice.md
+++ b/docs/plans/voxedge-v080-consolidation/code-structure/01-seeed-local-voice.md
@@ -1,0 +1,142 @@
+# seeed-local-voice — TOP layer (server + "OpenVoiceStream" agent)
+
+**Analyzed ref:** `main` @ **4532ed0** ("feat(rk1828): Gemma-4 multimodal …").
+**AST tool:** Python `ast` module (custom extractor) over the canonical source packages
+(`server/`, `agent/ovs_agent/` — excluding the vendored `.venv`, `third_party/`, `vendor/` which inflate the raw .py count to ~7k).
+
+Two products live here:
+1. **the server** (`server/`) — the WebSocket/HTTP voice service that loads ASR/TTS/LLM backends.
+2. **the agent** (`agent/ovs_agent/`, package "OpenVoiceStream / ovs_agent") — the device-side wake→capture→tool-calling app.
+
+---
+
+## 1. `server/core/` — backend registry + composition + provisioning (the heart for consolidation)
+
+```
+backend_manager.py        BackendManager[T] lifecycle (start/shutdown/reload/acquire, WS drain, hot-swap)
+asr_backend.py            ASRBackend facade ABC + _ASR_REGISTRY + create_asr_backend()
+tts_backend.py            TTSBackend facade ABC + _TTS_REGISTRY + create_tts_backend()
+edge_llm_backend.py       EdgeLLMBackend(LLMBackend)  (HTTP/SSE client to the edge-LLM service)
+voxedge_backend_config.py build_*_config(profile=...) — builds each voxedge backend's config from the profile
+leaf_composition.py       the leaf/device/model registry + CompositionPlan (pure, no I/O)
+composition_boot.py       gated glue: apply a profile's `composition` block → env (no-op for flat profiles)
+model_downloader.py       ensure_models(...) — profile-driven artifact pull (+ bundle suppression)
+profile_loader.py / profile_selector.py / engine_resolver.py / capability_resolver.py
+concurrency_capability.py session_limiter.py / asr_session_manager.py / coordinator.py / v2v.py
+tts_service.py / tts_runtime.py / tts_speakers.py / speaker_embedding.py / punctuation.py / vad.py
+rk_runtime.py / rk_artifacts.py / moss_artifacts.py / qwen3_artifact_downloader.py / hf_artifacts.py
+gpu_watchdog.py / metrics.py / admin_auth.py / api_auth.py / deploy_paths.py / worker_io.py
+```
+
+### Backend registry — the dispatch tables (asr_backend.py / tts_backend.py)
+
+**`_ASR_REGISTRY: Dict[str, (module_path, class_name)]`** (asr_backend.py:178):
+| key | module | class |
+|---|---|---|
+| `jetson.trt_edge_llm` | voxedge.backends.jetson.trt_edge_llm_asr | TRTEdgeLLMASRBackend |
+| `jetson.paraformer_trt` | voxedge.backends.jetson.paraformer_trt | ParaformerTRTBackend |
+| `jetson.sensevoice_trt` | voxedge.backends.jetson.sensevoice_trt | SenseVoiceTRTBackend |
+| `cpu.sherpa_asr` | voxedge.backends.sherpa.asr | SherpaASRBackend |
+| `rk.asr` | (resolved via build_rk_asr_config; RK backend) | |
+
+**`_TTS_REGISTRY`** (tts_backend.py:145):
+| key | module | class |
+|---|---|---|
+| `jetson.trt_edge_llm` | voxedge.backends.jetson.trt_edge_llm_tts | TRTEdgeLLMTTSBackend |
+| `jetson.matcha_trt` | voxedge.backends.jetson.matcha_trt | MatchaTRTBackend |
+| `jetson.kokoro_trt` | voxedge.backends.jetson.kokoro_trt | KokoroTRTBackend |
+| `jetson.qwen3_trt` | voxedge.backends.jetson.qwen3_trt | Qwen3TRTBackend |
+| `jetson.moss_tts_nano` | voxedge.backends.jetson.moss_tts_nano | MossTtsNanoBackend |
+| `cpu.sherpa` | voxedge.backends.sherpa.tts | SherpaTTSBackend |
+| `rk.tts` | (build_rk_tts_config; RK backend) | |
+
+**Dispatch flow** (`create_{asr,tts}_backend()`):
+1. read `ASR_BACKEND`/`TTS_BACKEND` env (a registry key).
+2. import `(module_path, class_name)` lazily from voxedge.
+3. `if spec == "...": config = voxedge_backend_config.build_*_config(profile=current_profile())` then `cls(config=config)`.
+
+> **Structural fact for consolidation:** seeed owns NO backend *implementations* — every registry value points into
+> voxedge. The only seeed-side per-backend code is the `build_*_config()` mappers in `voxedge_backend_config.py`
+> and the facade ABCs. RK backends (`rk.asr`/`rk.tts`) are resolved via config builders rather than a static
+> registry tuple — slightly asymmetric vs the jetson/cpu entries (worth normalizing in consolidation).
+
+### `BackendManager[T]` (backend_manager.py:102) — lifecycle
+- `__init__/start/shutdown`, `state()`, `backend_name()`, `profile_name()`, `is_ready()`, `get_backend_unsafe()`,
+  `acquire()` (async ctx mgr, raises `backend_unavailable`), `register_ws`/`unregister_ws`,
+  `_wait_for_http_drain`, `_force_close_ws_sessions`, **`reload(...)`** (hot-swap; closes WS 1012, dry-run pre-check).
+- Module funcs: `init_backend_managers(...)`, `tts_manager()`, `asr_manager()`. `BackendState` enum.
+
+### Leaf/composition config system
+- **`leaf_composition.py`** — pure registry loaded from `configs/leaves/*.yaml`:
+  `Leaf`, `Artifacts`, `DeviceSpec`, `ModelSpec`, `ResolvedLeaf`, `CompositionPlan`, `Registry`
+  (`device_class`, `resolve_precision` — explicit leaf precision wins else model `default_precision[class]`).
+  Funcs: `load_registry`, `validate_composition` (memory headroom / unknown-or-unbuilt leaf / illegal capability pairing),
+  `resolve_env` (merge leaf < overrides). Errors: `CompositionError`, `RegistryError`.
+- **`composition_boot.py`** — `selected_leaf_ids(composition)`, `apply_composition(profile)`:
+  gated behind a profile `composition` block; **flat profiles are byte-for-byte unchanged (strict no-op)**.
+  os.environ values WIN over leaf-derived (operator-owned env precedence).
+- **`configs/leaves/`** (11 yaml): `models.yaml`, `devices.yaml`, and per-leaf:
+  `qwen3-asr-nx`, `qwen3-tts-nx`, `qwen3-tts-base`, `moss-tts-nano`, `matcha-tts`, `kokoro-tts`,
+  `sensevoice-asr`, `paraformer-asr`. **Precision is a leaf attribute** (flip models.yaml to switch).
+- **`configs/profiles/`** — flat profiles (e.g. the new untracked `jetson-edgellm-v080-moss.json`).
+
+### `model_downloader.ensure_models(...)`
+- Routing: **profile-driven first** (profile.asr_backend/tts_backend), language_mode second.
+- `_BUNDLE_MODEL_BACKEND` map suppresses over-fetch (a Kokoro profile must not pull Matcha; a Qwen3 profile
+  must not pull Paraformer). `_ensure_qwen3_artifacts`, `_download_and_extract`, `_detect_tar_mode`.
+
+## 2. `server/main.py` + entrypoints
+- `server/main.py` — FastAPI/WS app; wires `init_backend_managers`, the `/asr` `/tts` `/v2v` endpoints,
+  the server-loop (`OVS_V2V_SERVER_LOOP=1`, `OVS_V2V_ENGINE=voxedge` → `voxedge.engine.turn_driver.run_turn`).
+- 90+ tests in `server/tests/` cover registry/composition/hot-swap/v2v race conditions.
+
+## 3. `agent/ovs_agent/` — the "OpenVoiceStream" device agent (105 .py)
+
+```
+ovs_agent/
+  cli.py app_base.py app_mode.py        entrypoints (wake→capture→dispatch app shells)
+  session.py state.py event_bus.py      session/state machine
+  audio_io.py vad.py wake_source.py     audio capture + wake-word
+  slv_client.py protocol.py             talks to the seeed server (SLV = server local voice) over WS
+  config.py plugin.py
+  llm/                                  local LLM client adapters
+  tools/  runner.py + @tool decorators  TOOL-CALLING pump  → imports voxedge turn_driver
+  modes/  wake_sources/  audio/  translator/  streaming_translate/
+  actuators/                            Actuator ABC + empty factory (arms register in apps/)
+  apps/   voice_arm/ voice_rebot_arm/ companion_robot/ live_caption/ simul_interpret/ translator/ multi_mode/
+  plugins/ (+ static/)
+```
+
+### `tools/runner.py` — the tool-calling shim (KEY cross-layer edge)
+- `from voxedge.engine.turn_driver import run_turn` (line 33).
+- `class ToolCallCtx`, `_ToolCallAcc`, `_AgentRegistryAdapter`, `_AgentMessageSink`, `_TokenTextSink`, `_ShimLLM`.
+- `async def stream_with_tools(...)` — thin shim over `run_turn`; the agent's local tool pump and the server's
+  server-loop now share the SAME `run_turn` (unification). `_open_stream`, `_wrap_tool_{started,completed}`,
+  `_wrap_completion_text`.
+- Actuators (SO-ARM, reBot B601-DM) self-register in `apps/voice_{arm,rebot_arm}/`; a new motor = a new app.
+
+## 4. `deploy/` — the deployment/overlay structure (NOT a build system)
+```
+deploy/docker/      Dockerfile.jetson(.slim) + many `*-overlay` / `*-patch` Dockerfiles:
+                    voxedge-latest-overlay, agent-latest-overlay, asr-multiturn-overlay,
+                    rebot-{graspangle,inject,micgate}-overlay, slv-{asrfix,preroll}-overlay,
+                    tts-phase-b-overlay, v2v-multiturn-overlay …  (Dockerfile.rk / .rpi too)
+deploy/asr-worker-v080/  qwen3_asr_worker.cpp + stripLangTag-firstword-fix.patch  (the ASR C++ worker source kept here)
+deploy/artifacts/   manifests (kokoro_trt / moss / rk)
+deploy/docker-compose.{jetson-rebot,radxa,rk,rpi}.yml + docker/_patch_*.py
+```
+> Overlays patch CHANGED files onto a baked production base image (canonical Dockerfile lacks openwakeword/entrypoint
+> → cannot full-rebuild). Production config is `.tmpl`-rendered, not baked. Deploy wheels are gitignored (pip-installed).
+
+## 5. Cross-project dependency edges (who imports voxedge)
+| seeed file | imports from voxedge |
+|---|---|
+| `server/core/edge_llm_backend.py` | `backends.base.{LLMBackend, LLMEvent}` |
+| `server/core/voxedge_backend_config.py` | builds configs for jetson/sherpa/rk backends |
+| `server/core/asr_session_manager.py` | re-exports `engine.asr_session_manager` |
+| `server/core/{punctuation,speaker_embedding}.py` | re-export `capabilities.*` (single source of truth) |
+| `server/main.py` | `engine.turn_driver.run_turn`, `transport.base.WebSocketTransport`, tts/qwen3/kokoro/matcha modules |
+| **`agent/ovs_agent/tools/runner.py`** | **`engine.turn_driver.run_turn`** (top layer → middle layer, direct) |
+
+The backend impl modules (`backends/jetson/*`, `backends/sherpa/*`) are imported **lazily** via the
+registry tuples — they are never top-level imports in seeed (keeps the server importable without CUDA).

--- a/docs/plans/voxedge-v080-consolidation/code-structure/02-voxedge.md
+++ b/docs/plans/voxedge-v080-consolidation/code-structure/02-voxedge.md
@@ -1,0 +1,114 @@
+# voxedge — MIDDLE layer (engine + backend abstraction library)
+
+**Analyzed ref:** `main` @ **b783037** ("feat(trt-edge-llm-tts): fixed base-model speaker-embedding injection").
+**AST tool:** Python `ast` module (custom extractor `/tmp/ast_extract.py`) over the 94 real `.py` files.
+
+voxedge is the **provider-agnostic engine + backend implementations** that seeed-local-voice consumes.
+It contains zero device-specific server glue; it exposes backend classes + a turn driver + transports.
+
+---
+
+## 1. Package tree
+
+```
+voxedge/
+  __init__.py            (only exports __version__ — public surface is the submodules below)
+  backends/
+    base.py              ABCs: ASRBackend, ASRStream, TTSBackend, + capability enums + ConcurrencyCapability
+    jetson/              the TRT/Jetson backends (see §3)
+    rk/                  Rockchip backends (asr.py, tts.py, runtime.py, artifacts.py)
+    sherpa/              CPU sherpa-onnx backends (asr.py, tts.py)
+  engine/                the turn driver + conversation/session machinery (see §4)
+  capabilities/          punctuation.py, speaker_embedding.py  (opt-in stateless add-ons)
+  transport/             base.py  (Transport ABC + InProcessTransport)
+  artifacts/  audio/  tests/
+```
+
+## 2. Backend abstraction — `voxedge/backends/base.py`
+
+The contract every backend implements (this is what seeed's `_ASR_REGISTRY`/`_TTS_REGISTRY` resolve to):
+
+- `class ASRStream(ABC)`: `accept_waveform(sr, samples)`, `finalize()->(text,lang)`, `get_partial()->(text,final)`,
+  `prepare_finalize()`, `cancel_and_finalize()`, `cancel()`, `close()`.
+- `class OfflineAccumulateStream(ASRStream)`: buffers audio, finalize calls backend.transcribe_array (sherpa/offline path).
+- `class ASRBackend(ABC)`: `name`, `capabilities()->set[ASRCapability]`, `sample_rate`, `is_ready`, `preload`,
+  `transcribe(...)`, `transcribe_array(...)`, `create_stream(language)->ASRStream`, `has_capability`, `unload`,
+  `concurrency_capability()->ConcurrencyCapability`.
+- `class TTSBackend(ABC)`: parallel surface (name/model_id/capabilities/sample_rate/is_ready/preload/unload,
+  `_synthesize_impl`, `_generate_streaming_impl`, `rate_pitch_caps`, optional `clone_voice`/`extract_speaker_embedding`).
+- Enums: `ASRCapability`, `TTSCapability`; `TranscriptionResult`.
+
+> **Note:** seeed-local-voice ALSO defines its own `ASRBackend`/`TTSBackend` ABCs in `server/core/{asr,tts}_backend.py`.
+> The voxedge ones are the implementation base; the seeed ones are the server-facing facade that the registry
+> resolves into. This is a deliberate two-layer ABC (facade in seeed, impl base in voxedge) — see consolidation note.
+
+## 3. `backends/jetson/` — the TRT backend family
+
+```
+trt_edge_llm_tts.py   TRTEdgeLLMTTSConfig + TRTEdgeLLMTTSBackend  (Qwen3-TTS via C++ worker)
+trt_edge_llm_asr.py   TRTEdgeLLMASRBackend                        (Qwen3-ASR via C++ worker)
+trt_edge_llm_ipc.py   IPC/worker-spawn plumbing shared by the two above
+_trt_edge_llm_util.py shared helpers
+worker_io.py          Python side of the JSON-line worker protocol (WorkerIO)
+matcha_trt.py         MatchaTRTBackend  (+ CudaMemoryPool)
+kokoro_trt.py         KokoroTRTBackend  (+ _KokoroCtxSlot, _OrtIoNames, _run_cpu_onnx)
+qwen3_trt.py          Qwen3TRTBackend   (legacy Qwen3-TTS path)
+moss_tts_nano.py      MossTtsNanoBackend
+paraformer_trt.py     ParaformerTRTBackend (+ decode_ids, _ParaformerCtxBundle)
+sensevoice_trt.py     SenseVoiceTRTBackend
+_util.py
+```
+
+### `TRTEdgeLLMTTSBackend` (trt_edge_llm_tts.py) — load-bearing methods
+- `class TRTEdgeLLMTTSConfig` (frozen-ish dataclass): `__post_init__`, `highperf_enabled`, `stateful_code2wav_enabled`, `fast_perf_profile`.
+- `PoolSaturatedError(RuntimeError)` (N>1 backpressure → maps to seeed 4429).
+- Backend: `concurrency_capability`, `supports_hot_reload`, `preload`/`unload`,
+  `_use_worker`, `_worker_env`, `_ensure_worker`, `_restart_worker_locked`,
+  `_synthesize_worker`, `_synthesize_worker_via_stream`, `_generate_streaming_{impl,single}`,
+  `_synthesize_impl`, `rate_pitch_caps`, `clone_voice`, `extract_speaker_embedding`,
+  `_load_product_explicit_kv_backend`, `_explicit_kv_flags`.
+- **It spawns the C++ `qwen3_tts_streaming_worker` binary** (from the TRT fork examples/omni) and speaks the
+  JSON-line protocol via `worker_io.py`. This is the seam where the Python (voxedge) layer meets the C++
+  (TRT fork) layer. `_worker_env`/`_explicit_kv_flags` build the worker argv/env.
+
+## 4. `engine/` — turn driver + conversation machinery (the unification target)
+
+```
+turn_driver.py        run_turn(...) — provider-agnostic, NO I/O. The unified server/client pump.
+conversation.py       higher-level conversation orchestration
+coordinator.py        coordination glue
+asr_loop.py  asr_session_manager.py  audio_dispatcher.py   ASR side
+tts_buffer.py  tts_sequencer.py                            TTS side
+llm_turn.py  builtin_tools.py  tool_registry.py            LLM/tool-calling
+capability_resolver.py  concurrency_capability.py          capability negotiation
+client_events.py  protocol.py  session_state.py
+```
+
+### `turn_driver.run_turn` (turn_driver.py) — the unified pump
+- Protocols: `TextSink` (`text`/`preamble`/`flush`), `MessageSink`
+  (`add_assistant_tool_calls`/`add_assistant_text`/`add_tool_result`/`working_messages`).
+- `async def run_turn(...)` — the single shared turn loop. `_ToolCallAcc`, `_template_fires`, `_template_completion`.
+- **Consumed directly by BOTH:** seeed's server (`server/main.py` / `server/core/coordinator`) AND the agent
+  (`agent/ovs_agent/tools/runner.py` imports `from voxedge.engine.turn_driver import run_turn`). This is the
+  server-loop/client-loop unification recorded in memory (turn_driver_unification).
+
+## 5. `transport/base.py`
+- `class Transport(ABC)`: `recv_audio`/`send_audio`/`recv_event`/`send_event`/`close`.
+- `class InProcessTransport(Transport)`: feed_audio/feed_event/end_input + audio_out/events_out +
+  drain_*_nowait. Used by the in-process e2e harness and the agent's local pump.
+- `transport/base.py::_pump` is load-bearing for the production `OVS_V2V_ENGINE=voxedge` path (per memory).
+
+## 6. `capabilities/`
+- `punctuation.py` — CT-Transformer punctuation (opt-in, default-off, stateless; byte-level no-op when off).
+- `speaker_embedding.py` — CAM++ speaker embedding (opt-in). Re-exported by seeed `server/core/{punctuation,speaker_embedding}.py`.
+
+## 7. Public API surface actually imported by seeed-local-voice
+(see also 01-seeed-local-voice.md §dependency edges)
+- `voxedge.backends.base.{LLMBackend, LLMEvent}` ← `server/core/edge_llm_backend.py`
+- `voxedge.backends.jetson.{trt_edge_llm_tts, trt_edge_llm_asr, matcha_trt, kokoro_trt, qwen3_trt, moss_tts_nano, paraformer_trt}`
+  ← resolved lazily via seeed's registry + `voxedge_backend_config.py`
+- `voxedge.backends.sherpa.{asr,tts}` ← sherpa registry entries
+- `voxedge.engine.turn_driver.run_turn` ← agent runner + server coordinator
+- `voxedge.engine.asr_session_manager` ← `server/core/asr_session_manager.py` (re-export)
+- `voxedge.transport.base.WebSocketTransport` ← server
+- `voxedge.capabilities.{punctuation,speaker_embedding}` ← server capability shims

--- a/docs/plans/voxedge-v080-consolidation/code-structure/03-tensorrt-edge-llm-fork.md
+++ b/docs/plans/voxedge-v080-consolidation/code-structure/03-tensorrt-edge-llm-fork.md
@@ -1,0 +1,151 @@
+# TensorRT-Edge-LLM fork — BOTTOM layer (source of truth for the C++ runtime)
+
+**Analyzed ref:** `port/qwen3-tts-base-v080` @ **873ca22** — the v0.8.0 base port.
+> NOTE: `wip/fp8-embedding` points to the **same commit** (873ca22) — the fp8 text-embedding
+> work landed on the base-v080 branch head; there is no separate fp8 tree to diff.
+> The repo's *checked-out* branch is `v071/customvoice-product` (LEGACY v0.7.1) — **NOT analyzed as canonical.**
+**int4 drivers ref:** `suharvest/wip/native-int4-talker` @ **ff2318e** (branches off the 0.8.0 release 8ac8fd6).
+
+AST/structural method: BSD `ctags` only (no C++ tags) and no libclang available on this host →
+C++ class/method inventory extracted by careful header parsing (regex over declarations). Python tooling
+(`tensorrt_edgellm/`) read directly. Stated per the guardrails.
+
+Read at-ref via `git archive port/qwen3-tts-base-v080 | tar -x` (working tree never switched).
+
+---
+
+## 1. Top-level tree (v0.8.0)
+
+```
+cpp/            C++ runtime + kernels + plugins (compiles to edgellmCore / edgellmKernels / NvInfer_edgellm_plugin)
+examples/omni/  qwen3_tts_inference.cpp + qwen3_tts_streaming_worker.cpp  (link edgellmCore)
+tensorrt_edgellm/  Python export/quant tooling + model definitions (the "build the engines" side)
+kernelSrcs/ cmake/ 3rdParty/ unittests/ tests/ experimental/pybind/
+CMakeLists.txt  (top — declares commonLibraryExt, adds cpp/ + examples/, ENABLE_CUTE_DSL group)
+```
+
+## 2. CMake build-target graph (the load-bearing part for consolidation)
+
+Top `CMakeLists.txt`:
+- `commonLibraryExt` (INTERFACE) → `TensorRT::TensorRT`, `TensorRT::OnnxParser`.
+- `add_subdirectory(cpp)` then `add_subdirectory(examples)`.
+- `ENABLE_CUTE_DSL` is a semicolon group (`fmha;gdn`); `OFF` falls back to cuBLAS
+  (the documented Jetson CUDA 12.6 build path — CuTe-DSL prebuilt needs CUDA 12.8 `cudaLibrary*`).
+- `unitTest` exe links `edgellmCore commonLibraryExt`.
+
+`cpp/CMakeLists.txt` — **the four artifacts**:
+
+| Target | Type | Sources (GLOB_RECURSE) |
+|---|---|---|
+| `edgellmKernels` | STATIC | `kernels/*.{cpp,cu}` + `common/*.cpp` (MoE-Marlin `ops`/`sm80` excluded; rdc=true for marlin) |
+| **`edgellmCore`** | STATIC | `common/ + kernels/ + sampler/ + multimodal/ + action/ + runtime/ + profiling/ + tokenizer/` — **this is the runtime everything links** |
+| `edgellmBuilder` | STATIC | `builder/*.cpp` + common (+ `NV_ONNX_PARSER_LIB`) |
+| `NvInfer_edgellm_plugin` | SHARED (so.1.0) | `plugins/*.cpp` |
+
+`examples/omni/CMakeLists.txt` — **the two voice executables** (both `PRIVATE edgellmCore exampleUtils commonLibraryExt`):
+- `qwen3_tts_inference` — one-shot TTS demo.
+- **`qwen3_tts_streaming_worker`** — the JSON-line stdin/stdout streaming worker, **slot-pool N>1**
+  (this is the binary the Python TTS backend spawns; see voxedge `trt_edge_llm_tts.py::_ensure_worker`).
+- Both conditionally link `trt_edgellm_cutedsl_cudart_shim` with `-Wl,-u,cudaLibrary*` forced symbols
+  (the CUDA 12.0–12.6 missing-export workaround).
+
+> **Consolidation note:** cuBLAS is **dlopen'd at runtime inside the TTS runtime** ("no compile-time
+> linking needed") — so the worker binary is portable across CUDA minor versions w.r.t. cuBLAS.
+
+## 3. `cpp/runtime/` — the runtime classes
+
+| File | Class / key API |
+|---|---|
+| `qwen3OmniTTSRuntime.{h,cpp}` | **`Qwen3OmniTTSRuntime`** — the TTS engine driver |
+| `llmInferenceRuntime.{h,cpp}` | `LLMInferenceRuntime` (thinker/LLM) |
+| `llmRuntimeUtils.{h,cpp}` | `Message`, `LLMGenerationRequest/Response`, `RopeConfig`, `collectRopeConfig`, rope/nope/longrope cache init, `buildBatchMapping`, `EmbeddingData` |
+| `streaming.{h,cpp}` | **`StreamChannel`** (create/consume/tryPop/waitPop/cancel/setStreamInterval), `StreamChunk`, `decodePerSlot`, `emitChunks`, `applyStopStringMatch` |
+| `slotPool.h` | **`SlotPool<TSlot>`** template — capacity/acquireFree/acquireOrExisting/release/bind/unbind, mutex-guarded. Namespace `tensorrt_edge_llm::runtime`. **This is the N>1 concurrency primitive** the worker reuses (`rt_slotpool = tensorrt_edge_llm::runtime`). |
+| `kvCacheManager.{h,cpp}` | `KVCacheManager`, `KVLayerConfig`, `getSeparateKVCache` |
+| `hybridCacheManager.{h,cpp}` | `HybridCacheManager` — KV + recurrent/conv state (GDN/Mamba hybrid): compact/capture/restore batch, `commitSequenceLength` |
+| `mambaCacheManager.{h,cpp}` | `MambaCacheManager` |
+| `audioUtils.h`, `imageUtils.{h,cpp}` | multimodal IO helpers |
+| sub-dirs | `config/ decoding/ exec/ features/ legacy/ preprocess/ state/` |
+
+### `Qwen3OmniTTSRuntime` (qwen3OmniTTSRuntime.h) — load-bearing surface
+- ctor: `Qwen3OmniTTSRuntime(talkerEngineDir, codePredictorEngineDir, tokenizerDir, cudaStream_t)`
+- Request structs:
+  - `TalkerGenerationRequest` — maxAudioLength, talkerTemperature/TopK/TopP, repetitionPenalty,
+    `speakerName`/`speakerId`/**`speakerEmbedding` (vector<float>)**, messages, applyChatTemplate,
+    `codecChunkFrames`/`subsequentChunkFrames`, `shouldCancel`.
+  - `OmniGenerationRequest` — fullText/textTokenIds, **`prefillLength`** (layer0/layer14 cover [0,prefillLength)), same sampling fields.
+  - `ThinkerTalkerStreamingConfig` — `talkerPrefillThreshold`, `codecChunkFrames`.
+  - `TalkerGenerationResponse` — `batchRvqCodes` (3-deep vector), numFramesPerSample, success.
+- Generation entrypoints (batched + single overloads):
+  `handleAudioGeneration(...)`, `handleAudioGenerationFromThinker(...)`,
+  **`handleStreamingGeneration(LLMInferenceRuntime& thinker, ...)`** — the joint thinker→talker stream.
+- Internals: `captureDecodingCUDAGraph`, `getSpeakerIdByName`, `initializeTTSEmbeddings`,
+  `executeTalkerPrefillStep`, `runCodePredictorGenerationForFrame`, `computeResidualConnection`,
+  `extractTalkerLastHidden`, `runTalkerGenerationLoop`, `runSingleTalkerDecodeFrame`,
+  `buildTalkerPrefillFromSegments`.
+- State structs: `PerBatchTalkerState` (codecToken/talkerFrames/finished/seenTokenSet/rvqCodes/lastChunkEnd),
+  `PerBatchStreamingHooks` (codecChunkFrames/subsequentChunkFrames/shouldCancel), `SegmentInfo`.
+
+> **Base vs CustomVoice (consolidation-critical):** the base v0.8.0 runtime takes `speakerName`/`speakerId`/
+> `speakerEmbedding` directly (8-row fixed speaker prefix). The legacy v0.7.1 customvoice path's blockers
+> (preload-talker-embeds / 9-row prefix / W8A16-EOS) are **NOT present here** — this branch is the clean base.
+
+## 4. `cpp/kernels/` — kernel families
+
+```
+common/  contextAttentionKernels/  decodeAttentionKernels/  embeddingKernels/
+gdnKernels/  int4GroupwiseGemmKernels/  kvCacheUtilKernels/  mamba/  moe/
+posEncoding/  preprocessKernels/  speculative/  talkerMLPKernels/
+```
+TTS-relevant: `embeddingKernels` (text/speaker embedding), `posEncoding`, **`talkerMLPKernels`**,
+`int4GroupwiseGemmKernels` (dequantize.cuh, int4WoQGemvCuda.cu, int4WoqGemmCuda.cu — **already present on base-v080**),
+`kvCacheUtilKernels` (the historically-patched KV-sizing kernel). GDN/Mamba/MoE serve the thinker LLM.
+
+## 5. `cpp/plugins/` — TRT plugins (compiled into `NvInfer_edgellm_plugin.so`)
+```
+attentionPlugin/ gatedDeltaNet/ int4GroupwiseGemmPlugin/ int4MoePlugin/ mamba/
+nvfp4MoePlugin/ nvfp4MoePluginGeforce/ utils/ vitAttentionPlugin/
+```
+**`int4GroupwiseGemmPlugin` is present on base-v080** (kernels + plugin both). What the int4 branch adds
+is the *export drivers*, not new runtime plugin code (see §7).
+
+## 6. `tensorrt_edgellm/` — Python export/quant tooling (engine-build side)
+
+```
+scripts/   export.py  quantize.py  reduce_vocab.py  insert_lora.py  merge_lora.py
+           process_lora_weights.py  preprocess_audio.py
+quantization/  quantize.py  quantization_configs.py  qwen3_asr_loader.py
+               nemotron_h_patch.py  models/qwen3_asr/...
+models/qwen3_tts/   modeling_qwen3_tts_text.py  _talker.py  _audio.py  _code2wav.py
+                    modeling_code_predictor.py
+models/qwen3_asr/   modeling_qwen3_asr_{text,audio}.py
+models/qwen3_omni/  ...   models/qwen3_5{,_moe}/ ... (thinker LLMs)
+onnx/ checkpoint/ lora/ chat_templates/ vocab_reduction/
+```
+`scripts/export.py` + `scripts/quantize.py` are the canonical engine-build entrypoints; the per-model
+`modeling_*.py` define the TRT graph builders. **qwen3_tts is split into text / talker / audio / code2wav / code_predictor** sub-models — mirrors the runtime's talker + code-predictor + code2wav stages.
+
+## 7. int4 export drivers — `wip/native-int4-talker` @ ff2318e (the reproducibility risk)
+
+These scripts live **at repo root on the int4 branch** (NOT under `tensorrt_edgellm/scripts/`):
+- **`quantize_talker_stage1.py`** — `main()` argparse; `remap_talker_to_hf(src_sd)`; loads Qwen3 talker,
+  runs `mtq.quantize(int4_awq)` (TensorRT-ModelOpt), checks NaN/Inf calib batches, `export_hf_checkpoint`.
+- **`stage2_export.py`** — `reprefix_unified_to_talker(uni_sd)` + `main()` (build TRT engine from stage1 ckpt).
+- **`cp_stage2_export.py`** — code-predictor stage-2 export.
+
+The branch also re-adds (vs the 0.8.0 release base it forked from): `cpp/kernels/int4GroupwiseGemmKernels/*`,
+`cpp/plugins/int4GroupwiseGemmPlugin/*`, `cpp/plugins/int4MoePlugin/*`, `unittests/woqInt4{Gemm,Gemv}Test.cu`.
+On `port/qwen3-tts-base-v080` those kernel/plugin trees already exist — so the **distinguishing payload of the
+int4 branch is the three root-level driver scripts** (stage1/stage2/cp_stage2). They are *not merged into the
+v0.8.0 base port branch*, so int4-talker reproducibility currently depends on a separate WIP branch — flag for
+the consolidation plan.
+
+## 8. examples/omni worker (`qwen3_tts_streaming_worker.cpp`) — structure
+- `struct Args` + `parseArgs` (`--max_slots`, engine dirs, tokenizer). `--max_slots=1` ⇒ single slot/thread (back-compat).
+- `audioToFloatSamples(AudioData)`; `emitEvent(Json)` (coutMutex-serialized JSON-line output).
+- Cancel registry: `registerCancel/unregisterCancel/tripCancel` (per-request atomic flag).
+- `struct TtsSlot { runtime, cudaStream, std::thread worker, atomic inUse, atomic shutdown, queue/cv }`;
+  `struct WorkItem { Json request }`; `gMaxSlots`.
+- Architecture: 1 stdin reader thread routes each JSON line to a free slot; **N worker threads, each bound to
+  one slot** (uses `tensorrt_edge_llm::runtime::SlotPool` for binding via `bindSession/unbindSession`).
+- This is the C++ counterpart of the Python `WorkerIO` protocol in voxedge/seeed (`worker_io.py`).

--- a/docs/plans/voxedge-v080-consolidation/code-structure/04-jetson-voice-engine.md
+++ b/docs/plans/voxedge-v080-consolidation/code-structure/04-jetson-voice-engine.md
@@ -1,0 +1,65 @@
+# jetson-voice-engine — BOTTOM (Jetson overlay / addon over upstream TRT-Edge-LLM)
+
+**Analyzed ref:** `main` @ **3750ea9**.
+**Tool:** directory + CMake/patch inspection.
+
+This repo is the **Jetson-side overlay**: it does NOT vendor the full TRT-Edge-LLM source. It pins an
+**upstream commit** and carries OUR features as patches + the native voice workers that link the built `edgellmCore`.
+
+> **Critical consolidation fact:** `engine-overlay/UPSTREAM_PIN` = **`364769036fc83351d9d0aac4cc064a8e56a83178`**
+> = NVIDIA TensorRT-Edge-LLM **v0.7.1** (Merge PR #90, dev-release/0.7.1).
+> So this overlay is still anchored to v0.7.1. The **v0.8.0 runtime lives in the FORK's
+> `port/qwen3-tts-base-v080` branch** (see 03-…), where these same features are now *native*. The overlay's
+> our-features-as-patches and the fork's native-v0.8.0 are two parallel encodings of the same capabilities —
+> the consolidation should collapse them onto the v0.8.0 fork.
+
+---
+
+## 1. Tree
+```
+native/edgellm_voice_worker/   the C++ voice workers (link the externally-built edgellmCore)
+  qwen3_tts_worker.cpp  qwen3_asr_worker.cpp
+  mel_extractor.{cpp,h}  audio_vad_split.{cpp,h}  kissfft/  tests/  CMakeLists.txt  README.md
+engine-overlay/                the upstream-overlay machinery
+  UPSTREAM_PIN  upstream.remote  build.sh  DIVERGENCE.md  README.md  .gitignore
+  patches/   0001..0008 (our features as numbered patches — see §3)
+  manifests/ customvoice-v071.toml  qwen3-asr-sm87.toml  qwen3-tts-highperf-sm87.toml
+  addon/
+patches/product/   edgellm-qwen3-tts-text-embedding-fp8*.patch (3 variants) + paraformer-eof-fix.patch
+configs/profiles/  deploy/{artifacts,audio_preprocessing}/  models/{common,kokoro,matcha,moss-tts-nano,paraformer,qwen3}/
+scripts/  tests/golden_mels/  docs/{performance,plans,issues,audio-evidence}/
+```
+
+## 2. `native/edgellm_voice_worker/CMakeLists.txt` — build-target graph
+- `project(jetson_voice_edgellm_workers LANGUAGES C CXX CUDA)`.
+- **Requires an externally-built TRT tree**: asserts `${EDGE_LLM_BUILD_DIR}/cpp/libedgellmCore.a` exists.
+- `read_edgellm_cache_entry(...)` reads the upstream build's CMakeCache (`ENABLE_CUTE_DSL`, `CUTE_DSL_ARTIFACT_TAG`,
+  `EMBEDDED_TARGET`) to stay ABI-consistent with how edgellmCore was built.
+- `add_library(edgellmCore STATIC IMPORTED GLOBAL)` → links the prebuilt `libedgellmCore.a`.
+- Builds `qwen3_tts_worker` + `qwen3_asr_worker` (+ unit tests for mel_extractor / audio_vad_split).
+- Adds CUDA stub lib link options (`-L${CUDA_DIR}/lib/stubs`).
+
+> So: **upstream TRT builds edgellmCore.a; this repo's workers IMPORT and link it.** This mirrors the fork's
+> `examples/omni/qwen3_tts_streaming_worker` (which links edgellmCore as a regular target). The two worker
+> source families (`deploy/asr-worker-v080/qwen3_asr_worker.cpp` in seeed, `native/edgellm_voice_worker/*` here,
+> and `examples/omni/*` in the fork) are **three copies of the worker concept** — a key consolidation target.
+
+## 3. `engine-overlay/patches/` — OUR features as numbered patches (the our-vs-upstream split)
+| patch | feature |
+|---|---|
+| 0001-orin-tegra-build-compat | Orin/Tegra build fixes |
+| 0002-weight-streaming-budget | weight-streaming memory budget |
+| 0003-asr-streaming-session | streaming ASR session (the #15 prefix/chunk-confirm path) |
+| 0004-tts-slotpool-concurrency | **N>1 TTS slot-pool** (native in fork v0.8.0 as `SlotPool`) |
+| 0005-customvoice-language-conditioning | CustomVoice language conditioning (v0.7.1 product) |
+| 0006-server-sse-disconnect-and-openai-api | SSE-disconnect fix + OpenAI API |
+| 0007-server-openai-api-docs | API docs |
+| 0008-build-misc-example-registration | example registration / build misc |
+
+`patches/product/` additionally has the **fp8 text-embedding** patches in 3 forms
+(`-cpp-only`, `-unified`, plain) + `paraformer-eof-fix`. The fp8 embedding work is **already merged natively**
+on the fork's `port/qwen3-tts-base-v080`/`wip/fp8-embedding` (873ca22) — so these product patches are the
+v0.7.1-overlay encoding of what is native in v0.8.0.
+
+`engine-overlay/manifests/*.toml` describe the build variants (customvoice-v071, qwen3-asr-sm87, qwen3-tts-highperf-sm87);
+`build.sh` is the only sanctioned build entry; `DIVERGENCE.md` documents the delta vs upstream.

--- a/docs/plans/voxedge-v080-consolidation/code-structure/05-rkvoice.md
+++ b/docs/plans/voxedge-v080-consolidation/code-structure/05-rkvoice.md
@@ -1,0 +1,49 @@
+# rkvoice-stream / rkvoice-engine — BOTTOM (Rockchip RK NPU layer)
+
+**Analyzed refs:** `rkvoice-stream` main @ **76e9ded**; `rkvoice-engine` main @ **1f133f3**.
+**Tool:** directory inspection (light depth per scope).
+
+These are the RK3576/RK3588 counterparts of the Jetson stack. **rkvoice-stream** = the runtime/server;
+**rkvoice-engine** = the model conversion (ONNX→RKNN / →RKLLM) pipeline (recently MIT-licensed / open-sourced).
+
+---
+
+## 1. rkvoice-stream (RK runtime + server)
+```
+rkvoice_stream/
+  app/server.py            the RK voice server (health + runtime_info endpoints)
+  backends/                RK ASR/TTS backends
+  engine/  asr.py  tts.py  the engine entrypoints
+  runtime/ rkllm_wrapper.py the RKLLM C-API ctypes wrapper + __init__
+  platform/                platform detection
+  vad/
+configs/  docker/  models/{asr,tts,common}/  baseline/  tools/  tests/  docs/evidence/
+```
+- `runtime/rkllm_wrapper.py` is the RKLLM driver shim (ctypes over librkllmrt).
+- `engine/{asr,tts}.py` are the RK equivalents of voxedge's jetson backends — but RK is a **separate runtime
+  tree**, not under voxedge. seeed reaches RK via `server/core/rk_runtime.py` + `rk_artifacts.py` and the
+  registry keys `rk.asr` / `rk.tts` (resolved through `build_rk_{asr,tts}_config`).
+- Conversion/verification helpers under `models/`: `convert_rknn_fixed.py`, `convert_vocoder_rknn.py`,
+  `verify_code2wav_stateful_parity.py`, `rk3576_tts_dump.py`, MOSS onnx→rkllm converters.
+
+## 2. rkvoice-engine (RK model conversion pipeline)
+```
+addon/models/
+  common/convert_rknn_fixed.py
+  asr/qwen3/   export_qwen3_asr_weights.py  export_decode_{variants,stream}.py  export_fixed_shapes.py
+               export_rkllm_talker.py  export_onnx.py  export_tokenizer_encode.py
+  asr/paraformer/  convert_paraformer_rknn.py  export_paraformer_hybrid.py
+  tts/moss/    convert_moss_onnx_to_rkllm_state.py  export_moss_rkllm_runtime_assets.py
+               probe_moss_{rkllm,rknn}_runtime.py
+  tts/convert_vocoder_rknn.py
+manifests/
+```
+- This is the RK analogue of the fork's `tensorrt_edgellm/scripts/{export,quantize}.py` — the "build the
+  device artifacts" side. Pure conversion/export drivers; no runtime serving.
+
+## 3. Placement in the layering
+- RK occupies the **same BOTTOM tier** as the TRT fork + jetson-voice-engine, but on a parallel rail:
+  RKLLM/RKNN instead of TensorRT. It is **NOT** consumed through voxedge's `backends/jetson`; seeed has a
+  dedicated RK path (`rk.asr`/`rk.tts` registry keys → `rk_runtime`/`rk_artifacts` + voxedge `backends/rk/*`).
+  voxedge DOES carry a thin `voxedge/backends/rk/` (asr.py/tts.py/runtime.py/artifacts.py), so the RK runtime
+  proper lives in rkvoice-stream while voxedge has the seeed-facing RK adapter — note this split for consolidation.

--- a/docs/plans/voxedge-v080-consolidation/code-structure/INDEX.md
+++ b/docs/plans/voxedge-v080-consolidation/code-structure/INDEX.md
@@ -1,0 +1,83 @@
+# Edge-Voice Code-Structure Reference (v0.8.0 consolidation)
+
+Structural/AST reference for the canonical edge-voice projects. **READ-ONLY analysis** — no working tree was
+switched (all at-ref reads via `git show`/`git archive`); no builds/deploys. Complements
+`consolidation-plan.md` (this is the *structure*; the plan is the *intent*).
+
+## Per-project files
+| # | File | Project | Layer | Ref analyzed |
+|---|---|---|---|---|
+| 1 | [01-seeed-local-voice.md](01-seeed-local-voice.md) | seeed-local-voice (server + "OpenVoiceStream" agent) | **TOP** | main @ 4532ed0 |
+| 2 | [02-voxedge.md](02-voxedge.md) | voxedge (engine + backend impls) | **MIDDLE** | main @ b783037 |
+| 3 | [03-tensorrt-edge-llm-fork.md](03-tensorrt-edge-llm-fork.md) | TensorRT-Edge-LLM fork (C++ runtime + Python export) | **BOTTOM** | **port/qwen3-tts-base-v080 @ 873ca22** (+ int4 drivers wip/native-int4-talker @ ff2318e) |
+| 4 | [04-jetson-voice-engine.md](04-jetson-voice-engine.md) | jetson-voice-engine (Jetson overlay/workers) | **BOTTOM** | main @ 3750ea9 (UPSTREAM_PIN=v0.7.1) |
+| 5 | [05-rkvoice.md](05-rkvoice.md) | rkvoice-stream / rkvoice-engine (RK NPU) | **BOTTOM** | main @ 76e9ded / 1f133f3 |
+
+## 3-layer dependency graph
+
+```
+ TOP     seeed-local-voice
+         ├─ server/            (FastAPI WS/HTTP service)
+         │    server/core/_ASR_REGISTRY, _TTS_REGISTRY  ──lazy import──┐
+         │    server/core/voxedge_backend_config.build_*_config()       │
+         │    server/main.py  ── run_turn, WebSocketTransport ──┐       │
+         └─ agent/ovs_agent/   ("OpenVoiceStream" device agent) │       │
+              tools/runner.py  ── run_turn ───────────────┐     │       │
+                                                          ▼     ▼       ▼
+ MIDDLE  voxedge
+         ├─ engine/turn_driver.run_turn   (shared server-loop + agent pump)
+         ├─ transport/base                (Transport / InProcessTransport / WebSocketTransport)
+         ├─ capabilities/{punctuation,speaker_embedding}   (re-exported by seeed)
+         └─ backends/
+              base.py (ASRBackend/TTSBackend ABCs)
+              jetson/trt_edge_llm_tts.py  ── spawns ──┐
+              jetson/{matcha,kokoro,qwen3,moss_tts_nano,paraformer,sensevoice}_trt.py
+              sherpa/{asr,tts}            rk/{asr,tts,runtime,artifacts}
+                                                       │
+                                                       ▼ (JSON-line worker protocol, worker_io.py)
+ BOTTOM  TensorRT-Edge-LLM fork  @ port/qwen3-tts-base-v080  (873ca22)  ← SOURCE OF TRUTH
+         ├─ cpp/ → edgellmCore.a (STATIC) + edgellmKernels + NvInfer_edgellm_plugin.so
+         │    runtime/Qwen3OmniTTSRuntime, LLMInferenceRuntime, StreamChannel, SlotPool<TSlot>, HybridCacheManager
+         ├─ examples/omni/qwen3_tts_streaming_worker  (links edgellmCore; the spawned binary)
+         └─ tensorrt_edgellm/scripts/{export,quantize}.py  (+ int4 drivers on wip/native-int4-talker)
+
+ BOTTOM  jetson-voice-engine (main, UPSTREAM_PIN=v0.7.1)  — parallel encoding of the same features:
+         native/edgellm_voice_worker/{qwen3_tts,qwen3_asr}_worker.cpp  (IMPORT prebuilt edgellmCore.a)
+         engine-overlay/patches/0001..0008  +  patches/product/fp8-embedding  (= native in fork v0.8.0)
+
+ BOTTOM  rkvoice-stream / rkvoice-engine (RK rail; NOT through voxedge.jetson):
+         seeed rk.asr/rk.tts → server/core/rk_runtime + voxedge/backends/rk  →  rkvoice-stream RKLLM runtime
+```
+
+## Where the layers physically meet
+1. **TOP→MIDDLE (Python imports):** seeed `_ASR/_TTS_REGISTRY` values = `voxedge.backends.*` dotted paths,
+   imported lazily; `agent/ovs_agent/tools/runner.py` + `server/main.py` import `voxedge.engine.turn_driver.run_turn`.
+2. **MIDDLE→BOTTOM (process boundary):** voxedge `trt_edge_llm_tts.py`/`trt_edge_llm_asr.py` **spawn the C++
+   worker binary** and speak the JSON-line protocol (`worker_io.py` ↔ `examples/omni/qwen3_tts_streaming_worker.cpp`).
+   No shared address space — this is the clean cut for swapping in the v0.8.0 worker.
+3. **BOTTOM build:** `edgellmCore` (STATIC) is the single linked artifact; both the fork's omni worker AND
+   jetson-voice-engine's native workers link it (fork: as a target; jetson-voice-engine: as IMPORTED prebuilt).
+
+## Findings that bear on the consolidation plan
+- **`port/qwen3-tts-base-v080` == `wip/fp8-embedding`** (both 873ca22): fp8 text-embedding is already on the
+  base port head — no separate fp8 branch to merge.
+- **The int4-talker export drivers are isolated on `wip/native-int4-talker` (ff2318e)** — `quantize_talker_stage1.py`,
+  `stage2_export.py`, `cp_stage2_export.py` at repo root, NOT in `tensorrt_edgellm/scripts/`, and NOT on the
+  base-v080 branch. The int4 *kernels/plugins* (`int4GroupwiseGemm*`) ARE on base-v080. So int4-talker
+  reproducibility depends on a side WIP branch → reproducibility risk flagged in the plan is real & located.
+- **jetson-voice-engine is still pinned to upstream v0.7.1** while the v0.8.0 runtime is in the fork — its 8
+  numbered patches + fp8 product patches are the v0.7.1 encoding of features that are now native in v0.8.0.
+- **Three worker source copies** of the same concept: fork `examples/omni/qwen3_tts_streaming_worker.cpp`,
+  jetson-voice-engine `native/edgellm_voice_worker/*`, and seeed `deploy/asr-worker-v080/qwen3_asr_worker.cpp`.
+- **Two-layer ABCs**: seeed `server/core/{asr,tts}_backend.py` define facade ABCs that resolve into voxedge's
+  impl-base ABCs in `backends/base.py` — intentional but a dedup candidate.
+- **RK asymmetry**: jetson/cpu backends are static `(module,class)` tuples in the registry; RK is resolved only
+  via `build_rk_*_config` + a dedicated `rk_runtime`/`voxedge.backends.rk` path — normalize during consolidation.
+
+## Methods / tools used
+- Python (projects 1,2): stdlib `ast` via a custom extractor (`/tmp/ast_extract.py`) — class bases + method
+  signatures + import edges. (griffe/pydeps not needed; stdlib ast sufficed.)
+- C++ (project 3): **no libclang and no universal-ctags on host** (only BSD ctags) → header declaration parsing
+  (regex over class/struct/method decls) + CMake target reading. Stated per guardrails.
+- Refs confirmed with `git branch -a` + `git log --oneline`; trees read at-ref via `git archive | tar -x`
+  into `/tmp/edge-voice-src/` (working tree never switched).

--- a/docs/plans/voxedge-v080-consolidation/competitor-research.md
+++ b/docs/plans/voxedge-v080-consolidation/competitor-research.md
@@ -1,0 +1,272 @@
+# 同类开源项目传播打法复盘 — VoxEdge 发布传播规划
+
+> 目的：为边缘端侧实时语音 AI 开源栈 **VoxEdge**（定位锚点 "Pipecat for the edge"）的发布传播做竞品打法复盘。
+> 方法：WebSearch / WebFetch，优先官方 README / 项目博客 / 一手讨论帖（Show HN / Reddit / X）。
+> 体例：严格区分 **【事实】**（带来源 URL）与 **【推测】**（基于事实的归纳）。检索不到的项已如实声明，未编造。
+> 抓取时间：2026-06。star 数为当日 GitHub 显示值，随时间变化。
+
+VoxEdge 背景（用于判断哪些打法可迁移）：面向边缘设备（Jetson / Rockchip / 树莓派）的开源实时语音 AI 栈 —— 端侧、低延迟、可对话（ASR→LLM→TTS + 打断 + 轮次）、多后端、自带量化（int4/fp8）、开箱即用应用（含机械臂语音控制 demo）。受众两层：①系统/算法开发者（看性能 + 多后端）②应用开发者（看一键部署 + SDK + demo）。
+
+---
+
+## 一、逐项目分析
+
+### 1. Pipecat（pipecat-ai/pipecat）— 最直接对标 ★最高权重
+
+**一句话**：实时语音 & 多模态 AI agent 的 Python 框架，自比 "LangChain/LlamaIndex for 对话 AI"。
+
+- **定位 / tagline**：【事实】README 逐字 "🎙️ Pipecat: Real-Time Voice & Multimodal AI Agents"；官网 "Open source framework for voice and multimodal conversational AI." + "Supported by the Pipecat community and the **Daily.co** engineering team."；Show HN 标题更朴素 "An open source framework for voice assistants"。
+- **首屏结构**：【事实】badges 齐全（PyPI/Tests/codecov/Docs/Discord/DeepWiki）+ 4 张**示例项目截图**（chatbot / storytelling / 多语翻译 / vision）+ 一行 quickstart `pipecat create quickstart` / `uv add pipecat-ai` + "What You Can Build" / "Why Pipecat?" 段。**首屏无性能数字、无架构图、无在线 playground**。【推测】走"示例驱动 + 一行装"，刻意不打 benchmark。
+- **发布渠道与节奏**：【事实】首发 = Show HN，**346 分 / 39 评论**（HN #40345696）；由 Daily（2016 起做实时音视频基础设施的公司）开发并背书；第二曲线 = 登上 NVIDIA build 平台、NVIDIA 官方维护 `NVIDIA/voice-agent-examples`（基于 Pipecat）。星数 ~12.9k。【推测】节奏 = Show HN 首爆 → Daily 持续投入 + GPT-4o 语音热度 → NVIDIA 联名第二曲线。
+- **demo 形态**：【事实】4 张示例截图 + 一行起一个可跑语音 agent；无在线 playground / 病毒视频。【推测】wow = "几行代码跑起一个能打断、能换 LLM 的实时语音 agent"的可复现性；多模态翻译 / vision 是差异化亮点。
+- **驱动传播的关键**：【事实】一行装 + 一行 quickstart；最大卖点 = **service swapping**（热插拔几乎所有主流 STT/LLM/TTS/Transport/VAD）；接管脏活（低延迟传输、回声消除、VAD、phrase endpointing、打断）。【推测】护城河 = Daily 多年音视频基础设施能力外溢。
+- **messaging 套路**：【事实】类比锚（核心招）"a LlamaIndex or LangChain for real-time/conversational AI"；用**好玩场景列举**替代抽象（"story-telling toys for kids, virtual friends, snarky social bots"）。【推测】不打"比 X 快 N%"，用"LangChain for 语音 + 好玩场景 + 接管脏活"组合拳，差异化对位托管服务（Vapi/Retell）。
+
+> **对 VoxEdge 的意义**：这是直接对标。Pipecat 占住了"云/服务器侧的语音 agent 框架"。VoxEdge 的 "Pipecat for the edge" 锚点正好填它的空白 —— Pipecat 几乎全是云 API 后端（Deepgram/Cartesia/OpenAI），**端侧/本地/量化是 VoxEdge 可以独占的对比维度**。
+
+---
+
+### 2. LiveKit Agents（livekit/agents）
+
+**一句话**：构建实时语音 AI agent 的开源框架（背靠开源 WebRTC 媒体服务器）。
+
+- **定位 / tagline**：【事实】README 逐字 "A framework for building realtime voice AI agents 🤖🎙️📹"；官网更宽 "Build voice, video, and physical AI agents"。
+- **首屏结构**：【事实 README】多 badge + 一行带 extras 安装 `pip install "livekit-agents[openai,deepgram,cartesia]"`（一条命令打包三供应商）；首屏未见 demo/架构图。【事实 landing】**客户 logo 墙**（OpenAI / xAI / Salesforce / Headspace）+ 醒目语 "OpenAI built ChatGPT's Advanced Voice on LiveKit Cloud"+ 规模数字 "1000ms Global latency"、"2,500,000,000+ Calls annually" + 钩子 "1,000 free agent session minutes monthly"。
+- **发布渠道与节奏**：【事实】首发 = Show HN，标题逐字 **"Show HN: Open source framework OpenAI uses for Advanced Voice"**，作者为联创 Russ d'Sa，**266 分 / 80+ 评论**（HN #41743327, 2024-10-04）；节奏 = 官博发 OpenAI 合作声明（10-03）→ 次日 Show HN 引爆。星数 agents ~11.1k / 主仓 livekit ~19.3k。融资 Series B $45M，10 万+ 开发者，30 亿+ calls/年。
+- **demo 形态**：【事实】官方托管 playground / sandbox + Agents UI，浏览器直接体验；wow = "和 ChatGPT 一样的实时语音体验"（~300ms 打断、自动 turn detection、内置降噪 / 背景人声过滤）。
+- **驱动传播的关键**：【事实】**杀手级背书 = ChatGPT Advanced Voice 跑在 LiveKit 上**（最大驱动）；一条命令安装；生态钩子（turn detection / 降噪 / SIP 电话栈 / MCP / 全平台 client SDK / Realtime API 封装）；全栈可自托管。【事实】HN 反驳点 = 质疑是否同款模型、纯后端是否真需 WebRTC、OpenAI 可能自研脱钩 —— **"借势 OpenAI"是双刃剑**。
+- **messaging 套路**：【事实】"同款技术"平权叙事（"the same stack that underpins Advanced Voice"）+ **用客户名当标题**（Show HN 不写产品名直接写 "OpenAI uses"，最锋利一招）+ 量化权威 + 社会价值（"1/4 of US 911 dispatch centers"、"saves at least one life every week"）。
+
+> **对 VoxEdge 的意义**：LiveKit 证明"用一个权威客户/合作方名字当标题"杠杆极高。VoxEdge 没有 OpenAI，但有 **Seeed（硬件生态）+ 真实机械臂 demo + 真实设备型号（Jetson/RK/Pi）** 可作为可信度锚。教训：别过度依赖单一外部背书。
+
+---
+
+### 3. ollama（ollama/ollama）— "本地 AI 一条命令跑"的范本
+
+**一句话**："本地跑大模型的 Docker" —— `curl | sh` 装好、`ollama run <model>` 即拉即跑。
+
+- **定位 / tagline**：【事实】当前 README "Start building with open models."；官网 "The easiest way to build with open models" + "Get up and running ... in minutes"；最初 Show HN（2023-07）= **"Run LLMs on your Mac"**（本地工具定位）。【推测】定位从"在你 Mac 上本地跑"演进到"用开源模型 build / 平台 + 云"。
+- **首屏结构**：【事实】logo + 一行 quickstart `ollama run <model>` + curl 安装一行 + OpenAI-compatible REST API（端口 11434）+ 模型库；**首屏无 demo / 无跑分 / 无架构图 / 几乎无 badge（反炫技）**；官网把"一行 curl 命令"做成首屏唯一视觉焦点。星数 ~175k。
+- **发布渠道与节奏**：【事实】Show HN 首发 2023-07-20 "Ollama – Run LLMs on your Mac"（HN #36802582）；团队来自 Docker、YC 校友；增长 = 月下载从 2023 约 10 万 → 2026 约 5200 万（约 520×），2024 ROSS Index 增长最快开源 AI 项目。【推测】Llama 支持 + Windows 版常被视为破圈节点（r/LocalLLaMA 高频传播）。
+- **demo 形态**：【事实】无视频 / playground；wow = 终端**一条命令把数 GB 模型拉下并立刻对话**。HN 用户原话 "Within a minute of seeing your README, I decided that this would be easy enough to experiment with."
+- **驱动传播的关键**：【事实】一行 curl 安装 + 模型库即拉即跑 + **OpenAI-compatible REST API**（生态融入）+ Docker 式 UX（`run`/`pull` + Modelfile 仿 Dockerfile）。【推测】护城河 = "把熟悉的 Docker 工作流直接搬到 LLM"，零学习成本，是相对 llama.cpp 破圈的关键。
+- **messaging 套路**：【事实】核心 analogy = **"Docker for LLMs"**（创始人真有 Docker 背景，命令语义 pull/run/Modelfile 真同构，可信度高）+ 极致简洁承诺（"easiest" / "in minutes" / 一行命令）。
+
+> **对 VoxEdge 的意义**：ollama 是"一行命令"的天花板范本。VoxEdge 的一键部署若能做到 `curl | sh` 或 `docker compose up` 级别的简洁，且把这条命令做成首屏唯一焦点，就抓住了最强钩子。**OpenAI-compatible API 的生态融入策略也可直接复用**（VoxEdge 已自带兼容 API 思路）。
+
+---
+
+### 4. whisper.cpp + faster-whisper — 端侧/优化 ASR（一对，相反路线）
+
+> 同一母体（OpenAI Whisper）的两个再实现，走**完全相反的起量路线**：whisper.cpp 靠"跑在 iPhone 上"的**设备奇观**病毒传播；faster-whisper 靠"同精度快 4 倍"的**硬核 benchmark 表**在工程圈口碑扩散。
+
+**4A. whisper.cpp**
+- **定位**：【事实】README "High-performance inference of OpenAI's Whisper ASR model"；Show HN 标题 "Port of OpenAI's Whisper model in C/C++"。
+- **首屏**：【事实】信息密度极高 —— 多个**嵌入 demo 视频**（iPhone 13 mini 实时转写 / Metal 加速 / 语音指令）+ 一行 quickstart + 多 badge + **内存/磁盘需求表** + 平台示例矩阵（iOS/Android/WASM）。无架构图。
+- **渠道节奏**：【事实】2022-12-07 Show HN 首发 **399 分 / 87 评论**（HN #33877893）；后续版本（v1.4.0、浏览器 WASM）持续上 HN。星数 ~50.9k。
+- **demo / wow**：【事实】录屏视频为主 + 浏览器内可玩 WASM demo；wow = Whisper **完全离线在 iPhone 上实时跑**。
+- **驱动 / messaging**：【事实】①零依赖（"两个文件" vs PyTorch/CUDA 安装地狱）②极简可读（<8000 行）③设备覆盖广即装即用（"Got it going in 1 min!"）；**把对手的复杂当卖点**（"no PyTorch baggage / two files, zero deps"）+ "runs on X device" + Apple Silicon 原生优化。
+
+**4B. faster-whisper**
+- **定位**：【事实】README "Faster Whisper transcription with CTranslate2"。
+- **首屏**：【事实】标题后紧跟断言 "**up to 4 times faster than openai/whisper for the same accuracy while using less memory**" + **三张 benchmark 对比表**（横向对 openai/whisper、whisper.cpp、transformers、各量化档）+ 一行 `pip install`。**无 demo / 无视频 / 无架构图** —— 对比表是唯一主视觉。
+- **渠道节奏**：【事实】作者 Guillaume Klein（OpenNMT/SYSTRAN 背景），PyPI 0.2.0 = 2023-03-22，后迁入 SYSTRAN org，星数 ~23.8k。【未证实】无明确 Show HN / Reddit 首发病毒帖。【推测】靠 PyPI + README + 工程口碑自然扩散，成为 WhisperX / 字幕工具默认后端。
+- **demo / wow**：【事实】无 demo；wow = **数字本身**（4x faster / 同精度 / 13min→17s with batch=8）。
+- **驱动 / messaging**：【事实】可信 benchmark 表 + `pip install` 即插即用 + drop-in 替换 openai-whisper；"数字驱动 / 工程师说服工程师"，锚点是 openai/whisper。
+
+> **对 VoxEdge 的意义**：这一对教科书级地展示了 VoxEdge 的**两层受众正好对应两条路线**：①应用开发者 ← whisper.cpp 式"在树莓派/Jetson 上离线实时跑"的设备奇观录屏；②系统/算法开发者 ← faster-whisper 式"同质量快 N 倍 / 显存省一半"的硬核对比表。VoxEdge 应**两条都做**。
+
+---
+
+### 5. llama.cpp — 端侧 LLM 推理（性能 + 多平台叙事）
+
+**一句话**：LLM inference in C/C++，纯 C/C++ 零依赖、4-bit 量化在普通硬件本地跑。
+
+- **定位**：【事实】当前 README 逐字 "LLM inference in C/C++"；历史最具传播力定位 = "run the model using **4-bit quantization on a MacBook**" + 自嘲 "This was hacked in an evening - I have no idea if it works correctly."
+- **首屏**：【事实】badge + 一行 quickstart（`llama-cli -hf ...` / `llama-server -hf ...`）+ **庞大后端矩阵**（Metal/CUDA/HIP/Vulkan/SYCL/OpenVINO/WebGPU/CANN/Hexagon…）+ "Apple silicon is a first-class citizen"。首屏无 demo / 无架构图。
+- **渠道节奏**：【事实】2023-03-10 首发（作者 Georgi Gerganov，源自 whisper.cpp 思路）；同日 Simon Willison 发 M2 MacBook 跑 LLaMA 的一手 TIL；**单个病毒帖** = HN "Llama.cpp 30B runs with only 6GB of RAM now"（2023-03-31，**1311 分 / 414 评论**，mmap 优化）。星数 2026 超 109k（号称最快达 100k 的开源 AI 项目）。
+- **demo / wow**：【事实/推测】wow 不是自带 playground，而是**第三方一手体验帖**（Simon Willison "this has absolutely blown me away…"）+ **极致省内存炫技**（30B 进 6GB）；官方 demo = 一行命令 + `llama-server` 自带本地 web UI。
+- **驱动 / messaging**：【事实】零依赖纯 C/C++ 一行构建 + killer "runs on X device"（MacBook 首发即爆）+ **性能/内存工程本身成为内容**（4-bit + mmap）+ 广平台支持 + **生态护城河 = ggml + GGUF 格式**（成为 Ollama / LM Studio 几乎所有本地推理工具的核心）；messaging = "runs on your laptop/phone/Pi" + 谦逊自黑 + 反直觉硬数字钩子（"30B with only 6GB"）。
+
+> **对 VoxEdge 的意义**：①"把性能/内存工程做成可分享内容"（反直觉硬数字钩子）对 VoxEdge 的 int4/fp8 量化故事极其适用 —— 例如"在 8GB Jetson 上端到端语音对话 < Xms"这种数字钩子。②谦逊自黑的语气在工程社区比夸大更可信。
+
+---
+
+### 6. sherpa-onnx（k2-fsa）— 端侧语音，多平台（广度驱动）
+
+**一句话**："下一代 Kaldi"生态里**全栈、纯离线、跑遍一切硬件**的端侧语音引擎（ASR/TTS/说话人/VAD）。
+
+- **定位**：【事实】README "Speech-to-text, text-to-speech, speaker diarization, ... and VAD using **next-gen Kaldi** with onnxruntime **without Internet connection**."；文档站把"离线"放第一位（"Everything is processed locally on your device"）。锚点 = next-gen Kaldi（权威继承）+ 离线/隐私。
+- **首屏**：【事实】**"能力 × 平台 × 语言三张矩阵铺满"型** —— 功能勾选表 + 架构×OS 矩阵（含 RISC-V / 各家 NPU RKNN/QNN/Ascend/Axera）+ 12 种语言绑定（C++/Python/JS/Java/C#/Kotlin/Swift/Go/Dart/Rust/Pascal + WASM）+ 多个 HF Space 链接 + 预编译 APK 下载表。**无显眼 demo 视频 / 无首屏 benchmark / 无一行 quickstart / 无架构图**。
+- **渠道节奏**：【事实】隶属 Next-gen Kaldi / k2-fsa 生态；社区渠道偏中文（WeChat/QQ/Bilibili）；**发布极高频（约每 1–2 周一个 release）**；多渠道分发（PyPI/npm/NuGet/SourceForge/HF）。星数约 11k–13k。【推测】无单一病毒帖；增长是"高频迭代 + 多语言绑定 + 中文社区渗透"的复利型。
+- **demo / wow**：【事实】主力 = **Hugging Face Spaces 在线 playground** + 预编译 APK 直接下载；wow = "浏览器（WASM）/ 树莓派 / 安卓 / iOS 离线实时跑"，WASM-in-browser 最直接（无需安装即证明端侧可行）。
+- **驱动 / messaging**：【事实】①极广平台/架构/NPU 覆盖 ②12 种语言绑定 ③纯离线 ④预编译产物 + 在线 playground ⑤"Next-gen Kaldi"品牌背书；messaging = **支持矩阵即主视觉**（广度本身就是卖点）+ "runs everywhere / no internet needed"。
+
+> **对 VoxEdge 的意义**：sherpa-onnx 是 VoxEdge **最像的功能竞品**（端侧语音、多平台、覆盖 Jetson/RK/Pi/NPU）。但 sherpa 是"组件库 / 引擎"，**不是"可对话的 agent 栈"（无 LLM、无打断、无轮次、无开箱即用对话应用）**。这正是 VoxEdge 的差异化：**sherpa 给你积木，VoxEdge 给你一个能直接对话、能打断的成品语音 agent**。可借鉴它的"支持矩阵即主视觉" + 在线 playground/预编译产物，但要避免它"只是组件库、传播复利慢、无爆点"的局限。
+
+---
+
+### 7. Moshi / Kyutai（kyutai-labs/moshi）
+
+**一句话**：能同时听和说的实时语音基础模型（full-duplex 语音 LLM）。
+
+- **定位**：【事实】README "Moshi: a **speech-text foundation model** for real time dialogue" + "full-duplex spoken dialogue framework ... uses Mimi, a streaming neural audio codec."
+- **首屏**：【事实】badges + 三核心链接（arXiv / **Live demo at moshi.chat** / HF）+ **架构图** + **性能数字**（理论 160ms 延迟，L4 实测 ~200ms）+ 三套实现并列（PyTorch 研究 / MLX 端侧 / Rust 生产）。
+- **渠道节奏**：【事实】2024-07-03 巴黎线下发布会 + 同日开放在线 demo；**病毒节点 = Yann LeCun 在 X 转发**（大佬背书）；多条 HN 帖（160ms live demo / 能表达情绪）；节奏 = 7 月先开 demo 造势 → 9 月才正式开源放代码权重（分两波）。星数 ~10.4k。
+- **demo / wow**：【事实】"Talk to Moshi now" —— 浏览器里**直接和它实时对话、可被打断、表达情绪**（不是看视频，是亲自说话）。这是核心 wow。
+- **驱动 / messaging**：【事实】**live demo（亲自试）> 一切** + 大佬背书 + 对标 GPT-4o 语音（当时 GPT-4o 语音尚未开放，抢"先能真用"窗口）；造词（"full-duplex" / "inner monologue"）+ 故事化（"八名研究员六个月"）。媒体起的 "GPT-4o killer" 标题传播力强（非官方）。
+
+> **对 VoxEdge 的意义**：①"亲自试 > 看视频"是最强 demo 形态；VoxEdge 端侧难做在线 playground，但**机械臂语音控制的现场/视频 demo 是 Moshi 同级的 wow**（物理世界的实时反馈比纯语音更震撼）。②延迟数字进首屏（160ms）是这赛道通用钩子。
+
+---
+
+### 8. RealtimeSTT + RealtimeTTS + RealtimeVoiceChat（KoljaB）— 独立开发者范本
+
+> 一组由独立开发者 KoljaB 维护的项目：两个底层库（成对）+ 一个应用层 demo。**RealtimeVoiceChat 的 Show HN 524 分**是这一生态最强单点信号，且与 VoxEdge 形态最接近。
+
+**8A. RealtimeSTT / RealtimeTTS**：【事实】定位 = "低延迟实时 STT/TTS Python 库"；首屏 = 内嵌短 demo 视频 + 一行 `pip install` + 5 行最小示例（无性能表 / 无架构图）；星数 STT ~9.9k / TTS ~4k；**镜像配对话术**（两库互相在 README 指认对方，形成"成套"心智）。
+
+**8B. RealtimeVoiceChat（KoljaB/RealtimeVoiceChat）**（与 VoxEdge 形态最接近）：
+- **定位**：【事实】"Have a natural, spoken conversation with AI!"
+- **首屏**：【事实】内嵌演示视频 + **七步流水线架构图**（capture→stream→transcribe→think→synthesize→return→打断）+ **Docker 一键** `docker compose up -d` + 浏览器 `localhost:8000`；可插拔后端（默认 Ollama）。
+- **渠道节奏**：【事实】2025-05 **Show HN: "Real-time AI Voice Chat at ~500ms Latency"，524 分 / 39 评论**（HN #43899028）+ 配套 YouTube 视频。星数 ~3.8k。
+- **wow / 驱动**：【事实】可打断、~500ms 回话的自然对话；**标题里硬延迟数字（~500ms）** + 一键 Docker 跑本地 + **第一人称痛点叙事**（"I built this because I was frustrated with the latency…"）。
+
+**8C. Willow（HeyWillow/willow）— 端侧硬件语音助手范本**：
+- 【事实】定位 = "Open source, local, and self-hosted **Amazon Echo/Google Home competitive** Voice Assistant alternative"；官网四大数字卖点（<500ms 响应、低误触发、<1% 失败率、完全隐私）+ ~$50 现成硬件（ESP32-S3-BOX）；两次 Show HN 接力（2023-05 "privacy-focused" / 2023-10 "fastest and most private"）。星数 ~3.1k。
+- 【事实】messaging = "X 的开源替代"对标锚（Echo/Home）+ **超越式对比**（"Response times faster than Alexa/Echo ... 500ms or less"，反转"开源=慢"的预期）+ 可信度数字（"<1% failure rate"）。
+
+> **对 VoxEdge 的意义**：①RealtimeVoiceChat 是**最可直接照搬的模板** —— 延迟数字进标题 + 流水线架构图 + `docker compose up` 一键 + 第一人称痛点。VoxEdge 比它强的地方（多设备 NPU / 量化 / 机械臂）正好是差异化。②Willow 证明"对标巨头 + 隐私 + 速度反转 + 可买的廉价硬件"在边缘语音赛道有效。
+
+---
+
+## 二、跨项目共性成功要素（top 7，可迁移到 VoxEdge）
+
+1. **首发主战场 = Show HN，标题里放可量化的钩子**。Pipecat 346 / LiveKit 266 / whisper.cpp 399 / llama.cpp 1311 / RealtimeVoiceChat 524 —— 全部靠 Show HN 起量。最有效的标题模板：**「数字 + 对标 / 设备」**（"~500ms Latency"、"30B runs with only 6GB"、"OpenAI uses for Advanced Voice"、"Run LLMs on your Mac"）。
+
+2. **"X for Y" 类比锚是最高杠杆的一句话定位**。"Docker for LLMs"（ollama）、"LangChain for 语音"（Pipecat）、"next-gen Kaldi"（sherpa）。VoxEdge 已有现成锚 "**Pipecat for the edge**" —— 直接用。
+
+3. **"亲自试" > "看视频" > "读文档"**。降低"亲自试"门槛是核心：在线 live demo（Moshi 最强）→ 一行 `curl|sh` / `pip install`（ollama / faster-whisper）→ `docker compose up`（RealtimeVoiceChat）→ 预编译产物 + HF Space（sherpa）。VoxEdge 至少要做到 `docker compose up` 一键。
+
+4. **"runs on X device" 设备奇观是端侧赛道独有的爆点**。whisper.cpp 的 iPhone、llama.cpp 的 MacBook、Willow 的 $50 硬件 —— "它居然能在这么便宜/小的东西上跑"是端侧最强情绪触发。VoxEdge 的 Jetson/RK/Pi + **机械臂** 是天然弹药。
+
+5. **两类内容并行打两层受众**：①**设备奇观录屏 / 现场 demo**（打应用开发者，情绪驱动）②**硬核 benchmark 对比表**（打系统/算法开发者，数字驱动）。whisper.cpp vs faster-whisper 正好是这两条路线的范本，VoxEdge 应两条都做。
+
+6. **生态融入 / 兼容标准是长期护城河**。OpenAI-compatible API（ollama）、GGUF 事实标准（llama.cpp）、成为下游默认后端（faster-whisper）、多语言绑定（sherpa）。VoxEdge 的 OpenAI-compatible 思路 + 多后端可插拔要在首屏强调。
+
+7. **可信度信号 > 营销辞藻**：真实客户名 / 合作方（LiveKit 借 OpenAI）、可复现的硬数字（延迟 / 显存 / star 里程碑）、谦逊自黑的工程语气（llama.cpp "hacked in an evening"）、支持矩阵（sherpa 广度即可信）。避免空泛形容词。
+
+---
+
+## 三、对 VoxEdge 的可执行建议
+
+### 3.1 一句话定位候选
+- **主用**：`VoxEdge — Pipecat for the edge.`（已有锚点，直接用作 tagline 副标）
+- README headline 候选：
+  - "🎙️ VoxEdge: Real-Time Voice AI Agents, **fully on-device** (Jetson · Rockchip · Raspberry Pi)"
+  - 一句话自述："An open-source real-time voice agent stack (ASR→LLM→TTS, with barge-in & turn-taking) that runs **fully offline on edge devices** — int4/fp8 quantized, multi-backend, batteries included."
+- 对比锚点话术（可选，工程圈有效）："Pipecat-style composability, but **local-first** — no cloud APIs, no per-minute billing, runs on a $200 Jetson."
+
+### 3.2 首屏 README 应该放什么（按优先级排）
+1. **一行 emoji headline + "Pipecat for the edge" 副标**。
+2. **一条延迟硬数字 + 设备名**（最强钩子）：如 "End-to-end voice loop in <XXX ms on a Jetson Orin Nano (8GB)"。先把这个数字测准（参考记忆里的真机数据）。
+3. **demo GIF/视频置顶** —— 机械臂语音控制的录屏（端侧赛道最稀缺的 wow，见 3.4）。
+4. **一行 quickstart**（`docker compose up` 或脚本一行），做成首屏视觉焦点（学 ollama）。
+5. **支持矩阵表**（设备 × 后端 × ASR/LLM/TTS），学 sherpa —— 广度即可信度，也直接服务"我的设备支持吗"这个第一疑问。
+6. badges（CI / license / Discord / PyPI）。
+7. **"What you can build" 场景列举**（学 Pipecat：语音助手 / 机械臂控制 / 离线翻译机 / 玩具），用具体场景替代抽象。
+> **首屏不要放**：长篇架构图（移到第二屏）、空泛的"为什么选我们"段。
+
+### 3.3 首发渠道与顺序
+1. **Show HN 为主战场**。标题模板二选一：
+   - 设备奇观式：`Show HN: VoxEdge – real-time voice AI agents running fully on-device (Jetson/RPi)`
+   - 数字式：`Show HN: Open-source voice agent stack with <XXXms end-to-end latency on a $200 edge device`
+   - 第一人称痛点开场（学 RealtimeVoiceChat 首评）："I was frustrated that every voice agent framework assumes cloud APIs / per-minute billing — so I built one that runs entirely on the edge…"
+2. **Reddit 同步**：r/LocalLLaMA（核心受众）、r/selfhosted（隐私/本地）、r/robotics（机械臂 demo）、r/raspberry_pi & r/JetsonNano（设备社区）。
+3. **X / 视频**：机械臂 demo 短视频，配延迟数字；争取硬件/边缘 AI 圈 KOL 转发（学 Moshi 的 LeCun 杠杆，VoxEdge 可借 Seeed 生态 + NVIDIA Jetson 社区）。
+4. **第二曲线**：争取出现在 NVIDIA Jetson 社区 / Seeed wiki / Awesome-edge-AI 列表（学 Pipecat 的 NVIDIA 联名）。
+5. **节奏**：先憋一个能"亲自试"的一键 demo + 一条过硬延迟数字，再 Show HN；发布后用"每个新设备/新后端配一条 demo"维持二次传播（学 whisper.cpp/sherpa 的高频小爆点）。
+
+### 3.4 demo 视频该怎么拍（机械臂端侧实时这个 wow）
+- **核心 wow = 物理世界的实时闭环**：人说话 → 机械臂立即动 → 全程无网络（拔网线 / 飞行模式入镜，强化"端侧离线"）。这是 sherpa/Pipecat/RealtimeVoiceChat 都给不出的差异点。
+- 一镜到底、真实延迟、不剪加速；**屏幕角落叠加实时延迟计时**（学 RealtimeVoiceChat / Moshi 把延迟可视化）。
+- 演示**打断（barge-in）**：人中途插话，机械臂立即停 —— 打断是实时语音的"高难技巧炫技点"。
+- 入镜真实廉价硬件 + 型号牌（"running on Jetson Orin Nano, $XXX"），复刻 whisper.cpp/Willow 的"它居然在这上面跑"。
+- 30–60 秒主视频（README + Show HN 置顶）+ 一个 2–3 分钟"how it works"长版（含 `docker compose up` 复现）。
+
+### 3.5 对比 / benchmark 怎么呈现（打系统/算法受众）
+- 做一张 **faster-whisper 式对比表**：横轴 = 同设备上 VoxEdge（int4/fp8） vs 全精度 vs 云方案；纵轴 = 端到端延迟 / 首字延迟(TTFA) / 显存 / 是否离线 / 每分钟成本。
+- 关键对比维度（VoxEdge 独占优势）：**"$0/min 离线" vs 云 API 的 per-minute 计费**（学 LiveKit HN 上对手被质疑的点，反过来用）。
+- 给一张 **支持矩阵**（设备 × 后端），广度本身是卖点（学 sherpa）。
+- 数字必须**真机实测、可复现**（附复现命令），工程社区会验证 —— 别信合成数字（与项目内部 perf 纪律一致）。
+
+### 3.6 两层受众分别的钩子
+| 受众 | 钩子 | 落点 |
+|---|---|---|
+| 系统/算法开发者 | 延迟/显存对比表、int4/fp8 量化故事、多后端可插拔、真机可复现 benchmark | README 第二屏 + Show HN 技术讨论 + r/LocalLLaMA |
+| 应用开发者 | `docker compose up` 一键、机械臂 demo 视频、SDK + "what you can build" 场景、OpenAI-compatible API | README 首屏 + demo 视频 + r/selfhosted / r/robotics |
+
+---
+
+## 四、反面教训（哪些传播平平 / 踩坑，为什么）
+
+1. **sherpa-onnx：功能最强但无爆点，复利型慢热**。原因：①定位是"组件库/引擎"而非"成品",缺一个"亲自试就上瘾"的杀手 demo；②首屏是密集矩阵、无 quickstart、无 demo 视频，对新人不友好；③社区偏中文、无 Show HN 爆款，英文圈渗透弱。**VoxEdge 要避免变成"又一个组件库"** —— 必须以"可对话的成品 agent + 机械臂 wow"破局，并补英文圈 Show HN/Reddit 首发。
+
+2. **faster-whisper：质量极高但缺人格化传播**。无 demo、无首发病毒帖、纯靠口碑，结果"墙内开花"——被大量下游用却不为人知（星数远低于功能相近的 whisper.cpp）。**教训：光有硬数字不够，要主动做首发 + 配一个能看的 demo**。
+
+3. **LiveKit：借势 OpenAI 是双刃剑**。HN 上即被质疑"是否同款模型 / OpenAI 可能自研脱钩"。**教训：可借外部背书放大，但护城河叙事要落在自己的能力（VoxEdge = 边缘性能工程 + 量化 + 多设备），别把身家押在单一合作方名字上**。
+
+4. **过度依赖单条病毒帖 = 不可复制**。Moshi/llama.cpp 的爆发有大佬背书/时机红利成分。**教训：VoxEdge 应建"可重复的小爆点机制"（每设备/每后端一条 demo + 高频 release），而非赌一次大爆**（学 whisper.cpp / sherpa 的高频节奏，但补 sherpa 缺的 demo 与 quickstart）。
+
+5. **首屏放架构图 / 空泛卖点会劝退**。几乎所有高传播项目首屏都不放大架构图，放的是 quickstart + demo + 矩阵。**教训：架构图移到第二屏，首屏只留"一句话定位 + 一个数字 + 一个 demo + 一行命令"**。
+
+---
+
+## 五、交付速览
+
+### ① 每个项目一行速览（定位 + 起量关键）
+- **Pipecat**：实时语音 agent 框架（"LangChain for 语音"）；起量 = Daily 背书 + Show HN 346 + 任意 STT/LLM/TTS 热插拔 + NVIDIA 联名第二曲线。
+- **LiveKit Agents**：实时语音 agent 框架（背靠 WebRTC）；起量 = 借势 OpenAI（"OpenAI 用的那套"当 Show HN 标题）+ 客户 logo 墙 + 规模数字。
+- **ollama**：本地跑 LLM 的 Docker；起量 = Docker 心智平移 + 一行 `curl|sh` 极致简洁 + OpenAI-compatible API + r/LocalLLaMA 复利。
+- **whisper.cpp**：纯 C/C++ 零依赖端侧 Whisper；起量 = Show HN 399 + "iPhone/Pi/浏览器离线跑"的设备奇观 demo + "两个文件零依赖"对立锚。
+- **faster-whisper**：CTranslate2 版 Whisper（同精度快 4x）；起量 = 首屏硬核 benchmark 对比表 + pip 即插即用 + 成为下游默认后端（但缺 demo、慢热）。
+- **llama.cpp**：LLM inference in C/C++；起量 = "MacBook 上跑 LLaMA"一手 wow + "30B/6GB"省内存爆款帖 + GGUF 生态事实标准。
+- **sherpa-onnx**：next-gen Kaldi 全栈离线端侧语音引擎；起量 = "跑遍一切硬件"支持矩阵 + HF/WASM playground + 高频 release（复利型，无单一爆点）。
+- **Moshi/Kyutai**：full-duplex 实时语音基础模型；起量 = 浏览器 live demo（亲自对话）+ LeCun 背书 + 对标 GPT-4o 语音的时机窗口。
+- **RealtimeVoiceChat（+STT/TTS）**：本地实时语音对话全栈 demo；起量 = "~500ms 延迟"进 Show HN 标题（524 分）+ `docker compose up` 一键 + 第一人称痛点叙事。
+- **Willow**：开源本地语音助手硬件；起量 = "Echo/Home 开源替代 + 比商业产品还快 + $50 现成硬件 + 隐私"双锚点，两轮 Show HN。
+
+### ② top 7 共性成功要素
+1. Show HN 首发 + 标题放可量化钩子（数字/对标/设备）。
+2. "X for Y" 类比锚一句话定位。
+3. 降低"亲自试"门槛（live demo > 一行命令 > docker up）。
+4. "runs on X device" 设备奇观（端侧独有爆点）。
+5. 两类内容并行打两层受众（设备奇观录屏 + 硬核 benchmark 表）。
+6. 生态融入/兼容标准做长期护城河（OpenAI-compatible API / 多后端 / 多绑定）。
+7. 可信度信号 > 营销辞藻（真客户名、可复现硬数字、谦逊工程语气、支持矩阵）。
+
+### ③ 对 VoxEdge 的可执行建议清单
+- **首屏**：emoji headline + "Pipecat for the edge" 副标 → 一条延迟硬数字+设备名 → 机械臂 demo 视频置顶 → 一行 `docker compose up`（视觉焦点）→ 设备×后端支持矩阵 → "what you can build" 场景。架构图移第二屏。
+- **渠道顺序**：Show HN（标题用"延迟数字 / 设备奇观"+ 第一人称痛点开场）→ 同步 r/LocalLLaMA + r/selfhosted + r/robotics + 设备社区 → X 机械臂短视频争取 Jetson/Seeed KOL 转发 → 进 NVIDIA Jetson / Awesome 列表第二曲线 → 用"每设备/每后端一条 demo"维持复利。
+- **demo**：一镜到底拍"说话→机械臂立即动→全程离线（拔网线入镜）"，叠加实时延迟计时，演示打断，入镜真实硬件型号牌；30–60s 主视频 + 2–3min how-it-works 长版。
+- **messaging**：主锚 "Pipecat for the edge"；差异化对比 "local-first, $0/min, runs on a $200 Jetson"；benchmark 用 faster-whisper 式对比表（含离线/每分钟成本维度，真机可复现）；两层受众用上表分别投放。
+
+### ④ 关键来源 URL
+**Pipecat**：https://github.com/pipecat-ai/pipecat ; https://www.pipecat.ai/ ; https://news.ycombinator.com/item?id=40345696 ; https://build.nvidia.com/pipecat/voice-agent-framework-for-conversational-ai ; https://github.com/NVIDIA/voice-agent-examples
+**LiveKit Agents**：https://github.com/livekit/agents ; https://livekit.com/ ; https://livekit.com/blog/openai-livekit-partnership-advanced-voice-realtime-api/ ; https://news.ycombinator.com/item?id=41743327 ; https://livekit.com/blog/livekits-series-b/
+**ollama**：https://github.com/ollama/ollama ; https://ollama.com ; https://news.ycombinator.com/item?id=36802582 ; https://news.ycombinator.com/item?id=36808754 ; https://en.wikipedia.org/wiki/Ollama
+**whisper.cpp / faster-whisper**：https://github.com/ggml-org/whisper.cpp ; https://news.ycombinator.com/item?id=33877893 ; https://github.com/SYSTRAN/faster-whisper ; https://pypi.org/project/faster-whisper/
+**llama.cpp**：https://github.com/ggml-org/llama.cpp ; https://en.wikipedia.org/wiki/Llama.cpp ; https://til.simonwillison.net/llms/llama-7b-m2 ; https://news.ycombinator.com/item?id=35393284
+**sherpa-onnx**：https://github.com/k2-fsa/sherpa-onnx ; https://k2-fsa.github.io/sherpa/onnx/index.html ; https://huggingface.co/spaces/k2-fsa/automatic-speech-recognition ; https://www.star-history.com/k2-fsa/sherpa-onnx/
+**Moshi / Kyutai**：https://github.com/kyutai-labs/moshi ; https://kyutai.org/blog/2024-09-18-moshi-release ; https://x.com/ylecun/status/1808573335439298629 ; https://news.ycombinator.com/item?id=40871369
+**RealtimeSTT / TTS / VoiceChat**：https://github.com/KoljaB/RealtimeSTT ; https://github.com/KoljaB/RealtimeTTS ; https://github.com/KoljaB/RealtimeVoiceChat ; https://news.ycombinator.com/item?id=43899028
+**Willow**：https://github.com/HeyWillow/willow ; https://heywillow.io/ ; https://news.ycombinator.com/item?id=35948462 ; https://news.ycombinator.com/item?id=37859286
+
+---
+
+## 六、信息缺口（如实声明，未编造）
+- 各项目 star-history 逐月曲线均未直接抓到，部分增长拐点日期为推测。
+- faster-whisper / sherpa-onnx 未找到单一首发病毒帖；增长归因为口碑/复利型（推测）。
+- Pipecat 准确首发日期有冲突（5/13 vs 5/23）未核实；其与 LiveKit/ollama README 首屏是否含 demo GIF 在抓取范围内未完全确认。
+- Willow 两次 Show HN 具体分数因 HN 限流（429）未取到。
+- RealtimeSTT/TTS 单次涨星与 RealtimeVoiceChat 的导流因果为推测，无星历曲线直接佐证。

--- a/docs/plans/voxedge-v080-consolidation/consolidation-plan.md
+++ b/docs/plans/voxedge-v080-consolidation/consolidation-plan.md
@@ -1,0 +1,388 @@
+# Edge-Voice Stack — v0.8.0 Consolidation & Layering Plan
+
+**Status:** REVIEW + PLANNING (read-only). No changes executed. Hand each workstream (C/D/E/F/G) to a separate executor.
+**Author:** main-thread review, 2026-06-21.
+**Scope guardrails for executors:** NEVER touch production `seeed-orin-nx` (live robot-arm stack). Test env = `orin-nx` / `orin-nano` / `wsl2-local`. Fork-vs-submodule policy: upstream-bug fixes → the TensorRT-Edge-LLM fork; purely-our-features → `jetson-voice-engine`.
+
+Referenced artifacts (do not duplicate — read these):
+- `~/project/seeed-local-voice/ARCHITECTURE.md`, `docs/CONFIGURATION.md`, `docs/REPRODUCE.md`, `deploy/IMAGE-TAGS.md`
+- Memory: `qwen3tts_base_v080_port_2026_06_19.md`, `customvoice_talker_int4_eos_fail_2026_06_20.md`, `qwen3asr_int4_validation_forcelanguage_2026_06_20.md`, `leaf_config_refactor_w8a16_goal_2026_06_12.md`, `trunk_consolidation_2026_06_18.md`, `edgellm_v080_jetson_cutedsl_cuda126_2026_06_19.md`, `trt_edge_llm_fork_path.md`
+- HF: `harvestsu/qwen3-asr-0.6b-int4-v080`, `harvestsu/qwen3-tts-0.6b-base-jetson-trtllm-int4fp8`, `harvestsu/qwen3-tts-0.6b-customvoice-jetson-trtllm-int4fp8`, `harvestsu/qwen3-edgellm-jetson-artifacts` (engine sets), `harvestsu/seeed-local-voice-artifacts`
+
+---
+
+## EXECUTIVE SUMMARY
+
+The intended 3-layer architecture **already exists** in code (agent = `seeed-local-voice/agent/ovs_agent`; orchestration = `voxedge`; backends = `jetson-voice-engine` submodule + the TensorRT-Edge-LLM fork + `rkvoice-stream` + sherpa). The consolidation work is **not a rewrite — it is reconciliation and version-alignment**:
+
+1. **Version skew is the core problem.** The `jetson-voice-engine` submodule is pinned to **TensorRT-Edge-LLM v0.7.1** (`engine-overlay/UPSTREAM_PIN` = `364769036…` / release/0.7.1), but every shipped v0.8.0 runtime, worker, engine, and the 3 new int4 models live OUTSIDE that submodule — on fork branches (`port/qwen3-tts-base-v080@873ca22`, `wip/native-int4-talker`), the `edgellm-v080-migration` scratch repo, overlay images, and HF. Production runs older overlay images. The submodule must be re-pinned to a v0.8.0 base and the divergent v0.8.0 patches (streaming worker, fp8-embed wiring, N≤0 prefill guard, M=1 GEMV, cuBLAS-free tiled GEMM, stateful-code2wav static-shape) folded into the canonical overlay per the fork-vs-submodule policy.
+2. **The new int4 models are validated but not wired into the deploy registry.** Qwen3-ASR int4 (ZH CER 0%/EN WER 11%), Qwen3-TTS base int4+fp8 (RTF 0.44, TTFA 0.21s, −1.06GB), Qwen3-TTS CustomVoice int4+fp8 (−960MB/instance) are on HF and ASR-verified, but `configs/leaves/*` still point at fp16/fp8embed-only engine sets. Wiring them in is the highest-leverage, lowest-risk win.
+3. **Duplicate checkouts** (`qwen3-edgellm-jetson` ≡ `jetson-voice-engine` same HEAD; `voxedge-engine` deprecated into `jetson-voice-engine`; `tensorrt-edge-llm`/`_qwen3tts-port` = stale fork clones; `seeed-local-voice-v080` = stale migration branch checkout) should be deprecated to one canonical repo per layer.
+4. **One-click deploy + auto-pull machinery exists** (leaf/composition + `model_downloader` + `install.sh` + per-device compose) but the new int4 leaves and a profile-picker UX need finishing.
+
+**Recommended path:** (A) wire the 3 int4 HF bundles into the leaf registry + a new v0.8.0 composition profile per device (low risk, big win) → (B) re-pin the submodule to a v0.8.0 base and consolidate the divergent v0.8.0 patches into one overlay (the structural fix) → (C) finish the one-click profile-picker + auto-pull UX → (D) docs/perf-table overhaul → (E) test-env build+smoke gate → (F) deprecate the duplicate checkouts. Each is independently dispatchable.
+
+---
+
+## A. CURRENT-STATE MAP
+
+> "TRT ver" = which TensorRT-Edge-LLM version the component targets. Statuses: **LIVE** (production path), **migration** (v0.8.0 work-in-progress, not yet prod), **legacy** (older but referenced), **dup** (duplicate checkout), **scratch** (working dir).
+
+| Project (path under ~/project) | Layer | Role | Branch | TRT ver | Status | Recommendation |
+|---|---|---|---|---|---|---|
+| **seeed-local-voice** [main @4532ed0] | TOP (agent + product) | The product: `server/` FastAPI, `agent/ovs_agent`, `configs/`, `deploy/`. THIS is "OpenVoiceStream". | main | drives v0.7.1(prod)→v0.8.0(target) | **LIVE / canonical** | KEEP — canonical top layer |
+| seeed-local-voice-v080 [feat/edgellm-v080-migration @1fed2f8] | TOP | Stale checkout of an old v080 migration branch (2026-06-10). | feat/edgellm-v080-migration | v0.8.0 (early) | **dup / stale** | DEPRECATE — work merged to main per trunk_consolidation; delete checkout after confirming no unmerged commits |
+| local_voice [main @2026-01-14] | — | Unrelated web app (backend/frontend/database) — not the edge voice stack. | main | n/a | **unrelated** | LEAVE — out of scope (different product) |
+| sensecraft_voice [no git] | — | Non-git scratch dir. | — | n/a | **scratch** | FLAG for user — confirm contents, likely deletable |
+| **voxedge** [main @b783037] | MIDDLE (orchestration) | "Pipecat for the edge": engine/conversation loop, backend ABCs, jetson/rk/sherpa backends, transport. Pure-python. **Has the shipped base-speaker injection (b783037).** | main | backend-agnostic; drives v0.8.0 worker via CLI | **LIVE / canonical** | KEEP — canonical middle layer |
+| voxedge-engine [main @03664b0] | (was BOTTOM) | Thin overlay over NVIDIA TRT-Edge-LLM. **Self-deprecated 2026-06-01: "merged into jetson-voice-engine engine-overlay".** | main | v0.7.1 pin | **legacy / deprecated** | DEPRECATE — content lives in jetson-voice-engine/engine-overlay; archive repo |
+| **jetson-voice-engine** [main @3750ea9] | BOTTOM (Jetson backend) | Submodule of seeed-local-voice (`third_party/jetson-voice-engine`). Overlay = UPSTREAM_PIN + addon/ + patches/ + DIVERGENCE.md. Renamed FROM qwen3-edgellm-jetson. | main | **v0.7.1 (UPSTREAM_PIN=364769036)** | **LIVE (prod) — but STALE version** | KEEP as canonical Jetson backend repo; **MUST re-pin to v0.8.0** (workstream C) |
+| qwen3-edgellm-jetson [main @3750ea9] | BOTTOM | **Identical HEAD + same remote** as jetson-voice-engine (old name, stale clone). | main | v0.7.1 | **dup** | DEPRECATE — delete checkout (it IS jetson-voice-engine pre-rename) |
+| **TensorRT-Edge-LLM** [v071/customvoice-product @893ba2a] | BOTTOM (the fork) | The real fork the user works from (per `trt_edge_llm_fork_path` memory). Holds the v0.8.0 TTS runtime work on branches: `port/qwen3-tts-base-v080@873ca22` (fp8-embed + streaming worker + base), `v071/customvoice-product`, `wip/w8a16`. **Source-of-truth for the TTS worker + runtime patches.** | currently v071/customvoice-product; v0.8.0 work on port/* | mixed (per branch) | **LIVE source-of-truth (fork)** | KEEP — canonical fork. Consolidate v0.8.0 branches; ensure `wip/native-int4-talker` (int4 drivers) is pushed here (see risk below) |
+| tensorrt-edge-llm [v071/customvoice-product @893ba2a] | BOTTOM | Lowercase duplicate checkout of the fork, same HEAD. | v071/customvoice-product | v0.7.1 | **dup** | DEPRECATE — redundant with TensorRT-Edge-LLM |
+| _qwen3tts-port [wip/fp8-embedding @873ca22] | BOTTOM | Underscore-prefixed scratch clone of the fork on the fp8-embed branch. | wip/fp8-embedding | v0.8.0 | **dup / scratch** | DEPRECATE — same content as fork port branch; delete after confirming pushed |
+| edgellm-v080-migration [feat/edgellm-v080-migration @c01059b] | BOTTOM (scratch) | v0.8.0 migration scratch: holds v0.8.0 worker sources (qwen3_asr_worker.cpp/qwen3_tts_worker.cpp), N=2 patch, turnkey compose, pipeline driver. Worker shim source (b4ffaa41 lineage). | feat/edgellm-v080-migration | v0.8.0 | **scratch / migration** | HARVEST then DEPRECATE — extract the v0.8.0 worker sources + compose into jetson-voice-engine overlay, then archive |
+| rkvoice-stream [main @9fe452c] | BOTTOM (RK backend) | Submodule `third_party/rkvoice-stream`. RK runtime. | main | n/a (RKNN) | **LIVE / canonical** | KEEP — canonical RK backend |
+| rkvoice-engine [main @1f133f3] | BOTTOM (RK) | RK conversion pipeline (MIT, open-sourced). Companion to rkvoice-stream. | main | n/a | **LIVE (tooling)** | KEEP — RK conversion tooling repo |
+| qwen3asr_rk [main @2026-03-06] | BOTTOM (RK) | Qwen3-ASR RK conversion scripts (convert_as_qwen3.py). | main | n/a | **legacy/tooling** | KEEP or fold into rkvoice-engine — confirm if still referenced |
+| jetson-qwen3-speech [main @2026-04-08] | BOTTOM | Older Jetson Qwen3 speech cpp/python + wheels; predates the overlay model. | main | pre-v0.7 era | **legacy** | DEPRECATE/ARCHIVE — superseded by jetson-voice-engine overlay |
+| jetson-voice [no git] | — | Non-git dir (likely NVIDIA's old jetson-voice). | — | n/a | **legacy/scratch** | FLAG — likely external reference, deletable |
+| jetson-llm-benchmark [detached HEAD] | — | Benchmark scratch. | HEAD (detached) | n/a | **scratch** | LEAVE/ARCHIVE |
+| jetson-sim [no git] | — | Isaac grasp sim scratch (per memory). | — | n/a | **scratch** | LEAVE — robot-arm sim, out of voice scope |
+| frigate-on-jetson [main @2025-08] | — | Unrelated (video). | main | n/a | **unrelated** | LEAVE — out of scope |
+| seeed-solutions-hub [feat/solution-seo @eb00a30] | — | Solutions website/hub. | feat/solution-seo-fields | n/a | **unrelated** | LEAVE — out of scope |
+
+### Canonical repo per layer/backend (the source-of-truth decision)
+
+| Layer / backend | Canonical repo | Source-of-truth note |
+|---|---|---|
+| TOP (agent + product) | **seeed-local-voice** [main] | The product. Branding "OpenVoiceStream". Holds `configs/`, `deploy/`, agent apps. |
+| MIDDLE (orchestration) | **voxedge** [main] | Pure-python lib; flows into images as a built wheel (`deploy/wheels/voxedge-*.whl`). |
+| BOTTOM — Jetson overlay | **jetson-voice-engine** [main] (submodule `third_party/jetson-voice-engine`) | Overlay (UPSTREAM_PIN + addon/ + patches/). **Holds purely-our-features.** Currently pinned v0.7.1 — must move to v0.8.0. |
+| BOTTOM — the fork (upstream-bug fixes + TTS worker/runtime) | **TensorRT-Edge-LLM** [fork, suharvest remote] | **TTS worker + runtime patches source-of-truth** (NOT the submodule — historical reconciliation point). Upstream-bug fixes land here; the overlay's UPSTREAM_PIN points at the corresponding base. |
+| BOTTOM — RK | **rkvoice-stream** (runtime, submodule) + **rkvoice-engine** (conversion) | RKNN path. |
+| BOTTOM — sherpa/RPi/CPU | inside **voxedge** `backends/sherpa/` + CDN model_downloader | No separate repo. |
+
+**Reconciliation rule (TTS worker source-of-truth):** the TTS streaming worker and runtime kernels are authored on the **TensorRT-Edge-LLM fork** (`port/qwen3-tts-base-v080`). The `jetson-voice-engine` overlay carries them as **addon/ files or patches** referenced from its `manifests/` so a build reconstructs the exact worker. Do NOT let the two drift: the overlay's `UPSTREAM_PIN` + `patches/` must reproduce the fork branch's worker byte-for-byte (validate via the worker md5s recorded in memory).
+
+---
+
+## B. TARGET ARCHITECTURE (clean 3 layers)
+
+```
+ TOP    seeed-local-voice  (product / "OpenVoiceStream")
+        ├─ server/      FastAPI: HTTP+WS API, backend registry, hot-reload, profiles
+        ├─ agent/       ovs_agent apps (voice_arm, voice_rebot_arm, multi_mode…)
+        ├─ configs/     profiles (JSON) + leaf composition (YAML)  ← one-click selection
+        └─ deploy/      Dockerfiles + compose + voxedge wheel + install.sh
+                 │ imports voxedge.*                    │ git submodules
+                 ▼                                      ▼
+ MIDDLE voxedge  (orchestration, pure-python)     BOTTOM third_party/
+        ├─ engine/    conversation loop                ├─ jetson-voice-engine  (Jetson overlay)
+        ├─ backends/  ASR/TTS/VAD/LLM ABCs +           │     UPSTREAM_PIN=v0.8.0 + addon/ + patches/
+        │   jetson/ rk/ sherpa/                         │     reconstructs the TRT worker at build
+        ├─ transport/ InProcess + WebSocket             └─ rkvoice-stream       (RK runtime)
+        └─ capabilities/
+                 │ jetson backends shell out to the native worker
+                 ▼
+        TensorRT-Edge-LLM fork (suharvest)  ── source-of-truth for the TTS worker + runtime
+            release base = v0.8.0;  branch port/qwen3-tts-base-v080 (streaming worker, fp8-embed,
+            base speaker-encoder backport, M=1 GEMV, cuBLAS-free tiled GEMM, N≤0 guard);
+            wip/native-int4-talker (int4-AWQ drivers).  → folded into jetson-voice-engine overlay.
+```
+
+**How the fork + submodule + edgellm-v080-migration patches relate (one source-of-truth):**
+- The **fork** (`TensorRT-Edge-LLM`) is where C++/CUDA runtime + worker authoring happens. v0.8.0 work = `port/qwen3-tts-base-v080` (+ int4 drivers on `wip/native-int4-talker`).
+- The **submodule** (`jetson-voice-engine`) is the *overlay* that pins an upstream NVIDIA commit and re-applies the fork's deltas as `addon/`+`patches/`. **Re-pin UPSTREAM_PIN from v0.7.1 → the NVIDIA v0.8.0 base**, then regenerate `patches/` from the fork's v0.8.0 branch so a clean `build.sh` reproduces the shipped worker.
+- **edgellm-v080-migration** is *scratch* that proved out the v0.8.0 workers (`qwen3_tts_worker.cpp` CLI-shim b4ffaa41, `qwen3_asr_worker.cpp` 8cf0b8df) + N=2 patch + turnkey compose. **Harvest those into the overlay, then archive the scratch repo.** It is NOT a long-term home.
+
+**Precision policy (target defaults, v0.8.0):**
+- Qwen3-ASR (Jetson): **int4-AWQ decoder + fp16 audio encoder** (validated; replaces fp16 default).
+- Qwen3-TTS base (Jetson): **int4-AWQ talker + int4 CP + fp8 text_embedding + fp16 code2wav** (strictly better than fp16: RTF 0.44 vs 0.69, −1.06GB).
+- Qwen3-TTS CustomVoice (Jetson): **int4-AWQ talker + fp8 embedding + fp16 CP/code2wav** (talker 906→246MB; int4 RESOLVED — earlier "EOS-broken" verdict was a wrong-tokenizer harness bug, see `customvoice_talker_int4_eos_fail` memory). **用户定 CV = 一等公民(2026-06-21):走 int4(非 w8a16,w8a16 EOS 破已 DROP),P5 9-row CV 条件移植到 v0.8.0。** 默认翻转前过 F4 + F5-CV + license 免责声明(音色肖像权)。当前 production CV 仍 fp16 → int4 经 F4/F5-CV 验证后可进默认。
+- These flip via `configs/leaves/models.yaml default_precision[jetson]` once leaves reference the int4 artifact paths.
+
+### B.1 最终 canonical 仓库 = 3 层 5 个职责单元(6 个物理仓)(权威版)
+
+整合**不减仓库数**,而是给每仓定唯一职责、删跨仓重复编码。对外只有一个品牌(VoxEdge=引擎层),其余用"关系"描述。
+> 注:RK 后端是 **2 个物理仓**(`rkvoice-stream` 运行时 + `rkvoice-engine` 模型/工具),逻辑上算 1 个"RK 后端"职责单元。故 = 5 职责单元 / 6 物理仓。
+
+| 层 | 仓库 | 唯一职责 | 对外叫法 |
+|---|---|---|---|
+| **TOP 应用** | `seeed-local-voice` | FastAPI server + ovs_agent apps + demos(机械臂/翻译/字幕)+ configs/deploy | "VoxEdge 参考应用/示例" |
+| **MIDDLE 引擎** | `voxedge` | 实时管线(turn_driver/transport/capabilities)+ 后端 ABC + 各后端 Python 适配 | **VoxEdge**(品牌,`pip install voxedge`) |
+| **BOTTOM 后端** | `TensorRT-Edge-LLM`(fork, suharvest) | Jetson C++ runtime + 导出工具 **source-of-truth**;pin v0.8.0;只带**可上游**的薄 patch | "Jetson backend" |
+| **BOTTOM 后端** | `jetson-voice-engine` | 我们自己的、**不可上游**的 Jetson 功能/overlay/worker 编排 + 量化 recipes driver | (后端 overlay) |
+| **BOTTOM 后端** | `rkvoice-stream` / `rkvoice-engine` | RK NPU 后端(RKLLM runtime) | "RK backend" |
+
+> RPi(sherpa)无独立仓 —— 在 voxedge `backends/sherpa/` 内,无 C++ 后端,不占仓位。
+
+**fork vs jetson-voice-engine 职责切分 —— 三类变更模型(消除"fp8 wiring 双写"歧义):**
+
+关键原则:**任何 C++/CUDA runtime 改动都只在 fork 落地(fork 是 runtime 的唯一 source-of-truth)**;jve 不独立手写 runtime 代码,只把 fork 的 delta 机械地 re-apply 成 overlay patch。据此把变更分三类:
+
+| 类 | 定义 | source-of-truth | 上游性 | 例 |
+|---|---|---|---|---|
+| **C1 上游 bug 修复** | 修上游 runtime 的 bug(C++/CUDA) | **fork**(打 `upstreamable` 标) | 推上游,合并即归零 | `N≤0` prefill guard |
+| **C2 本地 runtime 扩展** | 我们加的 runtime 能力(C++/CUDA),暂不/不可上游 | **fork**(维护型 patch) | 不归零,长期维护 | fp8-embed wiring、cuBLAS-free tiled GEMM、M=1 GEMV |
+| **C3 overlay/编排/recipes** | 非 runtime:构建胶水、worker spawn 配置、Python 导出 driver、profile | **jetson-voice-engine** | n/a | int4 导出 driver、overlay patch 生成、deploy compose |
+
+→ **fp8-embed wiring 归为 C2 类 = 只在 fork 维护**;jve 侧的"overlay patch"是从 fork **自动生成**的(不是第二份手写源),因此不存在双写。worker **二进制**从 fork 源码编译,jve 只负责打包,**绝不**保留第二份 runtime 源。
+
+**变更映射(现状 → 最终,治"同一 feature 编码两遍"):**
+1. `jetson-voice-engine` 现 pin v0.7.1,扛 8 个 patch + fp8 product patch —— 这些在 fork v0.8.0 已原生 → **重 pin 到 v0.8.0,删已原生的冗余 patch**(workstream C2)。
+2. worker 源码现散 3 处(fork `examples/omni`、jve `native/edgellm_voice_worker`、seeed `deploy/asr-worker-v080`)→ **收敛到 fork 一棵树**,另两处变 build-input。
+3. int4/fp8 导出 driver 现孤立在 fork `wip/native-int4-talker` → 迁到 **`jetson-voice-engine/recipes/`**(class C3 recipes,**不放 fork**),pin 一个 fork commit;它们只调 fork 的 export API(`_export_talker` 已原生 detect W4A16),不改 runtime。fork 只留 native int4 kernels/plugin + export API。(对应 C6;统一了早先"推到 fork"的措辞。)
+4. 终端用户消费的不是任何源码仓,而是 **HF 预编译 int4 引擎**(已传 3 bundle):`docker run` + 按 config 自动拉。
+5. `voxedge-engine`(已自废,2026-06-01 并入 jve)、`qwen3-edgellm-jetson`(旧名)→ 留 README 指针归档(workstream G)。
+
+---
+
+## C. v0.8.0 CONSOLIDATION WORKSTREAM (ordered)
+
+**Goal:** every production-path component on TensorRT-Edge-LLM v0.8.0. Dispatch as 2–3 sub-workstreams; C1 (config/registry) is independent of C2/C3 (repo/build).
+
+| # | Step | Repo / path | Dependencies | Risk | Effort |
+|---|---|---|---|---|---|
+| **C0** | **✅ DONE — patch ownership manifest 已产出 → `c0-patch-ownership-manifest.md`(20 项全分类 + 双写风险 + 待拍板项)。关键发现:(1) jve 当前 pin v0.7.1 非 v0.8.0,整合本质=re-pin+删冗余封装(非照搬 8 patch);(2) int4 native kernels/plugin 上游 v0.8.0 已原生,我们只需 export drivers(C3);(3) **fork 里根本没有 ASR worker 源** → stripLangTag 修复(现仅在 seeed/jve 副本)必须先落回 fork 建唯一源;(4) **N≤0 guard 尚未落地**(分支里只有 empty-fullText LOG_ERROR)→ 是计划新写项非已存在 patch。生成 manifest(原始任务): 列出每个 patch:`patch id / owner repo(fork or jve)/ class(C1上游bug \| C2本地runtime扩展 \| C3 overlay-recipes)/ source-of-truth(源码在哪)vs packaging(overlay patch 在哪,自动生成)/ upstreamability / removal condition / validation gate / affected engines`。**关键:对每个 runtime 改动显式区分"源"(fork)与"封装"(jve 自动生成的 overlay patch),执行体只改"源",绝不手改"封装"。** 必须逐项拍死归属的两可项(codex 终审标出):`N≤0 prefill guard`(防御性 runtime,两可于 C1/C2)、`fp8-embed wiring`(C2,源在 fork,jve patch 自动生成)、`worker 源 vs 封装`(源=fork、打包=jve)、`CuTe-DSL→cuBLAS tiled GEMM fallback`(sm_87 平台兼容,两可于 C1/C2)、`ASR stripLangTag 英文首词修复`(C++ worker,此前未纳入任何 class)、`int4 native kernels/plugin(fork) vs export drivers(jve recipes)`(跨 C2/C3,F8 同依赖两处)。 | jetson-voice-engine `DIVERGENCE.md` + fork branch notes | none | **MED(防双写,关键前置)** | 0.5–1d |
+| C1 | **Wire the 3 int4 HF bundles into the leaf registry — opt-in only, DO NOT flip defaults.** Update `configs/leaves/qwen3-tts-base.yaml`/`qwen3-asr-nx.yaml` to ADD int4 leaf variants (int4 talker+CP+fp8 embed / int4 decoder) pointing `artifacts.repo`/`files` at the HF int4 bundles; add a `qwen3-tts-customvoice` int4 leaf marked **experimental**. Create explicit **opt-in profiles** (`jetson-edgellm-v080-int4-*`). **`models.yaml default_precision[jetson]` 保持 fp16 不变**——默认翻转是单独一步(见 C1b),挂在 F-gate 全绿之后。 | seeed-local-voice `configs/leaves/*`, `configs/profiles/*` | none (config-only) | LOW | 0.5–1d |
+| **C1b** | **Flip default precision to int4 — gated, NOT in C1.** 只有当对应 F-gate 全绿才翻 `default_precision[jetson]`:ASR int4 → 需 **F2b**(过 production worker + N=2,F2a 已绿);TTS base int4+fp8 → 需 **F5**(int4+fp8 N=2 burst/MD5);**CustomVoice int4(一等公民,用户定)→ 需 F4(streaming worker+EOS+全链 perf)+ F5-CV(CV N=2),全绿后可进默认**(license 跟随 Qwen 官方,不设额外门槛);在此之前 experimental opt-in。 | seeed-local-voice `configs/leaves/models.yaml` | C1, F2b/F4/F5/F5-CV | **MED(改默认=改生产路径)** | 0.5d |
+| C2 | **Re-pin the Jetson overlay to v0.8.0.** Change `jetson-voice-engine/engine-overlay/UPSTREAM_PIN` from `364769036…`(v0.7.1) to the NVIDIA `release/0.8.0` base commit; regenerate `patches/` from the fork `port/qwen3-tts-base-v080`; update `addon/` with the v0.8.0 streaming worker + plugins; refresh `manifests/` + `DIVERGENCE.md`. Bump the submodule pointer in seeed-local-voice. | jetson-voice-engine (canonical); seeed-local-voice submodule bump | C-fork-branch-consolidation | **HIGH** (build reproducibility; shared plugin blast radius — base TTS + ASR int4 + CustomVoice share the plugin) | 3–5d |
+| C3 | **Land the 2 pending runtime fixes — both ON THE FORK (per C0 manifest).** (a) **N≤0 prefill guard** (defensive — fixes silent garbled output on tokenizer mismatch) = **class C1 上游bug**. ⚠️ **C0 finding: NOT yet in any fork branch** — only an uncommitted local edit on orin-nx (`.prefillguard.bak`); the branches have just an `empty fullText` LOG_ERROR (`qwen3OmniTTSRuntime.cpp:1655`). **Action: write/recover it and COMMIT to fork** as the single source, tag upstreamable. (b) **fp8 text_embedding wiring** (`mTextEmbeddingScales` at 5 call sites, commit 873ca22) = **class C2 本地runtime扩展** → already on fork port branch, **stays in fork**. jve's overlay patch for it is **auto-generated from the fork**, NOT a separate hand-written copy (no double-write). (c) **Establish the ASR worker source in the fork (C0 finding: fork has NO asr_worker).** Land `qwen3_asr_worker.cpp` **with the stripLangTag fix** (currently only in seeed `deploy/asr-worker-v080` md5 `13b34dc` + a stale jve copy `7885f2e`) into fork `examples/omni/` as the single source = **class C1**; seeed/jve copies become generated packaging. | fork TensorRT-Edge-LLM (source); jve/seeed copies generated | C0, C2 | MED | 1–2d |
+| C4 | **Harvest edgellm-v080-migration workers into the overlay.** Move `qwen3_tts_worker.cpp` (CLI-shim b4ffaa41), `qwen3_asr_worker.cpp` (8cf0b8df), the N=2 patch, and the turnkey compose into jetson-voice-engine addon/patches + manifests. Validate reconstructed worker md5 matches the recorded values. | jetson-voice-engine ← edgellm-v080-migration | C2 | MED | 1–2d |
+| C5 | **Reconcile divergent overlay branches.** Memory cites deployed v0.8.0 runtime on `edgellm-v080 @7b6ac36` + fp8-embed only on the fork port branch (873ca22) + a separate `~/project/edgellm-v080` build tree. Pick ONE: the jetson-voice-engine overlay reconstructed from the fork. Verify the reconstructed engine set matches the HF `highperf-v080/` bundle. | jetson-voice-engine, fork | C2,C3,C4 | MED | 1d |
+| C6 | **Relocate the int4/fp8 export drivers to `jetson-voice-engine/recipes/` (class C3 recipes, NOT the fork).** ✅ **Recovery DONE 2026-06-21** — driver branches are SAFE on suharvest fork: `wip/native-int4-talker` (ff2318e, TTS talker+CP `quantize_talker_stage1.py`/`stage2_export.py`/`quantize_cp_stage1.py`/`cp_stage2_export.py`) was already pushed; `wip/asr-int4-decoder` (c80bcc0, ASR int4) **now pushed**. Uncommitted working files (`quantize_talker_stage1_bigcalib.py` + `cv-int4-derisk/*` fp16/CV scripts+logs) **pulled to Mac** `~/project-backups/20260621-133543/wsl2-recovered/`. These thin drivers CALL the fork export API (`tensorrt_edgellm/scripts/`, `_export_talker` W4A16 auto-detect), do NOT touch C++/CUDA runtime → recipes layer. **Remaining (consolidation, not data-loss):** land them in `jetson-voice-engine/recipes/` with a pinned fork commit + recipes README; keep fork minimal (native int4 kernels/plugin + export API only). Reproducibility validated by F8. | jetson-voice-engine `recipes/` (drivers) + fork (pinned, unchanged) | none | LOW (recovery done; relocation remains) | 0.5d |
+| C7 | **Rebake the v0.8.0 production-path image (overlay model).** Per memory, the composition image is an OVERLAY on a prefix base (`composition-e2e-v080w4/w5`): COPY v0.8.0 workers (TTS b4ffaa41 + ASR 8cf0b8df) + plugin (7d3fabe) + updated leaves. Bake with the int4 engine set. `deploy/jetson-workers` MUST stay at production-original (it is a shared build input — leaving v0.8.0 workers there mis-bakes flat-prod images). | seeed-local-voice deploy + jetson-voice-engine | C1–C5 | **HIGH** (image bake; shared build input) | 1–2d |
+
+**Ordering:** C6 + C1 can start immediately in parallel. C2→C3→C4→C5 is the repo/build chain. C7 last. Do NOT deploy C7 to seeed-orin-nx — bake + test on orin-nx/orin-nano.
+
+**Known traps (from memory — do not re-derive):**
+- v0.7.0 `tensorrt-edge-llm/build/llm_inference` SEGFAULTS on v0.8.0 engines; use the v0.8.0 binary (`~/project/edgellm-v080-build/build/...`).
+- Shared `speech-models` volume: a v0.8.0 Qwen3-ASR engine and the prod v0.7.0 ASR worker CANNOT co-exist (version-mismatch refusal). Clean e2e MUST use an isolated volume / host dir (`~/comp-e2e-models`).
+- ASR audio encoder must be the **minchunk1** build (opt-profile min-dim 1) or batch=1 prewarm fails.
+- CuTe-DSL GEMM is NOT viable on sm_87 (`invalid device function`); build `ENABLE_CUTE_DSL=OFF`, use the cuBLAS-free tiled FP16 GEMM. `-rdc` incremental device-link is broken → clean `rm -rf build` after any `.cu` change.
+
+---
+
+## D. ONE-CLICK DEPLOY + AUTO MODEL-PULL
+
+**What exists today:**
+- `deploy/install.sh` — auto-detects target (jetson/rk3576/rk3588/rpi via `/etc/nv_tegra_release`, `/dev/rknpu`, device-tree), selects the compose file, `--pull --verify`.
+- `deploy/docker-compose.yml` (+ `.rk.yml`, `.rpi.yml`, `.radxa.yml`) — `OVS_PROFILE=… docker compose up -d`; models auto-download on first start into a `speech-models` volume.
+- `server/core/model_downloader.py` — CDN tarball pull (matcha/paraformer/kokoro) + `QWEN3_ARTIFACT_MANIFEST` → HF pull for Qwen3 engines.
+- Leaf composition: `server/core/leaf_composition.py` + `composition_boot.py` → a `composition` profile selects leaves, and the **leaf-union drives the HF pull** per config (Slice 1–3 DONE, commits 00e4d6e/c70a67b/dee93e4).
+
+**Target UX (genuinely one-click):**
+```
+# Pick a profile, everything else is automatic:
+OVS_PROFILE=jetson-edgellm-v080-int4 deploy/install.sh --pull --verify
+#   → install.sh detects Jetson → selects compose → pulls image
+#   → container boot: composition_boot resolves the profile's leaves
+#   → leaf-union → model_downloader auto-pulls EXACTLY the int4 bundles for that config from HF
+#   → engine_resolver no-op (leaf env sets paths) → prewarm → /readyz green
+```
+
+| # | Step | Repo / path | Dep | Risk | Effort |
+|---|---|---|---|---|---|
+| D1 | **Add v0.8.0 int4 composition profiles** — one per device/use-case: `jetson-edgellm-v080-int4-nx` (ASR int4 + TTS base int4), `…-customvoice`, `…-nano`. Use the `composition:{device,asr,tts}` form (cf. `jetson-qwen3-composition-nx.json`) so leaf-union auto-pull engages. | seeed-local-voice `configs/profiles/` | C1 | LOW | 0.5d |
+| D2 | **Register the int4 HF bundles as pullable leaves.** Ensure `model_downloader._ensure_qwen3_artifacts_via_hf` receives the leaf-union `required_files` for the int4 bundles (the non-empty-override path, model_downloader.py ~:333/350). Confirm the fat-script path doesn't shadow the override (known boundary). | seeed-local-voice `server/core/model_downloader.py` + leaves | C1,D1 | MED (the fat-script override boundary) | 1d |
+| D3 | **Profile-picker UX.** Add a `--profile` flag / interactive menu to `install.sh` that lists the v0.8.0 profiles with one-line descriptions + device fit (RAM ceiling from leaf `peak_unified_mb` + device `base_reservation_mb`), so the user picks by use-case not by memorizing profile names. Validate the pick against device RAM via `validate_composition` before `up`. | seeed-local-voice `deploy/install.sh` | D1 | LOW | 1d |
+| D4 | **First-boot auto-pull verification + artifact-source fallback.** Add to `verify.sh`: assert the leaf-union pulled the expected int4 files (md5/size), engines loaded, /readyz green, TTS smoke + TTS→ASR roundtrip. **Define artifact source priority: HF → mirror → local cache**, and on each pull **print the actual source + checksum**; if mirror hasn't synced a new bundle (orin-nx can't reach hf.co directly), fall back to local cache and **fail loudly with the missing md5** rather than silently booting a wrong/old engine. | seeed-local-voice `deploy/verify.sh` + `model_downloader.py` | D1,D2 | MED (mirror lag) | 0.5d |
+| D5 | **Compose env hygiene.** The compose still references `QWEN3_EDGELLM_JETSON_ROOT=/opt/qwen3-edgellm-jetson` (old submodule name). Update to the renamed `jetson-voice-engine` path + the new int4 env keys; keep backward-compat defaults. | seeed-local-voice `deploy/docker-compose*.yml` | C7 | LOW | 0.5d |
+
+**UX principle:** the user picks ONE thing (a profile name describing a use-case, e.g. "Orin Nano — fast multilingual dialogue, int4"), and `install.sh` + composition_boot + leaf-union + model_downloader do detection → image pull → per-config model pull → prewarm → health, with a single `--verify` proving it.
+
+---
+
+## E. README / DOCS OVERHAUL + PERF METRICS
+
+| # | Step | Path | Risk | Effort |
+|---|---|---|---|---|
+| E1 | **Top-level README**: update the model badges/tables to include the 3 new int4 v0.8.0 models; add a "v0.8.0" section; fix the registry-namespace note; update Quick-Start to the new int4 profiles. | seeed-local-voice `README.md` | LOW | 0.5d |
+| E2 | **ARCHITECTURE.md is STALE** — it still describes `voxedge-engine` as the engine repo and the submodule as `qwen3-edgellm-jetson`. Rewrite the "three repositories" section: voxedge-engine deprecated → `jetson-voice-engine` (renamed) is the overlay submodule; fork = TTS worker source-of-truth. | seeed-local-voice `ARCHITECTURE.md` | LOW | 0.5d |
+| E3 | **Add perf/VRAM/quality tables** (numbers below) to README + a `docs/perf/` page + the per-model leaf header comments + (optionally) sync the HF READMEs (the ASR + CustomVoice HF cards lack RTF/TTFA — add from memory). | seeed-local-voice README + docs/perf + HF cards | LOW | 0.5d |
+| E4 | **Per-project READMEs**: jetson-voice-engine README still says UPSTREAM_PIN v0.7.1 — update post-C2; voxedge README; deprecate voxedge-engine / qwen3-edgellm-jetson READMEs with a pointer to canonical. | jetson-voice-engine, voxedge, voxedge-engine | LOW | 0.5d |
+| E5 | **`BENCHMARKS.md`(全量矩阵)** — 渲染表 A(设备×后端×模型×精度→RTF/TTFA/VRAM/CER)+ 方法论口径。数据**唯一来源** = `benchmarks-dataset.md`(已汇总,带 file 出处)。每个数字保留出处脚注,`—` 单元格列进「待测」。 | seeed-local-voice `BENCHMARKS.md` | LOW | 0.5d |
+| E6 | **Recipes 选择器页**(用例×设备→推荐栈+能力)— 渲染表 B,每行末尾给「一键部署 profile」链接,闭环到 workstream D 的 `--profile`。这是把"看 benchmark 的人"转成"用户"的转化点。 | seeed-local-voice `docs/recipes.md`(或 landing) | LOW | 0.5d |
+
+### E 节·benchmark/recipes 呈现策略(single-source → 按受众多视图)
+
+**一个数据源 → 四个视图,绝不各处手抄数字**:
+
+```
+benchmarks-dataset.md   ← 唯一真相(表A性能 + 表B最佳实践 + 方法论 + GAPS)
+        │
+        ├─▶ Landing README "hero 数字"  → 给所有人:只挑**已验证+有出处**的(Orin Nano Base int4+fp8 RTF 0.44 / TTFA 0.21s【N=1】/ int4 省 ~1GB/实例;MOSS-TTS-Nano N=2 byte-identical【已验】)。⚠️ Base int4+fp8 的 N=2 待 F5,**不得**作为 hero;CustomVoice int4 experimental 不进 hero。
+        ├─▶ BENCHMARKS.md (E5)          → 给系统开发者:全量表A + 口径,数字即护城河
+        ├─▶ Recipes 选择器 (E6)         → 给应用开发者:表B,"我要做X用什么"→ 直给 profile + 一键命令
+        └─▶ HF model cards / leaf 头注释 → 给消费引擎的人:单模型那一行 perf(E3 已覆盖,补 RTF/TTFA)
+```
+
+**三条规则**:
+1. **数字只在数据集文件改一次**,四个视图都从它生成/引用 —— 杜绝 README 和 HF card 数字打架。
+2. **每个数字带出处**(memory/spec/commit),对外文档保留方法论口径段(贪婪解码、finalize 口径、N=verified 定义),否则"性能数字"不可信。
+3. **Recipes → 一键部署闭环**:表 B 每行的"推荐栈"必须对应一个真实存在的 leaf/profile 组合;选择器输出 = `docker run ... --profile <X>`,直接落到 workstream D。没有这个闭环,漏斗会漏。
+
+**受众-视图-卖点对应**(呼应定位文档第四节双受众漏斗):
+| 视图 | 受众 | 卖点 | 落点 |
+|---|---|---|---|
+| Landing hero | 所有人 | "哇,端侧能这么快" | README 顶部 + demo GIF |
+| BENCHMARKS.md | 系统/算法开发者 | 全量性能 + 量化深度 + 多后端覆盖 | repo 根 |
+| Recipes 选择器 | 应用开发者 | "我的用例→直接能跑的栈" | docs/landing + 闭环 profile |
+| HF card / leaf 注释 | 拉引擎的人 | 这个引擎多大多快多准 | HF + configs/leaves |
+
+
+**Perf/quality/VRAM tables to add** (sources: memory files + HF cards; ✱ = from memory, HF card omits):
+
+*Qwen3-ASR-0.6B int4-AWQ (v0.8.0, Jetson)* — `harvestsu/qwen3-asr-0.6b-int4-v080`
+| Metric | Value |
+|---|---|
+| ZH CER | 0.00% (6/6 exact, opencc-normalized) |
+| EN WER | ~11% (single substitution on a 3-word clip) |
+| LLM engine | ~525 MB (int4-AWQ / W4A16) |
+| Audio encoder | ~364 MB (fp16) |
+| Embedding params | ~297 MB |
+| Plugin | ~43 MB |
+| Decode contract | greedy (temp 0.0, top_k 1, top_p 1.0) + force_language prime |
+
+*Qwen3-TTS-0.6B BASE int4+fp8 (v0.8.0, Orin Nano)* — `harvestsu/qwen3-tts-0.6b-base-jetson-trtllm-int4fp8`
+| Metric | Value |
+|---|---|
+| RTF | 0.44 |
+| TTFA (warm) | 0.21 s |
+| Talker | 907 MB → 245 MB (int4-AWQ) |
+| CodePredictor | 191 MB → 98 MB (int4-AWQ) |
+| text_embedding | 622 MB → 320 MB (fp8 e4m3) |
+| Code2Wav | fp16 (INT8 not viable: TRT10.3 Conv1D QDQ) |
+| VRAM | ≈ −1.06 GB / instance |
+| EN WER / ZH CER | 0% / 1.7% (== fp16 baseline) |
+| Concurrency | N=2 **verified at fp16** (KV cap 1536, 5.6GB free); int4+fp8 N=2 **pending F5 gate** — do NOT cite as a verified hero number |
+
+*Qwen3-TTS-0.6B CustomVoice int4+fp8 (v0.8.0, Orin NX)* — `harvestsu/qwen3-tts-0.6b-customvoice-jetson-trtllm-int4fp8`
+| Metric | Value |
+|---|---|
+| Talker | 246 MB (int4-AWQ) |
+| text_embedding | 321 MB (fp8 e4m3, per-group-128) |
+| Code predictor | ~182 MB (fp16) |
+| Code2wav | ~224 MB (fp16) |
+| Sidecars | 6.3 MB embedding + 12.6 MB text_projection |
+| VRAM | ≈ −960 MB / instance vs all-fp16 |
+| Quality | A/B vs fp16, ASR-verified intelligible ZH+EN |
+| Safety | hard N≤0 prefill guard (fails loud on tokenizer mismatch) |
+| ✱RTF/TTFA | not yet measured through streaming worker — add after F |
+
+---
+
+## F. TEST / COMPILE VERIFICATION (test env only — NOT seeed-orin-nx)
+
+> **F 是各 workstream 的 exit-criteria,不是收尾阶段。** C1b(翻默认)、C2(re-pin)、C7(bake)在标 DONE 前必须先过对应 F-gate:C1b→F2b/F4/F5、C2→F1+F8、C7→F6。**不允许 C/D 标完成后再补跑 F。**
+
+**Devices:** build host = **orin-nano** (`~/project/edgellm-v080-build`, ENABLE_CUTE_DSL=OFF) for Jetson; **wsl2-local** (RTX, has modelopt 0.39) for int4/fp8 export; **orin-nx** for NX-class memory/perf (free it of co-resident services first — it is a profiling device, the arm stack is on seeed-orin-nx). Use `fleet` (full path in subshells).
+
+| # | Component | Where | Command (sketch) | Pass gate |
+|---|---|---|---|---|
+| F1 | v0.8.0 engine + worker build | orin-nano | `cd ~/project/edgellm-v080-build && rm -rf build && cmake -DENABLE_CUTE_DSL=OFF … && make qwen3_tts_streaming_worker qwen3_asr_worker llm_inference NvInfer_edgellm_plugin` | binaries link; plugin .so produced; record md5 |
+| F2 | Qwen3-ASR int4 validation — **two sub-gates** | orin-nano / orin-nx | **F2a (decode contract, DONE):** `llm_inference` w/ `temp=0,top_k=1,top_p=1`, `apply_chat_template`, assistant primed `"language <Lang><asr_text>"`, `--engineDir=<llm> --multimodalEngineDir=<audio_PARENT>`, audio min-dim minTimeSteps=100. **F2b (PENDING, required before C1b):** run int4 through the **production `qwen3_asr_worker` streaming path** (not just `llm_inference`) + **N=2 slot-pool**. | F2a: ZH CER 0% (6-clip, opencc-norm), EN ≤1 acoustic word. F2b: same accuracy through real worker + N=2 both slots rc=0, no OOM |
+| F3 | Qwen3-TTS base int4+fp8 synth | orin-nano | worker + `EDGELLM_PLUGIN_PATH` + talker/cp/code2wav int4 engines + `speaker_embedding_b64` (precomputed) → wav; faster-whisper round-trip | clean EOS; intelligible (faster-whisper, NOT Groq — key expired); RTF≈0.44/TTFA≈0.21 |
+| F4 | Qwen3-TTS CustomVoice int4 synth | orin-nx | worker + **CORRECT CV tokenizerDir** (the wrong-tokenizer trap — assistant role must be non-empty) + N≤0 guard build | "你好"/"今天天气怎么样" intelligible (faster-whisper); EOS clean (NOT maxFrames); prefill ≥12 rows |
+| F5 | N=2 parallel TTS (base int4+fp8) | orin-nano | 2 slots, `--max_slots 2`, KV cap 1536 | both slots rc=0, no OOM, ≥5GB free (base on 8GB) |
+| F5-CV | N=2 parallel TTS (**CustomVoice int4**, 一等公民) | orin-nx | 2 slots `--max_slots 2`, CV checkpoint + P5 9-row conditioning ported to v0.8.0 | both slots rc=0, no OOM, EOS clean, intelligible (faster-whisper) |
+| F6 | Composition e2e (config → leaf-union pull → engines → /asr+/tts) | orin-nx (isolated volume `~/comp-e2e-models`, NOT the prod speech-models volume) | overlay image `composition-e2e-v080w*` + `OVS_PROFILE=<int4 profile>`, no config overrides | /asr accurate transcript; /tts non-silent wav; prewarm batch=1 OK |
+| F7 | voxedge unit + engine-inprocess (no GPU) | mac / any | `cd ../voxedge && pytest voxedge/tests/test_engine_inprocess.py -q`; `pytest server/tests/test_leaf_composition.py -q` | green (byte-equivalent contract) |
+| F8 | int4 export reproducibility | wsl2-local | run `jetson-voice-engine/recipes/quantize_talker_stage1.py` + `stage2_export.py` (recipes calling the **pinned fork** export API, after C6 relocates them) → ONNX → engines match HF md5 | export reproduces shipped int4 engines byte-for-byte (engine md5 == HF bundle) |
+
+**Gates carried from memory:** bytes≠speech (always ASR-verify audio); md5 byte-gate is invalid for sampling paths (use greedy or ASR check); opencc t2s-normalize before CER; faster-whisper not Groq.
+
+**F 节盲区(codex 终审标出,F1–F8 未覆盖,补进 H 节回归策略):** ① license/model-card 分发风险 gate ② artifact mirror-lag/source-fallback 自动化 ③ README/HF/leaf benchmark 数字一致性 CI ④ worker sampling 参数生效验证(CV 曾被 harness 采样误导)⑤ ASR `stripLangTag` 英文首词回归(生产级 bug)⑥ clean-device 一键 install 全链路 ⑦ 逐组合真机 e2e(35 leaf × 设备)。(⑧ stateful×N=2 已实机 closed:flag 在 slot-pool 是 no-op,无收益无风险,见数据集 GAPS#10 + manifest W2 — 无需 gate。)
+
+---
+
+## H. MIGRATION REGRESSION STRATEGY (防衰退 — 迁移前置)
+
+> 迁移面:生产路径 v0.7.1 overlay→v0.8.0、引擎 fp16→int4/fp8、worker 源 3处→1处、export driver→recipes。本节是"不衰退"的硬约束,与 F 节(单点验证)互补:F 验"新东西能跑",H 验"老行为没退"。
+
+### H1. Golden 基线(迁移前必须先冻结)
+迁移**任何**生产路径前,先抓基线包存 `golden/v080-migration/<date>/<profile>/`:
+- **音频**:输入 wav + 输出 wav + md5 + 采样参数(N=x verified 的 MD5 音频门定义见数据集方法论)。
+- **CER/WER**:ASR 用 greedy + force_language scaffold + opencc t2s;当前基线 ZH CER 0% / EN WER 11.11%。
+- **TTFA/RTF**:warm TTFA、RTF=wall/audio;Base int4+fp8 基线 RTF 0.44 / TTFA 0.21s(Orin Nano)。
+- **VRAM**:engine size + 运行峰值;Base −1.06GB/实例、CV −960MB/实例。
+- **md5 钉死**:engine md5 + **worker md5** + plugin md5(教训:ASR worker 8cf0b8df 靠 md5 钉死才发现镜像漂移)。
+
+### H2. 等价性判据(分两类,别用错 gate)
+| 场景 | gate | 阈值 |
+|---|---|---|
+| greedy TTS / N=2 slot 输出 / worker rebuild / export 复现 | **byte-identical** | md5 完全一致(MOSS 30/30、F8 engine md5==HF) |
+| sampling TTS | **质量等价**(md5 无效) | faster-whisper round-trip 可懂 + EOS clean |
+| ASR int4 vs fp16 | **质量等价** | ZH CER ≤ 0.5% / EN WER ≤ 15% / 无 language leak/loop |
+| TTS Base int4+fp8 vs fp16 | **质量等价** | RTF ≤ 0.50 / TTFA ≤ 0.25s / CER·WER 不劣于 fp16 |
+| CustomVoice int4(F4 前 experimental) | **质量等价** | faster-whisper 可懂 + EOS clean + prefill ≥ 12 rows |
+
+### H3. 分层测试矩阵(各层迁移各跑什么)
+| 层 | 内容 | gate | GPU |
+|---|---|---|---|
+| unit | leaf composition、engine-inprocess 契约 | F7 全绿、byte-equivalent | 无(进 CI) |
+| worker 协议 | ASR/TTS worker CLI、force_language scaffold、**stripLangTag**、N=2 streaming | 准确率同 F2a;EOS clean;**英文首词不丢** | Jetson |
+| engine 数值 | llm_inference/worker 直测、engine/plugin md5、export 复现 | F1 md5 + F8 engine md5==HF | Jetson + wsl2 |
+| e2e composition | config→leaf-union pull→engines→/asr+/tts | F6(隔离卷) | Orin NX |
+| N=2 | TTS slot pool、ASR streaming slot-pool、VRAM/竞态 | F5 + F2b 两 slot rc=0 无 OOM | Orin Nano/NX |
+
+### H4. 回归触发点(改 X → 必跑 Y)
+- **换 plugin** → F1 + F3/F4 + F6(C2 blast radius:base TTS + ASR int4 + CV 共享 plugin)。
+- **re-pin overlay** → F1 + F8 + F6 + **全 worker md5 回归**。
+- **换引擎精度** → ASR:F2b;TTS base:F3+F5;CV:F4+F5;默认翻转挂 C1b gate。
+- **换 worker 源** → worker 协议层 + F6 + md5 钉死(ASR firstword 事故教训)。
+- **换 artifact pull 源/mirror** → D4 checksum + F6 first-boot,missing md5 必须 fail loudly。
+- **改 leaf/profile** → F7 + F6。
+- **改 tokenizer/chat-template** → F4/CV smoke(wrong tokenizer→N≤0→垃圾音频)。
+
+### H5. CI 化(防"忘了跑")
+- **进 CI(无 GPU)**:F7(`pytest voxedge/tests/test_engine_inprocess.py` + `server/tests/test_leaf_composition.py`)+ benchmark id/repro 元数据存在性校验。
+- **真机手动**:F1–F6/F8(全需 Jetson/wsl2 GPU)。
+- **防忘**:C1b/C2/C7 的 Done 条件写成 **gate-blocking**;PR 模板强制粘贴 F-gate 编号 + 设备 + engine md5 + worker md5 + artifact checksum(否则视为未验证)。
+
+### H6. 复用现有资产(别新造)
+| 资产 | 路径 | 复用为 |
+|---|---|---|
+| `smoke_tts_multiturn` | `bench/perf/smoke_tts_multiturn.py` | F3/F4 TTS 多轮 smoke(已含 faster-whisper round-trip) |
+| `perf gate.py` | `bench/perf/gate.py` | TTFA/RTF/VRAM gate 收敛入口(口径见数据集) |
+| `test_engine_inprocess` | `voxedge/tests/` | 直接进 CI(F7) |
+| `test_leaf_composition` | `server/tests/` | leaf 契约,进 CI |
+| `toolcall_stability_bench` | (repo) | server-loop 稳定性回归(机械臂用例) |
+| `grasp_cycle_check` | (voice_rebot_arm) | 机械臂 demo/toolcall 回归入口(也是传播 hook) |
+| `sim_pump` | `agent/tests/sim_pump.py` | agent 侧音频/事件泵确定性模拟 |
+| faster-whisper round-trip | F3/F4 | **唯一** TTS 质量 gate(Groq key 已过期,禁用) |
+
+---
+
+## G. DEPRECATION / CLEANUP LIST (flag for user — DO NOT DELETE)
+
+| Item | Type | Why redundant | Confirm-before-delete |
+|---|---|---|---|
+| `~/project/qwen3-edgellm-jetson` | dup checkout | Same HEAD + remote as `jetson-voice-engine` (the pre-rename name). ⚠️ AUDIT: 0 unpushed but **20 uncommitted changes**; and prod compose + `model_downloader.py` still use `QWEN3_EDGELLM_JETSON_ROOT=/opt/qwen3-edgellm-jetson` env path. | review/discard the 20 changes; update env var or keep a compat alias BEFORE rename; then archive |
+| `~/project/tensorrt-edge-llm` | dup checkout | Lowercase clone of the canonical fork `TensorRT-Edge-LLM`. ✅ **RESOLVED 2026-06-21: the 4 commits (893ba2a SlotPool / 7b52dc6 ASR-assistant prefix / 07b500d N-instance slot-pool worker / 766530b shared-engine ctor) PUSHED to `suharvest/v071/customvoice-product` (fast-forward `1668470..893ba2a`, unpushed now 0).** 3 untracked (docs/DIVERGENCE.md, docs/IPC-CONTRACT.md, uv.lock) backed up. Still hardcoded by many jetson-voice-engine `scripts/*.sh` + docs as `~/project/tensorrt-edge-llm`. | **Remaining: rebase all `~/project/tensorrt-edge-llm` path refs → `TensorRT-Edge-LLM` (or env var), then archive.** (data-loss risk cleared) |
+| `~/project/_qwen3tts-port` | **git worktree** | Worktree of fork @ wip/fp8-embedding (873ca22 = same as fork port branch); no direct refs. | low risk; remove via `git worktree remove` (NOT `rm -rf`) after confirming 873ca22 pushed |
+| `~/project/seeed-local-voice-v080` | **git worktree** | Worktree on feat/edgellm-v080-migration, 0 unpushed; per trunk_consolidation feat==main; no refs. | low risk; `git worktree remove` |
+| `~/project/edgellm-v080-migration` | scratch | v0.8.0 worker/compose scratch — HARVEST into overlay (C4) then archive. | after C4 lands its content in jetson-voice-engine |
+| `~/project/voxedge-engine` | deprecated repo | Self-deprecated 2026-06-01 (merged into jetson-voice-engine). | archive (keep README pointer) |
+| `~/project/jetson-qwen3-speech` | legacy | Pre-overlay Jetson Qwen3 speech; superseded. | confirm nothing imports it |
+| `~/project/sensecraft_voice` | non-git scratch (284MB) | Referenced by seeed `docs/specs/ovs-punct-speaker-handoff.md` as PoC for punctuation/speaker capability. | archive (not delete) + repoint the doc; or keep |
+| `~/project/jetson-voice` | non-git empty shell (12KB, only `.claude`+`.DS_Store`) | No refs, empty. | safe to remove |
+| `~/project/jetson-qwen3-speech` | legacy git repo (f689f95, 2026-04) | 0 unpushed; 1 historical doc mention in jetson-voice-engine perf doc. | low risk; archive |
+| `~/project/jetson-llm-benchmark` (detached HEAD) | scratch | Benchmark scratch, 11 uncommitted, no refs. | archive |
+| `~/project/qwen3asr_rk` (external) | **external lib (HF qzxyz, 22GB)** | AUDIT: **NOT ours** — different maintainer, ZERO code overlap with rkvoice-engine (it's a runtime consumer, rkvoice-engine is a model producer); NO canonical code reference (only a hardcoded test path in rkvoice-stream). | **DECISION: out of our consolidation scope — KEEP as-is, do NOT fold into rkvoice-engine, no action.** Remove from this list. |
+| Fork stale branches: `qwen3tts-issue-artifacts-20260516`, `official-*`, `pr-*` | branch cruft | Investigation/PR-prep branches. | user confirms which to prune |
+| seeed-local-voice untracked dirs: `_tts_rate_demo/`, `agent/_grasp_frames*/`, `_ik_envelope_new.csv` | scratch artifacts | Demo/sim scratch, not tracked. | gitignore or remove |
+
+**Untracked in-tree (decide tracked-vs-ignore):** `configs/profiles/jetson-edgellm-v080-moss.json`, `deploy/jetson/Dockerfile.edgellm-moss-nx`, `deploy/asr-worker-v080/` — these are the v0.8.0 deploy basis; **track them** (they belong in the C/D workstreams), don't delete.
+
+---
+
+## DISPATCH NOTES FOR EXECUTORS
+
+- Each of C/D/E/F/G is independently dispatchable. Suggested parallelism: **C1+C6 (now)** ∥ **C2→C3→C4→C5 (chain)**; **D1–D5 after C1**; **E after C2**; **F throughout (gate each C/D step)**; **G last (needs user confirm)**.
+- Every build/deploy dispatch MUST carry the EVIDENCE + no-destructive guardrails (md5s, raw verification output, before/after, `docker logs | grep -iE error|crash|fail`) and the Fleet rules block. NEVER `docker compose down` the prod project; use `up -d <service>` for image swaps. NEVER touch seeed-orin-nx.
+- **Preflight 防误触(每个 deploy/test 任务模板首行强制执行):** 先 `hostname`/`fleet status` 打印目标 → **若命中 `seeed-orin-nx` 立即 STOP**;**拒绝**操作 prod compose project 名;deploy/test 必须用 isolated volume(`~/comp-e2e-models`),**拒绝**挂 prod `speech-models` 卷。preflight 不过不准往下走。
+- ✅ **Data-loss risks CLEARED 2026-06-21:** (1) `tensorrt-edge-llm` 4 unpushed commits → pushed to `suharvest/v071/customvoice-product`; (2) int4 export drivers → `wip/native-int4-talker` + `wip/asr-int4-decoder` both on suharvest, uncommitted working files pulled to Mac backup. **No outstanding data-loss risk.** Remaining C6 work is pure consolidation (relocate drivers into `jetson-voice-engine/recipes/`), not loss-prevention.
+- **Path-hardcode debt (audit-found):** many `jetson-voice-engine/scripts/*.sh` + docs hardcode `~/project/tensorrt-edge-llm` (lowercase); prod compose + `model_downloader.py` use `QWEN3_EDGELLM_JETSON_ROOT=/opt/qwen3-edgellm-jetson`. Rebase refs / add compat alias before any rename or delete. Worktrees (`_qwen3tts-port`, `seeed-local-voice-v080`) → `git worktree remove`, never `rm -rf`.
+```

--- a/docs/plans/voxedge-v080-consolidation/positioning-and-propagation.md
+++ b/docs/plans/voxedge-v080-consolidation/positioning-and-propagation.md
@@ -1,0 +1,174 @@
+# VoxEdge — 定位、分层与传播规划
+
+> 配套文档:`consolidation-plan.md`(代码整合计划)、`code-structure/`(代码结构分析)。
+> 本文解决三件事:① 对外怎么讲清"这是什么"(定位 + 命名分层);② 底层 TensorRT-Edge-LLM 依赖该 fork 还是 patch;③ 怎么做成有传播性、吸引不同层次开发者。
+
+---
+
+## 一、一句话定位
+
+**VoxEdge = 面向边缘设备的开源实时语音 AI 栈。任何边缘芯片,端侧运行,低延迟,可对话。**
+
+- 英文 tagline:*"Real-time voice AI for any edge device. On-device, low-latency, open."*
+- 类比锚点(让人秒懂):**"边缘版的 Pipecat / LiveKit Agents"**——但端侧高性能 + 多后端,不依赖云。
+- 一句话故事:**"VoxEdge 让实时语音在任何边缘设备上跑;OpenVoiceStream 是基于它的开箱即用应用。"**
+
+---
+
+## 二、分层架构(对外清晰:三层,只有一个品牌)
+
+**核心原则:对外只有一个品牌 = VoxEdge(引擎层)。其余一律用"关系"来描述,不再起并列品牌名。**
+这是为了消除 "Voice Stream / Voice Engine" 这类并列命名造成的"到底用哪个"的困惑——两个长得像的名字 = 没人分得清层级。
+
+| 层 | 是什么 | 代码 | 对外叫法 | 受众 |
+|---|---|---|---|---|
+| **引擎层** | 可嵌入的高性能实时语音管线(ASR→LLM→TTS、打断、轮次管理、后端抽象) | `voxedge` | **VoxEdge**(品牌本身,`pip install voxedge`) | 系统/算法开发者 |
+| **后端层** | 各设备的模型执行后端(不是产品,是插件) | TRT-Edge-LLM(Jetson)/ RK(RKNN)/ sherpa(RPi) | "**VoxEdge backends**" | 选设备的开发者 |
+| **应用层** | 基于引擎搭的开箱即用应用 + 示例(不是并列品牌) | OpenVoiceStream + demos | "**built with VoxEdge**"(参考应用/示例) | 应用开发者 |
+
+- 品牌只压在**引擎**上(它才是差异化:高性能 + 多后端 + 端侧)。
+- 一键 Docker 部署的那个 = "**VoxEdge 参考应用**(OpenVoiceStream)";机械臂语音、实时翻译等 = "**VoxEdge 应用示例**"。
+- **不要**把应用层当成跟引擎并列的产品去推。
+
+**两层受众,两套卖点:**
+- 后端/引擎层 → 有开发能力的系统开发者:*"不管你什么设备,都能跑一个高性能实时语音库"*。卖点 = **性能数字 + 多后端覆盖 + 量化深度**。
+- 应用层 → 应用开发者:*"在我们这儿能很方便搭各种语音应用"*。卖点 = **一键部署 + demo gallery + SDK**。
+
+**落到代码 = 3 层 5 个职责单元 / 6 物理仓(与整合计划 B.1 一致;RK = rkvoice-stream + rkvoice-engine 两仓算一个后端职责):**
+
+| 层 | 仓库 | 职责 | 对外叫法 |
+|---|---|---|---|
+| TOP 应用 | `seeed-local-voice` | server + agent apps + demos | "VoxEdge 参考应用/示例" |
+| MIDDLE 引擎 | `voxedge` | 管线 + 后端抽象 + Python 适配 | **VoxEdge**(品牌) |
+| BOTTOM 后端 | `TensorRT-Edge-LLM`(fork) | Jetson runtime+导出 source-of-truth,pin v0.8.0,薄可上游 patch | "Jetson backend" |
+| BOTTOM 后端 | `jetson-voice-engine` | 纯自研不可上游的 Jetson 功能/overlay/recipes | (后端 overlay) |
+| BOTTOM 后端 | `rkvoice-stream`/`rkvoice-engine` | RK NPU 后端 | "RK backend" |
+
+- 仓库数基本不变(~5),变的是**每仓只干一件事 + 删跨仓重复**。
+- **fork vs jetson-voice-engine 切干净**:可上游 bug → fork(薄 patch,合并即归零);纯自研功能 → jetson-voice-engine。
+- 99% 终端用户**不碰任何源码仓**,只 `docker run` + 自动拉 HF 预编译引擎。详见整合计划 B.1。
+
+---
+
+## 三、TensorRT-Edge-LLM 依赖:fork vs patch 的解法
+
+**痛点(你说的):** fork = 每次上游升级迁移税大;patch = 理解成本高、构建复杂。
+
+**解法 —— 关键洞察:我们的增值不是 fork runtime,而是"产出制品的工具"。** 据此把底层拆成三块:
+
+1. **上游 TRT-Edge-LLM = 固定版本依赖 + 一组薄的、编号的 patch(分两类,见整合计划 B.1 三类变更模型)**
+   - **C1 上游 bug 修复**(如 `N≤0` prefill guard):可上游、**合并即归零**,理解成本最低。
+   - **C2 本地 runtime 扩展**(如 fp8-embed wiring、cuBLAS-free tiled GEMM):我们加的 runtime 能力,暂不/不可上游,**长期维护型 patch**,但仍只在 fork 落地(fork = runtime 唯一 source-of-truth),不会出现第二份手写源。
+   - 两类都在 fork;jve 侧的 overlay patch 从 fork **自动生成**,非手写。
+
+2. **我们的 recipes / model-zoo = 量化+导出工具(int4-AWQ + fp8),在上游之上跑,不 fork runtime**
+   - 物理位置 = **`jetson-voice-engine/recipes/`**(class C3),只调 fork 的 export API、pin 一个 fork commit,**不改 runtime**。
+   - 我们的模型导出跟官方不一样,是因为这是**我们额外的优化步骤**——它干净地独立成一层,而不是把 runtime 分叉。
+   - 终端用户想自己量化才会碰这层;大多数人不碰。
+
+3. **预编译优化引擎放 HF(已经有 3 个 bundle)= 终端用户实际消费的东西**
+   - 99% 用户**不编译、不看 fork、不看 patch**:`docker run` + 按配置自动从 HF 拉对应的 int4 引擎。
+   - 已上传:`harvestsu/qwen3-asr-0.6b-int4-v080`、`qwen3-tts-0.6b-base-jetson-trtllm-int4fp8`、`qwen3-tts-0.6b-customvoice-jetson-trtllm-int4fp8`。
+
+> **一句话:** "fork vs patch 的理解成本只对贡献者存在;终端用户看到的永远是『拉引擎 → 跑』。" 所以——patch 集保持小且可上游、recipes 独立成层、引擎预编译分发。
+
+**和代码现状的衔接(AST 分析发现的):** 现在同一批 feature 被编码了两遍——`jetson-voice-engine` 上 8 个 v0.7.1 patch ⟷ fork v0.8.0 已原生;worker 概念在 3 个源码树重复(fork `examples/omni`、jetson-voice-engine `native/edgellm_voice_worker`、seeed `deploy/asr-worker-v080`)。
+→ 整合方向:**fork 的 v0.8.0 = 唯一 source-of-truth**;overlay(jetson-voice-engine)重新 pin 到 v0.8.0、删掉已原生的冗余 patch;worker 收敛到一个树,其余变成 build-input。int4 导出 driver(现只在 `wip/native-int4-talker`)并进 canonical 分支作为 recipes 层。
+
+---
+
+## 四、传播策略
+
+**双受众漏斗 + "wow → run → build" 内容弧:**
+
+1. **Hook(所有人)** — 一个端侧实时 demo,最好是**机械臂听语音实时执行、全程无云**。制造"哇,这怎么做到的"的瞬间。
+2. **→ 系统开发者** — "在你自己的 Jetson / Pi / RK 上,一条命令跑起来" + **benchmark 页**(Orin Nano RTF<1、TTFA 0.2s、int4 省 ~960MB、多路并发)。**性能就是护城河。**
+3. **→ 应用开发者** — "N 行代码搭你自己的" + **demo gallery**(语音机械臂、实时翻译、实时字幕) + SDK quickstart。
+
+**传播必备资产(也是 README/文档要补的):**
+- 杀手级 **landing README**:简化架构图(上面那三层) + 性能表 + demo GIF/视频 + **真·一条命令** quickstart。
+- **benchmarks 文档**——我们性能确实硬,要把数字摆出来。
+- **app gallery**(机械臂 / 翻译 / 字幕,每个配一段视频)。
+- 各层**清晰的贡献路径**("贡献一个后端" / "搭一个应用")。
+- **一键 Docker + 按配置自动拉模型**(整合计划 workstream D)——这是把"看视频的人"转化成"用户"的关键;没有它,漏斗会漏。
+
+**性能指标(可对外的 hero 数字,数据出处见 `benchmarks-dataset.md`):**
+> ⚠️ 只列**已验证 + 有出处**的数字。带 ⚠️ 的为 experimental,**不进 hero/README/Show HN**,仅内部追踪。发布前每个数字须补 repro 元数据(设备/profile/engine md5),见数据集 repro 要求。
+
+| 模型 | 精度 | 关键指标 | 状态 |
+|---|---|---|---|
+| Qwen3-TTS-0.6B base | int4+fp8 | **RTF 0.44 / TTFA 0.21s**(Orin Nano)、−1.06GB/实例、CER==fp16 | ✅ 已验(N=1;N=2 待 gate) |
+| Qwen3-ASR-0.6B | int4-AWQ | ZH CER 0% / EN WER ~11%(短指令)、引擎 −45% | ✅ 解码契约验(未过 production worker) |
+| Qwen3-TTS-0.6B CustomVoice | int4+fp8 | ASR 可懂、talker −660MB | ⚠️ experimental(无 RTF/TTFA、未过 worker) |
+| 覆盖 | — | 多后端(Jetson/RK/RPi)、任意 ASR×TTS 组合 | ✅ |
+
+**启动序列(建议):**
+- **准备期**:README/landing + benchmark + 1–2 个旗舰 demo 视频 + 一键部署可跑。
+- **软发布**:目标社区——Hacker News(Show HN)、Reddit(r/LocalLLaMA、r/embedded、r/selfhosted)、X/Twitter、相关 Discord、NVIDIA Jetson / Rockchip 社区。
+- **内容分发**:短视频(机械臂 wow,面向所有人) + 技术博客(int4 端侧优化的工程深度,钓系统开发者) + quickstart 教程(钓应用开发者)。
+- **定位锚点反复用**:"Pipecat for the edge" / "ollama for voice agents",一句话让人记住。
+
+---
+
+## 五、落地(和整合计划衔接)
+
+- 本文的分层 → 落到代码 canonical repos:`seeed-local-voice`=Apps、`voxedge`=Engine、`TensorRT-Edge-LLM` fork=后端 source-of-truth(见整合计划 A/B)。
+- 命名:对外只推 **VoxEdge**;`OpenVoiceStream` 改称"VoxEdge 参考应用"。
+- 执行顺序接整合计划:C(统一到 v0.8.0)→ D(一键部署 + 自动拉模型)→ E(README/landing + 性能表 + demo gallery)。
+
+**发布前 license / model-card 结论(已调研,2026-06-21):**
+
+| 模型 | License | 商用 | 重分发 engine | 处理 |
+|---|---|---|---|---|
+| Qwen3-TTS-Base / Qwen3-ASR / Qwen3-4B | Apache-2.0 | ✅ | ✅ | 附 LICENSE/NOTICE 即可 |
+| Kokoro-82M | Apache-2.0 | ✅ | ✅ | 同上 |
+| Matcha-TTS(代码) | MIT | ✅ | ✅ | 保留版权 |
+| NVIDIA TensorRT-Edge-LLM(fork base) | Apache-2.0 | ✅ | ✅ | 标注我们的修改文件 |
+| **Paraformer / SenseVoice** | FunASR Model License v1.1(阿里自定义,非 Apache) | ✅ | ✅(有条件) | **必须署名来源 + 随附 MODEL_LICENSE 原文**;含失权条款 |
+| **NLLB-200**(翻译) | **CC-BY-NC-4.0** | ❌ **非商用** | 仅非商用 | **不打进默认包**;翻译做可选组件、只发 recipe、文档标非商用 + 给可商用替代 |
+| **Qwen3-TTS-CustomVoice**(一等公民) | Apache-2.0(随 Qwen 官方) | ✅ | ✅ | **跟随 Qwen 官方 CV license,我们不增不改**:附 Qwen 的 LICENSE/NOTICE 原样分发,使用条款以 Qwen model card 为准,我们不自加额外限制或免责门槛。与 Base 同档处理。 |
+| **MOSS-TTS-Nano** | 元数据 Apache-2.0,但正文有"LICENSE 未发布前视为未授权"兜底语 | ?待核 | ?待核 | 合并前核对仓库根 LICENSE 文件是否落地 Apache 全文;未落地则暂不打包 engine |
+
+→ 发布前出 `LEGAL_AND_LICENSE.md`:第一档(Apache/MIT)随包;FunASR 两个附署名+协议;**NLLB 剥成可选非商用组件**;**CustomVoice 跟随 Qwen 官方 license 原样分发(不自加限制)**;MOSS 核实 LICENSE 文件。
+
+**Launch readiness checklist(全绿才发 Show HN / Reddit):**
+- [ ] `docker compose up` / install.sh 在**干净设备**上一键跑通(对应 plan D)。
+- [ ] HF / mirror 自动拉模型成功 + checksum 校验(对应 plan D4)。
+- [ ] demo 视频里用的 **exact profile 真实存在**且可复现。
+- [ ] 每个对外 hero 数字有 repro 元数据(设备/profile/engine md5),benchmark profile 真实存在。
+- [ ] license matrix 完成,无未澄清的可分发性风险。
+
+> ⚠️ **数据纪律(codex 审核结论):** 对外只用**已验证 + 有出处 + 有 repro 元数据**的数字。当前 CustomVoice int4 仅 experimental(无 RTF/TTFA、未过 streaming worker),**不进 hero/README/Show HN**;ASR int4 是裸解码契约验证、未过 production worker;Base int4+fp8 的 N=2 仍待 gate(只有 fp16 N=2 实测)。详见 `benchmarks-dataset.md` GAPS + repro 要求。
+
+---
+
+## 六、竞品传播复盘(已补:打法验证)
+
+> 全文 `competitor-research.md`(10 个项目 × 6 维度,带源 URL)。下面是对第四节传播策略的**实证校准**。
+
+**对标定位被证实成立:**
+- **"Pipecat for the edge" 锚点直接可用** —— Pipecat 几乎全是云后端,"端侧/本地/量化"正是它给不了的对比维度 = VoxEdge 护城河。tagline 直接用 `VoxEdge — Pipecat for the edge.`
+- **最像的功能竞品是 sherpa-onnx**,但它是"组件库"不是"可对话成品"(无 LLM/打断/轮次/开箱即用 app)。VoxEdge 差异化叙事 = **"成品语音 agent + 机械臂 wow"**,并补 sherpa 缺的 Show HN 首发与一键 demo。
+
+**七条被验证的成功要素(可迁移):**
+1. **首发主战场 = Show HN,标题放可量化钩子**(数字/对标/设备)。范例分数:llama.cpp 1311 / RealtimeVoiceChat 524 / whisper.cpp 399 / Pipecat 346。
+2. **"X for Y" 类比锚**是最高杠杆的一句话定位。
+3. **降低"亲自试"门槛**:live demo > `curl|sh`/`pip` > `docker compose up`。VoxEdge 至少做到 `docker compose up`(呼应 workstream D)。
+4. **"runs on X device" 设备奇观**是端侧独有爆点(whisper.cpp 的 iPhone、llama.cpp 的 MacBook)。VoxEdge 的 Jetson/RK/Pi + **机械臂**是天然弹药。
+5. **两类内容并行打两层受众**:设备奇观录屏(应用开发者,情绪)+ 硬核 benchmark 对比表(系统开发者,数字)。whisper.cpp vs faster-whisper 正是这两条路线范本。
+6. **生态兼容做长期护城河**:OpenAI-compatible API + 多后端可插拔,首屏强调。
+7. **可信度信号 > 营销辞藻**:真机可复现硬数字(与项目内部 perf 纪律一致)、支持矩阵、谦逊工程语气。
+
+**首屏 README 优先级(被验证的排序):** ① emoji headline + "Pipecat for the edge" 副标 → ② 一条延迟硬数字 + 设备名("end-to-end <XXXms on Jetson Orin Nano 8GB") → ③ 机械臂 demo 视频置顶 → ④ 一行 `docker compose up`(视觉焦点) → ⑤ 设备×后端支持矩阵(来自 `benchmarks-dataset.md` 表A) → ⑥ "what you can build" 场景(表B)。**架构图移第二屏。空泛卖点删。**
+
+**机械臂 demo 怎么拍(本赛道最稀缺 wow):** 一镜到底"说话→机械臂立即动→全程离线(拔网线/飞行模式入镜)";屏角叠加实时延迟计时;演示**打断(barge-in)**;入镜真实硬件型号牌;30–60s 主视频 + 2–3min how-it-works(含 `docker compose up` 复现)。
+
+**benchmark 呈现(打系统受众):** faster-whisper 式对比表——VoxEdge(int4/fp8) vs 全精度 vs 云,纵轴 = 端到端延迟/TTFA/显存/**是否离线**/**每分钟成本**。"$0/min 离线 vs 云 per-minute 计费"是 VoxEdge 独占维度。数据全部出自 `benchmarks-dataset.md`,真机可复现附命令。
+
+**四条反面教训(规避):**
+- sherpa-onnx:功能最强但"组件库"无爆点、慢热 → VoxEdge 必须以成品 agent + demo 破局。
+- faster-whisper:硬数字极强但无 demo/无首发 → "墙内开花"被低估 → 光有数字不够,必做首发 + 配 demo。
+- LiveKit:借势 OpenAI 双刃剑 → 护城河叙事落在自身能力(边缘性能+量化+多设备),别押单一合作方。
+- 几乎所有高传播项目首屏都**不放大架构图** → 首屏只留"定位+数字+demo+一行命令"。
+
+**渠道顺序:** Show HN(标题用延迟数字/设备奇观 + 第一人称痛点开场)→ 同步 r/LocalLLaMA + r/selfhosted + r/robotics + Jetson/RPi 设备社区 → X 机械臂短视频争取 Jetson/Seeed KOL 转发 → 进 NVIDIA Jetson / Awesome-edge-AI 列表(第二曲线)→ "每设备/每后端一条 demo"维持复利小爆点。


### PR DESCRIPTION
## Summary

Documentation set for the VoxEdge v0.8.0 N1/N2 work. This branch chains the consolidation planning docs (`docs/voxedge-v080-consolidation`, 491c743) and the verified-benchmark docs (16350a0) into one PR.

- **VoxEdge v0.8.0 consolidation + positioning + benchmarks spec** (491c743) — planning doc set + unified backend structure.
- **Verified N>1 BENCHMARKS + N=2 deploy runbook** (16350a0) — published numbers + step-by-step N=2 deploy.
- **README N>1 section** — N>1 capability + deployment guidance.
- Two submodule bumps for `rkvoice-stream` (RK1828 Phase1 Qwen3-TTS) ride along in the chain (8d98328, d378ee5).

## Verification evidence (N>1 gates, captured in BENCHMARKS)
- **ASR N=2**: CER 0.105, 4429 session-limiter behavior verified.
- **TTS N=2 (int4)**: ~4GB peak — fits 8G and 16G Jetson.
- **shared-engine ctor**: ~436MB VRAM saved at N=2.
- **Zero regression**: 17/20 byte-comparison (zero-degradation) gate.
- Worker / engine md5 + device coords recorded in the runbook.

## Notes
- codex 审查后再合; image / registry push 另议 (none in this PR — docs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)