### PR TITLE
fix(profile): qwen3ttsbase non-clobbering required_engines env_var (latent same bug as CV)

### DIFF
--- a/configs/profiles/jetson-edgellm-v080-qwen3ttsbase.json
+++ b/configs/profiles/jetson-edgellm-v080-qwen3ttsbase.json
@@ -49,21 +49,21 @@
       "model_id": "qwen3-tts-0.6b-base",
       "engine_file": "llm.engine",
       "engine_path": "/opt/models/qwen3-tts-base/engines/talker/llm.engine",
-      "env_var": "EDGE_LLM_TTS_TALKER_DIR",
+      "env_var": "EDGE_LLM_TTS_TALKER_ENGINE_FILE",
       "required": true
     },
     {
       "model_id": "qwen3-tts-0.6b-base",
       "engine_file": "llm.engine",
       "engine_path": "/opt/models/qwen3-tts-base/engines/code_predictor/llm.engine",
-      "env_var": "EDGE_LLM_TTS_CP_DIR",
+      "env_var": "EDGE_LLM_TTS_CP_ENGINE_FILE",
       "required": true
     },
     {
       "model_id": "qwen3-tts-0.6b-base",
       "engine_file": "code2wav.engine",
       "engine_path": "/opt/models/qwen3-tts-base/engines/code2wav/code2wav.engine",
-      "env_var": "EDGE_LLM_TTS_CODE2WAV_DIR",
+      "env_var": "EDGE_LLM_TTS_CODE2WAV_ENGINE_FILE",
       "required": true
     }
   ],


### PR DESCRIPTION
Same latent clobber the CustomVoice profile had (fixed in #23): `required_engines[].env_var` reuses `EDGE_LLM_TTS_TALKER_DIR`/`CP_DIR`/`CODE2WAV_DIR` — names the TTS backend reads as **directories** — and `resolve_all` (startup, `main.py:912`) overwrites each with the engine **FILE** path → `tts_manager_start_failed`. qwen3ttsbase never hit it because it was only verified via the **dev path**, never through production startup `resolve_all` against baked `/opt`. Rename to `EDGE_LLM_TTS_*_ENGINE_FILE` (resolver still validates the files; dir vars from the `env` block survive). Profile-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)