### PR TITLE
fix(profile): profile_owned_env — profile overrides baked operator keys (CV no -e)

### DIFF
--- a/configs/profiles/jetson-edgellm-v080-customvoice.json
+++ b/configs/profiles/jetson-edgellm-v080-customvoice.json
@@ -44,6 +44,18 @@
     "OVS_TTS_SEED": "42"
   },
   "tts_worker_concurrency": 1,
+  "profile_owned_env": [
+    "EDGE_LLM_TTS_WORKER",
+    "EDGE_LLM_TTS_WORKER_BIN",
+    "EDGE_LLM_TTS_TALKER_DIR",
+    "EDGE_LLM_TTS_CP_DIR",
+    "EDGE_LLM_TTS_CODE2WAV_DIR",
+    "EDGE_LLM_TTS_TOKENIZER_DIR",
+    "EDGE_LLM_TTS_STATEFUL_CODE2WAV",
+    "EDGE_LLM_TTS_CHUNK_FRAMES",
+    "OVS_TTS_MODEL_ID",
+    "OVS_TTS_WORKER_CONCURRENCY"
+  ],
   "required_engines": [
     {
       "model_id": "qwen3-tts-customvoice",

--- a/docs/deploy-customvoice-v080.md
+++ b/docs/deploy-customvoice-v080.md
@@ -49,43 +49,45 @@ code2wav + tokenizer) bakes to `/opt/models/qwen3-tts-customvoice/`.
    value. The CV plugin path therefore MUST live in the **profile env** (it does,
    above) — not just `-e`. *(See "Open items" — this asymmetry is a footgun.)*
 
-3. **The baked entrypoint pre-stamps `EDGE_LLM_TTS_*` + `OVS_TTS_WORKER_CONCURRENCY`.**
-   Those ARE operator-prefixed, so they win over the profile and point the talker
-   at the wrong (baked Base) path → `tts_manager_start_failed`. Until the
-   entrypoint is made conditional, pass the CV paths as explicit `-e` operator
-   overrides. Also `EDGE_LLM_TTS_STATEFUL_CODE2WAV=1` is REQUIRED — the streaming
-   worker uses `_synthesize_worker_via_stream` (gated on `stateful_code2wav_enabled()`);
-   `=0` takes the non-streaming branch that raises `KeyError: 'output_file'`.
+3. **`EDGE_LLM_TTS_STATEFUL_CODE2WAV=1` is REQUIRED** — the streaming worker uses
+   `_synthesize_worker_via_stream` (gated on `stateful_code2wav_enabled()`); `=0`
+   takes the non-streaming branch that raises `KeyError: 'output_file'`. (This is
+   set in the profile env.)
 
-## Run recipe (until the entrypoint is fixed)
+### Solved: the entrypoint-prestamp shadowing (`profile_owned_env`)
 
-Bring up the CV image with the profile **and** these operator `-e` overrides (the
-entrypoint pre-stamp defeats the profile for `EDGE_LLM_TTS_*`/`OVS_TTS_*`):
+The baked entrypoint pre-stamps `EDGE_LLM_TTS_*` + `OVS_TTS_*`. Those are
+operator-prefixed, so `profile_loader` snapshots them as operator-owned and the
+profile's values were silently shadowed → talker pointed at the wrong (baked Base)
+path → `tts_manager_start_failed`. This is now fixed: the profile declares
+`profile_owned_env` (the list of operator-prefixed keys it FULLY owns), and
+`apply_profile` lets the profile override the operator snapshot for exactly those
+keys. **The CV profile owns its TTS engine wiring, so `OVS_PROFILE` alone drives
+it — no `-e` overrides needed.** This is opt-in per profile: profiles that omit
+`profile_owned_env` (e.g. the multilang profiles that rely on baked TTS defaults,
+and the MOSS profile) are byte-identical to before.
+
+## Run recipe
+
+Bring up the CV image with just the profile (and the slim-image host lib mounts):
 
 ```bash
--e OVS_PROFILE=jetson-edgellm-v080-customvoice \
--e EDGE_LLM_TTS_WORKER_BIN=/opt/jv-workers/qwen3_tts_streaming_worker \
--e EDGE_LLM_TTS_TALKER_DIR=/opt/models/qwen3-tts-customvoice/talker_assembled_dir \
--e EDGE_LLM_TTS_CP_DIR=/opt/models/qwen3-tts-customvoice/code_predictor \
--e EDGE_LLM_TTS_CODE2WAV_DIR=/opt/models/qwen3-tts-customvoice/code2wav \
--e EDGE_LLM_TTS_TOKENIZER_DIR=/opt/models/qwen3-tts-customvoice/tokenizer \
--e EDGE_LLM_TTS_STATEFUL_CODE2WAV=1 \
--e OVS_TTS_MODEL_ID=qwen3-tts-customvoice \
--e OVS_TTS_WORKER_CONCURRENCY=1
-# EDGELLM_PLUGIN_PATH comes from the profile (NOT operator-prefixed — see gotcha 2).
+-e OVS_PROFILE=jetson-edgellm-v080-customvoice
+# The profile owns EDGE_LLM_TTS_* + OVS_TTS_* via profile_owned_env, and carries
+# EDGELLM_PLUGIN_PATH (not operator-prefixed). No other -e overrides needed.
 # The :v0.8.0-n1n2-rebake base is a SLIM image: also bind-mount host CUDA/TRT libs
 # (/host-cuda, /host-nvidia-libs, /host-libs) per deploy/jetson-release-highperf.sh.
 ```
 
+> NOTE: this applies to images whose server code includes the `profile_owned_env`
+> support in `profile_loader.py`. A CV image built BEFORE that change still needs
+> the explicit `-e EDGE_LLM_TTS_*` / `OVS_TTS_*` overrides for the same paths.
+
 ## Open items (for review / follow-up)
 
-- **Fix the `EDGELLM_` vs `EDGE_LLM_` operator-prefix asymmetry** in
-  `profile_loader.py` (rename the var to `EDGE_LLM_PLUGIN_PATH`, or add `EDGELLM_`
-  to the operator prefixes). Today the gap *happens* to help (profile carries the
-  CV plugin) but it is a silent footgun.
-- **Make the image entrypoint not pre-stamp `EDGE_LLM_TTS_*`/`OVS_TTS_*`** when a
-  profile supplies them, so the profile alone drives CV (drops the `-e` recipe).
+- **`EDGELLM_` vs `EDGE_LLM_` operator-prefix asymmetry** in `profile_loader.py`
+  is a latent footgun (it currently *helps* — the profile carries the CV plugin).
+  Optional cleanup: rename to `EDGE_LLM_PLUGIN_PATH` for consistency. Not urgent.
 - **Bake the CV bundle to `/opt/models/qwen3-tts-customvoice/`** and re-run the
   through-service gate against the baked `/opt` paths (the PASS above used a
   RO-mounted `/cv-bundle`).
-- **Image push** is held — not pushed to any registry yet.

--- a/server/core/profile_loader.py
+++ b/server/core/profile_loader.py
@@ -246,16 +246,27 @@ def apply_profile(
 
         new_keys = set(merged.keys())
 
+        # Profile-owned operator keys: a profile may declare operator-prefixed
+        # keys it FULLY owns (e.g. a CustomVoice profile owning its EDGE_LLM_TTS_*
+        # engine wiring). For those, the profile's value overrides the import-time
+        # operator snapshot (image-baked defaults / inherited env) instead of being
+        # silently shadowed by it. Default (field absent) = no owned keys =
+        # byte-identical behavior for every existing profile. Use this only when a
+        # profile carries the COMPLETE set of values for those keys; partial
+        # profiles that rely on baked defaults must NOT list them.
+        owned = {str(k) for k in (profile.get("profile_owned_env") or [])}
+        eff_operator = _OPERATOR_KEYS - owned
+
         # 1. Clear stale keys (in previous profile but not in this one),
         #    skipping operator-owned keys.
         stale = _APPLIED_KEYS - new_keys
         for k in stale:
-            if k not in _OPERATOR_KEYS:
+            if k not in eff_operator:
                 os.environ.pop(k, None)
 
         # 2. Write new values, unconditionally overwriting unless operator-owned.
         for k, v in merged.items():
-            if k in _OPERATOR_KEYS:
+            if k in eff_operator:
                 existing = os.environ.get(k)
                 if existing != v:
                     if k in CRITICAL_KEYS:
@@ -275,7 +286,7 @@ def apply_profile(
 
         # 3. Update bookkeeping.
         _APPLIED_KEYS.clear()
-        _APPLIED_KEYS.update(k for k in new_keys if k not in _OPERATOR_KEYS)
+        _APPLIED_KEYS.update(k for k in new_keys if k not in eff_operator)
         _CURRENT_PROFILE = profile
 
         if resolve_engines:

--- a/server/tests/test_profile_loader.py
+++ b/server/tests/test_profile_loader.py
@@ -100,6 +100,49 @@ def test_operator_env_never_overwritten(tmp_path, monkeypatch):
     assert "OVS_OPERATOR_TEST" not in profile_loader.get_applied_keys()
 
 
+def test_profile_owned_env_overrides_operator_baked(tmp_path, monkeypatch):
+    """A profile that declares profile_owned_env owns those operator-prefixed
+    keys: the profile value overrides the import-time operator snapshot (e.g.
+    image-baked EDGE_LLM_TTS_* defaults) instead of being shadowed. Contrast
+    with test_operator_env_never_overwritten (no opt-in → operator wins)."""
+    import os
+
+    # Simulate a baked/operator value present at snapshot time.
+    monkeypatch.setenv("EDGE_LLM_TTS_TALKER_DIR", "/opt/baked/wrong")
+    monkeypatch.setattr(
+        profile_loader, "_OPERATOR_KEYS", frozenset({"EDGE_LLM_TTS_TALKER_DIR"})
+    )
+
+    p = _write_profile(
+        tmp_path, "CV",
+        {
+            "env": {"EDGE_LLM_TTS_TALKER_DIR": "/opt/models/cv/talker"},
+            "profile_owned_env": ["EDGE_LLM_TTS_TALKER_DIR"],
+        },
+    )
+    profile_loader.apply_profile(str(p))
+
+    # Owned → profile wins over the baked snapshot, and it is tracked as applied
+    # (so a later profile switch clears it).
+    assert os.environ["EDGE_LLM_TTS_TALKER_DIR"] == "/opt/models/cv/talker"
+    assert "EDGE_LLM_TTS_TALKER_DIR" in profile_loader.get_applied_keys()
+
+
+def test_profile_owned_env_absent_is_unchanged(tmp_path, monkeypatch):
+    """No profile_owned_env field → byte-identical to today: operator wins."""
+    import os
+
+    monkeypatch.setenv("EDGE_LLM_TTS_TALKER_DIR", "/opt/baked/wins")
+    monkeypatch.setattr(
+        profile_loader, "_OPERATOR_KEYS", frozenset({"EDGE_LLM_TTS_TALKER_DIR"})
+    )
+    p = _write_profile(
+        tmp_path, "P", {"env": {"EDGE_LLM_TTS_TALKER_DIR": "/opt/models/cv/talker"}}
+    )
+    profile_loader.apply_profile(str(p))
+    assert os.environ["EDGE_LLM_TTS_TALKER_DIR"] == "/opt/baked/wins"
+
+
 def test_snapshot_operator_keys_excludes_empty_values(monkeypatch):
     """docker-compose passes declared-but-unset vars as empty strings,
     not unset; these must not be treated as operator-owned (otherwise


### PR DESCRIPTION
Resolves the CustomVoice deploy footgun (codex's design question on #21) — the **safe way**: at the `profile_loader` layer, opt-in per profile. NOT via the entrypoint (which would break `jetson-multilang-*` / MOSS profiles that intentionally rely on baked `EDGE_LLM_TTS_*`/`OVS_TTS_*` defaults — audited).

## Root cause
`profile_loader._snapshot_operator_keys()` snapshots operator-prefixed env at import; image-baked `EDGE_LLM_TTS_*` are thus operator-owned and **shadow the profile** → CV talker pointed at the wrong baked path → `tts_manager_start_failed`. That forced the `-e` override recipe.

## Fix (opt-in, non-breaking)
- New profile field **`profile_owned_env`**: the operator-prefixed keys a profile FULLY owns. `apply_profile` subtracts them from the operator snapshot for that apply, so the profile value wins. **Absent field = byte-identical to today** for every existing profile.
- CV profile opts in for its TTS engine wiring → `OVS_PROFILE=jetson-edgellm-v080-customvoice` alone drives it, **no `-e` needed**.
- Runbook updated; the `EDGELLM_`-vs-`EDGE_LLM_` rename is left as optional non-urgent cleanup (it currently helps).

## Tests
`server/tests/test_profile_loader.py` +2 (owned overrides baked / absent unchanged); **25 pass**.

> Applies to images whose server code includes this change. The already-built `:v0.8.0-n1n2-cv` image (pre-fix) still needs the `-e` recipe; a source-rebuilt image won't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)