### PR TITLE
fix(deploy): voxedge wheel rebuilt with voxedge.audio included

### DIFF
--- a/deploy/wheels/voxedge.BUILD.txt
+++ b/deploy/wheels/voxedge.BUILD.txt
@@ -1,8 +1,8 @@
 # Provenance for voxedge-0.0.2a0-py3-none-any.whl
 wheel:        voxedge-0.0.2a0-py3-none-any.whl
-wheel_sha256: 8fdf2935a8fd58e96a1b2cb364fb4ecf9db866fbf6dae05c14d135327e202350
+wheel_sha256: 3fa48b831cebeb7e52eea719673d1ff9e1c672630bf6841a3862cea4b995ca2c
 source_repo:  voxedge (../voxedge)
-source_sha:   34edd02384dfe4c6396d5676dc9a56adb6138bdc
+source_sha:   c1a70dee151b664735304cb9ff2758ad8cf5f004
 source_state: clean (origin/main)
-built_at:     2026-07-02T19:15:41Z
-note:         main incl. diarization + SparkTTS backend + rk finalize tuple fix
+built_at:     2026-07-03T12:12:53Z
+note:         adds missing voxedge.audio subpackage (c1a70de); supersedes 8fdf2935 wheel


### PR DESCRIPTION
The 0.0.2a0 wheel merged in #27 omitted the `voxedge/audio` subpackage (explicit packages list in voxedge pyproject predates the dir; fixed upstream in voxedge c1a70de). Runtime effect on jetson-slim: `ModuleNotFoundError: voxedge.audio` from TTS pitch DSP and diarization label paths. This replaces the wheel with a rebuild from voxedge main (sha256 3fa48b83…, provenance in voxedge.BUILD.txt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016D5iyrpqJur3s8KVp5oDZt