### PR TITLE
fix(profile): non-clobbering required_engines env_var for CV TTS (baked /opt)

### DIFF
--- a/configs/profiles/jetson-edgellm-v080-customvoice.json
+++ b/configs/profiles/jetson-edgellm-v080-customvoice.json
@@ -61,21 +61,21 @@
       "model_id": "qwen3-tts-customvoice",
       "engine_file": "llm.engine",
       "engine_path": "/opt/models/qwen3-tts-customvoice/talker_assembled_dir/llm.engine",
-      "env_var": "EDGE_LLM_TTS_TALKER_DIR",
+      "env_var": "EDGE_LLM_TTS_TALKER_ENGINE_FILE",
       "required": true
     },
     {
       "model_id": "qwen3-tts-customvoice",
       "engine_file": "llm.engine",
       "engine_path": "/opt/models/qwen3-tts-customvoice/code_predictor/llm.engine",
-      "env_var": "EDGE_LLM_TTS_CP_DIR",
+      "env_var": "EDGE_LLM_TTS_CP_ENGINE_FILE",
       "required": true
     },
     {
       "model_id": "qwen3-tts-customvoice",
       "engine_file": "code2wav.engine",
       "engine_path": "/opt/models/qwen3-tts-customvoice/code2wav/code2wav.engine",
-      "env_var": "EDGE_LLM_TTS_CODE2WAV_DIR",
+      "env_var": "EDGE_LLM_TTS_CODE2WAV_ENGINE_FILE",
       "required": true
     }
   ],

--- a/docs/deploy-customvoice-v080.md
+++ b/docs/deploy-customvoice-v080.md
@@ -19,6 +19,28 @@ Profile: [`configs/profiles/jetson-edgellm-v080-customvoice.json`](../configs/pr
 Worker reached ready, no `tts_manager_start_failed`, 0 CUDA errors. Standalone
 worker gate (langId 2055/2050 → 9-row, langId -1 → 8-row, all EOS) also PASS.
 
+## Shipped image
+
+`sensecraft-missionpack.seeed.cn/solution/seeed-local-voice:v0.8.0-n1n2-cv`
+digest `sha256:7fa8ba47e6b315516cc12a021ff87994d8a179a5110fce97218520b529a87dde`
+(baked-path through-service gate PASS, zh/en/Base exact). NOTE: this pushed image
+predates the `profile_owned_env` change, so it still needs the `-e EDGE_LLM_TTS_*`
+overrides at runtime. A future image built from current `main` (which has both
+`profile_owned_env` and the `*_ENGINE_FILE` fix below) needs `OVS_PROFILE` only.
+
+### Two baked-`/opt` deploy bugs found + fixed (the `/opt` path had never been served before)
+
+1. **Engine-resolver cache miss** — baked engines must ship `.meta.json` sidecars
+   (host-correct, e.g. `sm87-trt10.3-jp6.2-cuda12.6`) next to each `*.engine`, or
+   the resolver attempts an HF fetch and fails offline. Generate them with the
+   resolver's own `_write_meta` when assembling the bundle.
+2. **`required_engines[].env_var` clobber** — those `env_var`s must NOT reuse the
+   `EDGE_LLM_TTS_TALKER_DIR`/`CP_DIR`/`CODE2WAV_DIR` names the TTS backend reads as
+   **directories**: `resolve_all` overwrites them with the engine **file** path →
+   `tts_manager_start_failed`. The profile now uses non-clobbering
+   `EDGE_LLM_TTS_*_ENGINE_FILE` names (resolver still validates the files; the dir
+   vars from the `env` block survive).
+
 ## Image
 
 Overlay the CV worker + a **dedicated CV plugin** onto the `:v0.8.0-n1n2-rebake`


### PR DESCRIPTION
The CV profile's `required_engines[].env_var` reused `EDGE_LLM_TTS_TALKER_DIR`/`CP_DIR`/`CODE2WAV_DIR` — names the TTS backend reads as **directories**. `engine_resolver.resolve_all` overwrites each `env_var` with the engine **file** path → dir vars clobbered → `tts_manager_start_failed`. Only surfaced when the baked `/opt` path was first served (deploy). Fix: non-clobbering `EDGE_LLM_TTS_*_ENGINE_FILE` names (resolver still validates the files; dir vars from the `env` block survive). Matches the fix baked into the shipped image (`:v0.8.0-n1n2-cv`, `7fa8ba47`). Runbook updated with both baked-/opt bugs + shipped digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)