### PR TITLE
feat(tts): CPU-ONNX voice enrollment (device-side clone, torch-less)

### DIFF
--- a/server/core/sparktts_voices.py
+++ b/server/core/sparktts_voices.py
@@ -166,6 +166,128 @@ def register_from_profile_files(
     return {"voice_id": vid, "json": jpath, "npz": npath, "registry_count": n}
 
 
+def register_embedding_voice(
+    voice_id: str,
+    embedding_bytes: bytes,
+    sample_rate: int = 24000,
+    ref_text: Optional[str] = None,
+    source_meta: Optional[dict] = None,
+) -> dict:
+    """Persist an *embedding-profile* clone voice (float32[1024] speaker vector).
+
+    Unlike :func:`register_from_profile_files` (SparkTTS ``global_ids`` profiles,
+    consumed by the voxedge ``VoiceRegistry``), this writes a lightweight profile
+    the *server* resolves at synth time: ``<id>.json`` carries
+    ``profile_type: "speaker_embedding"`` and ``<id>.npz`` stores the raw
+    embedding under the key ``speaker_embedding``. The Qwen3 BASE backend has no
+    voice registry — the server loads the npz on demand and forwards the raw
+    ``speaker_embedding`` bytes to the backend (see ``load_embedding_voice`` and
+    ``_request_voice_kwargs`` in server/main.py).
+
+    Do NOT route these through ``register_from_profile_files``: it requires 32
+    ``global_ids`` and would reject an embedding-only profile.
+    """
+    import io
+    import numpy as np  # lazy
+
+    if not voice_id:
+        raise ValueError("voice_id is required")
+    emb = np.frombuffer(embedding_bytes, dtype=np.float32)
+    if emb.size == 0 or emb.nbytes % 4 != 0:
+        raise ValueError("embedding must be a non-empty float32 byte vector")
+    embedding_dim = int(emb.size)
+
+    d = voices_dir()
+    os.makedirs(d, exist_ok=True)
+    safe = _safe_id(voice_id)
+    jpath = os.path.join(d, safe + ".json")
+    npath = os.path.join(d, safe + ".npz")
+
+    buf = io.BytesIO()
+    np.savez(buf, speaker_embedding=emb.astype(np.float32, copy=False))
+    npz_bytes = buf.getvalue()
+
+    j = {
+        "voice_id": voice_id,
+        "npz_file": os.path.basename(npath),
+        "profile_type": "speaker_embedding",
+        "embedding_dim": embedding_dim,
+        "embedding_dtype": "float32",
+        "sample_rate": sample_rate,
+        "ref_text": ref_text,
+        "source_meta": source_meta,
+    }
+
+    with _write_lock:
+        with open(npath, "wb") as f:
+            f.write(npz_bytes)
+        tmp = jpath + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(j, f, ensure_ascii=False, indent=2)
+        os.replace(tmp, jpath)
+
+    # Best-effort registry reload — the SparkTTS VoiceRegistry ignores embedding
+    # profiles (no global_ids), so this is a no-op there, but keeps other
+    # registries in sync when present.
+    n = _reload_live_registry()
+    logger.info(
+        "Registered embedding clone voice %r (dim=%d, registry→%s)",
+        voice_id, embedding_dim, n,
+    )
+    return {
+        "voice_id": voice_id,
+        "json": jpath,
+        "npz": npath,
+        "profile_type": "speaker_embedding",
+        "embedding_dim": embedding_dim,
+        "registry_count": n,
+    }
+
+
+def load_embedding_voice(voice_id: str) -> Optional[bytes]:
+    """Return raw float32 speaker-embedding bytes for an embedding-profile voice.
+
+    Returns ``None`` when the id is unknown or the on-disk profile is not an
+    embedding-profile (e.g. a SparkTTS ``global_ids`` clone) — callers then treat
+    ``voice_id`` as an opaque backend-routed selector instead.
+    """
+    import io
+    import numpy as np  # lazy
+
+    if not voice_id:
+        return None
+    d = voices_dir()
+    safe = _safe_id(voice_id)
+    jpath = os.path.join(d, safe + ".json")
+    if not os.path.isfile(jpath):
+        return None
+    try:
+        with open(jpath, "r", encoding="utf-8") as f:
+            j = json.load(f)
+    except Exception:
+        return None
+    if j.get("profile_type") != "speaker_embedding":
+        return None
+    npz_name = j.get("npz_file") or (safe + ".npz")
+    npath = os.path.join(d, npz_name)
+    if not os.path.isfile(npath):
+        return None
+    try:
+        with open(npath, "rb") as f:
+            npz_bytes = f.read()
+        with np.load(io.BytesIO(npz_bytes)) as npz:
+            key = "speaker_embedding" if "speaker_embedding" in npz else (
+                "d_vector" if "d_vector" in npz else None
+            )
+            if key is None:
+                return None
+            emb = npz[key].reshape(-1).astype(np.float32, copy=False)
+    except Exception:
+        logger.warning("failed loading embedding voice %r", voice_id, exc_info=True)
+        return None
+    return emb.tobytes()
+
+
 def enroll_from_audio(
     wav_bytes: bytes,
     voice_id: str,

--- a/server/core/tts_backend.py
+++ b/server/core/tts_backend.py
@@ -40,6 +40,13 @@ class TTSBackend(ABC):
     # this to True. BackendManager.reload() refuses with HTTP 400 otherwise.
     supports_hot_reload: bool = False
 
+    # Honest device-side voice-enrollment signal. True only when the backend can
+    # extract a speaker embedding from a reference WAV *on this host* (its
+    # ``extract_speaker_embedding`` is usable — e.g. a CPU-ONNX speaker encoder
+    # is present). Distinct from ``VOICE_CLONE`` capability, which only means the
+    # backend can *consume* a raw embedding at synth time. Backends override.
+    supports_voice_enrollment: bool = False
+
     @property
     @abstractmethod
     def name(self) -> str:

--- a/server/main.py
+++ b/server/main.py
@@ -316,8 +316,45 @@ def _request_voice_kwargs(req: TTSRequest, *, backend=None) -> dict:
     # don't recognise it ignore the extra kwarg.
     voice = getattr(req, "voice", None)
     if voice:
-        out["voice"] = voice
+        # Server-side embedding-profile resolution: if `voice` names an
+        # embedding-profile enrolled via /tts/voices/enroll (CPU-ONNX path),
+        # load its raw float32 speaker vector and forward it as
+        # `speaker_embedding` — the Qwen3 BASE backend has no voice registry but
+        # already consumes raw embeddings. SparkTTS `global_ids` clones and any
+        # other opaque selector fall through as a plain `voice` passthrough.
+        from server.core import sparktts_voices
+        emb = sparktts_voices.load_embedding_voice(voice)
+        if emb is not None:
+            if backend is not None and getattr(backend, "supports_voice_cloning", True) is False:
+                from server.core.tts_backend import TTSCapability
+                if not backend.has_capability(TTSCapability.VOICE_CLONE):
+                    raise _VoiceCloneUnsupportedError(backend)
+            out["speaker_embedding"] = emb
+            out.pop("voice", None)
+        else:
+            out["voice"] = voice
     return out
+
+
+def _peek_tts_backend():
+    """Return the live TTS backend for metadata/CPU-only ops (no slot acquire).
+
+    Prefers the BackendManager's current backend (``get_backend_unsafe`` — safe
+    for readiness/metadata queries per its contract), falling back to the legacy
+    ``tts_service`` backend. Used by /tts/voices/enroll to reach the CPU-ONNX
+    ``extract_speaker_embedding`` without holding a synthesis slot. Returns
+    ``None`` when no backend is ready.
+    """
+    mgr = _try_tts_manager()
+    if mgr is not None:
+        try:
+            return mgr.get_backend_unsafe()
+        except Exception:
+            pass
+    from server.core import tts_service
+    if tts_service.is_ready():
+        return tts_service.get_backend()
+    return None
 
 
 def _get_asr_backend():
@@ -1403,6 +1440,7 @@ async def tts_capabilities(_: None = Depends(_require_api_key)):
         "model_id": backend.model_id,
         "capabilities": caps,
         "supports_voice_cloning": getattr(backend, "supports_voice_cloning", "voice_clone" in caps),
+        "supports_voice_enrollment": bool(getattr(backend, "supports_voice_enrollment", False)),
         "sample_rate": tts_service.get_sample_rate(),
         "speakers": available_speakers(backend.model_id),
     }
@@ -1551,13 +1589,55 @@ async def tts_voices_enroll(
     ref_text: str | None = Form(None),
     _: None = Depends(_require_api_key),
 ):
-    """Enroll a clone voice from reference audio by running the analysis chain in-process.
+    """Enroll a clone voice from reference audio.
 
-    Only works on a host with the SparkTTS PyTorch stack (spec §3.2). On a Jetson this
-    returns 501 with guidance to use POST /tts/voices/profile with a host-generated pair.
+    Two paths, tried in order:
+
+      1. **CPU-ONNX (torch-less, preferred on Jetson TRT)** — when the active TTS
+         backend exposes a usable ``extract_speaker_embedding`` (its
+         ``supports_voice_enrollment`` is true because a speaker-encoder ONNX is
+         present). Produces a float32[1024] embedding on ONNX Runtime and persists
+         it as an *embedding-profile* the server resolves at synth time.
+      2. **PyTorch SparkTTS analysis chain** — falls back to the in-process
+         wav2vec2 + BiCodec enroller (host deployments with the torch stack).
+
+    Returns 501 only when neither path is available, with guidance to POST a
+    host-generated ``.json + .npz`` to /tts/voices/profile.
     """
     from server.core import sparktts_voices
     audio = await file.read()
+
+    # Path 1: CPU-ONNX extractor on the active backend (no torch required).
+    backend = _peek_tts_backend()
+    if backend is not None and getattr(backend, "supports_voice_enrollment", False):
+        try:
+            embedding = backend.extract_speaker_embedding(audio)
+        except NotImplementedError:
+            embedding = None
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+        except Exception as exc:  # extractor blew up — surface, don't silently torch-fall
+            logger.warning("ONNX speaker embedding extraction failed", exc_info=True)
+            return JSONResponse(
+                {"error": f"speaker embedding extraction failed: {exc}"},
+                status_code=500,
+            )
+        if embedding:
+            try:
+                res = sparktts_voices.register_embedding_voice(
+                    voice_id,
+                    embedding,
+                    sample_rate=getattr(backend, "sample_rate", 24000),
+                    ref_text=ref_text,
+                    source_meta={"method": "onnx_speaker_encoder",
+                                 "backend": getattr(backend, "name", None)},
+                )
+            except ValueError as exc:
+                return JSONResponse({"error": str(exc)}, status_code=400)
+            res["method"] = "onnx_speaker_encoder"
+            return res
+
+    # Path 2: in-process PyTorch SparkTTS enrollment (host deployments).
     try:
         res = sparktts_voices.enroll_from_audio(audio, voice_id, ref_text=ref_text)
     except sparktts_voices.EnrollmentUnavailable as exc:
@@ -1567,6 +1647,7 @@ async def tts_voices_enroll(
         )
     except ValueError as exc:
         return JSONResponse({"error": str(exc)}, status_code=400)
+    res["method"] = "sparktts_pytorch"
     return res
 
 

--- a/server/tests/test_onnx_voice_enroll.py
+++ b/server/tests/test_onnx_voice_enroll.py
@@ -1,0 +1,188 @@
+"""Device-side voice enrollment via CPU-ONNX (torch-less) — endpoint coverage.
+
+Verifies the acceptance contract for the ONNX enroll path:
+
+  1. POST /tts/voices/enroll succeeds by calling the active backend's
+     ``extract_speaker_embedding`` (CPU-ONNX, float32[1024]) and persisting an
+     *embedding-profile* — even when the PyTorch SparkTTS enroller is absent.
+  2. POST /tts (voice="<id>") resolves that embedding-profile server-side and
+     forwards the raw ``speaker_embedding`` bytes to the backend (closed loop).
+  3. /tts/capabilities exposes ``supports_voice_enrollment``.
+  4. When the backend cannot enroll AND torch is absent → 501 (honest fallback).
+
+Reuses the fake-backend manager harness from ``test_main_hot_swap`` (no CUDA).
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+from server.tests.test_main_hot_swap import (
+    _FakeASRBackend,
+    _FakeTTSBackend,
+    _install_managers,
+)
+
+# The float32[1024] vector the fake ONNX encoder "extracts".
+_ENROLL_EMB = np.zeros(1024, dtype=np.float32).tobytes()
+
+
+class _EnrollTTSBackend(_FakeTTSBackend):
+    """Fake Qwen3 BASE backend: voice-clone + a usable CPU-ONNX enroller."""
+
+    name = "fake-enroll"
+    # supports_voice_enrollment gated True (encoder "present").
+    supports_voice_enrollment = True
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.extract_calls: list[bytes] = []
+
+    def extract_speaker_embedding(self, audio_wav_bytes: bytes) -> bytes:
+        self.extract_calls.append(audio_wav_bytes)
+        return _ENROLL_EMB
+
+
+class _NoEnrollTTSBackend(_FakeTTSBackend):
+    """Fake backend with no CPU-ONNX enroller (Jetson without speaker_encoder)."""
+
+    name = "fake-no-enroll"
+    supports_voice_enrollment = False
+
+
+def _make_client(monkeypatch, tmp_path, tts_be):
+    from server.core import tts_runtime, tts_service, session_limiter
+
+    monkeypatch.setenv("SPARKTTS_VOICES_DIR", str(tmp_path))
+    tts_runtime.reset_overrides()
+    session_limiter._reset_for_tests()
+    session_limiter.init_limiter({"max_concurrent_sessions": 64})
+
+    _install_managers(asr=_FakeASRBackend(), tts=tts_be)
+
+    monkeypatch.setattr(tts_service, "is_ready", lambda: True)
+    monkeypatch.setattr(tts_service, "get_backend", lambda: tts_be)
+    monkeypatch.setattr(tts_service, "is_configured", lambda: True)
+    monkeypatch.setattr(tts_service, "_backend", tts_be, raising=False)
+    monkeypatch.setattr(tts_service, "backend_name", lambda: tts_be.name)
+
+    from server.main import app
+    from server.core.admin_auth import require_admin
+
+    async def _allow():
+        return None
+
+    app.dependency_overrides[require_admin] = _allow
+    c = TestClient(app)
+    c.tts_be = tts_be  # type: ignore[attr-defined]
+    return c
+
+
+@pytest.fixture
+def enroll_client(monkeypatch, tmp_path):
+    c = _make_client(monkeypatch, tmp_path, _EnrollTTSBackend())
+    try:
+        yield c
+    finally:
+        from server.main import app
+        from server.core.admin_auth import require_admin
+        from server.core import backend_manager as bm, session_limiter, tts_runtime
+        app.dependency_overrides.pop(require_admin, None)
+        tts_runtime.reset_overrides()
+        session_limiter._reset_for_tests()
+        bm._reset_for_tests()
+
+
+def test_enroll_via_onnx_persists_embedding_profile(enroll_client, tmp_path):
+    # torch enroller absent → the ONNX path is the only way this can succeed.
+    from server.core import sparktts_voices
+    wav = b"RIFFxxxxWAVE" + b"\x00" * 64
+
+    r = enroll_client.post(
+        "/tts/voices/enroll",
+        data={"voice_id": "clone:onnx"},
+        files={"file": ("ref.wav", wav, "audio/wav")},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["voice_id"] == "clone:onnx"
+    assert body["method"] == "onnx_speaker_encoder"
+    assert body["profile_type"] == "speaker_embedding"
+
+    # Backend extractor actually ran on the uploaded audio.
+    assert enroll_client.tts_be.extract_calls == [wav]
+
+    # Persisted profile round-trips to the exact float32 embedding.
+    raw = sparktts_voices.load_embedding_voice("clone:onnx")
+    assert raw == _ENROLL_EMB
+    assert (tmp_path / "clone_onnx.json").exists()
+    assert (tmp_path / "clone_onnx.npz").exists()
+
+
+def test_stream_resolves_enrolled_voice_to_speaker_embedding(enroll_client):
+    """enroll → /tts voice="<id>" closes the loop: backend gets speaker_embedding."""
+    enroll_client.post(
+        "/tts/voices/enroll",
+        data={"voice_id": "clone:loop"},
+        files={"file": ("ref.wav", b"RIFFxxxxWAVE" + b"\x00" * 64, "audio/wav")},
+    )
+    enroll_client.tts_be.synthesize_calls.clear()
+
+    r = enroll_client.post("/tts", json={"text": "hi", "voice": "clone:loop"})
+    assert r.status_code == 200, r.text
+
+    call = enroll_client.tts_be.synthesize_calls[-1]
+    # Server-side resolution: raw float32 bytes forwarded as speaker_embedding,
+    # and the opaque `voice` selector dropped (BASE backend has no registry).
+    assert call.get("speaker_embedding") == _ENROLL_EMB
+    assert "voice" not in call
+
+
+def test_capabilities_exposes_supports_voice_enrollment(enroll_client):
+    r = enroll_client.get("/tts/capabilities")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["supports_voice_enrollment"] is True
+    # existing signal untouched (zero-regression)
+    assert body["supports_voice_cloning"] is True
+
+
+def test_enroll_501_when_no_onnx_and_no_torch(monkeypatch, tmp_path):
+    """No CPU-ONNX enroller + no torch stack → honest 501 (not a crash)."""
+    from server.core import sparktts_voices
+    monkeypatch.setattr(sparktts_voices, "_load_enroller", lambda md: None)
+
+    c = _make_client(monkeypatch, tmp_path, _NoEnrollTTSBackend())
+    try:
+        r = c.post(
+            "/tts/voices/enroll",
+            data={"voice_id": "clone:x"},
+            files={"file": ("ref.wav", b"\x00\x00", "audio/wav")},
+        )
+        assert r.status_code == 501, r.text
+        assert "hint" in r.json()
+    finally:
+        from server.main import app
+        from server.core.admin_auth import require_admin
+        from server.core import backend_manager as bm, session_limiter, tts_runtime
+        app.dependency_overrides.pop(require_admin, None)
+        tts_runtime.reset_overrides()
+        session_limiter._reset_for_tests()
+        bm._reset_for_tests()
+
+
+def test_capabilities_false_when_backend_cannot_enroll(monkeypatch, tmp_path):
+    c = _make_client(monkeypatch, tmp_path, _NoEnrollTTSBackend())
+    try:
+        r = c.get("/tts/capabilities")
+        assert r.status_code == 200, r.text
+        assert r.json()["supports_voice_enrollment"] is False
+    finally:
+        from server.main import app
+        from server.core.admin_auth import require_admin
+        from server.core import backend_manager as bm, session_limiter, tts_runtime
+        app.dependency_overrides.pop(require_admin, None)
+        tts_runtime.reset_overrides()
+        session_limiter._reset_for_tests()
+        bm._reset_for_tests()

--- a/server/tests/test_sparktts_voices.py
+++ b/server/tests/test_sparktts_voices.py
@@ -79,3 +79,60 @@ def test_enroll_from_audio_unavailable_without_torch(voices_env, monkeypatch):
     monkeypatch.setattr(sparktts_voices, "_load_enroller", lambda md: None)
     with pytest.raises(sparktts_voices.EnrollmentUnavailable):
         sparktts_voices.enroll_from_audio(b"\x00\x00", "clone:x")
+
+
+# --------------------------------------------------------------- embedding-profile
+
+
+def test_register_embedding_voice_writes_float32_profile(voices_env):
+    emb = np.arange(1024, dtype=np.float32)
+    res = sparktts_voices.register_embedding_voice(
+        "clone:emb", emb.tobytes(), sample_rate=24000, ref_text="hello",
+    )
+    assert res["voice_id"] == "clone:emb"
+    assert res["profile_type"] == "speaker_embedding"
+    assert res["embedding_dim"] == 1024
+
+    jpath = voices_env / "clone_emb.json"
+    npath = voices_env / "clone_emb.npz"
+    assert jpath.exists() and npath.exists()
+
+    j = json.loads(jpath.read_text())
+    assert j["profile_type"] == "speaker_embedding"
+    assert j["embedding_dim"] == 1024
+    assert j["embedding_dtype"] == "float32"
+    assert j["npz_file"] == "clone_emb.npz"
+    assert j["sample_rate"] == 24000
+
+    with np.load(npath) as npz:
+        assert "speaker_embedding" in npz
+        stored = npz["speaker_embedding"]
+        assert stored.dtype == np.float32
+        assert stored.shape == (1024,)
+        np.testing.assert_array_equal(stored, emb)
+
+
+def test_register_embedding_voice_rejects_non_float32_aligned(voices_env):
+    with pytest.raises(ValueError):
+        sparktts_voices.register_embedding_voice("clone:bad", b"\x00\x00\x00")  # 3 bytes
+
+
+def test_load_embedding_voice_roundtrip(voices_env):
+    emb = np.linspace(-1.0, 1.0, 1024, dtype=np.float32)
+    sparktts_voices.register_embedding_voice("clone:rt", emb.tobytes())
+    raw = sparktts_voices.load_embedding_voice("clone:rt")
+    assert raw is not None
+    back = np.frombuffer(raw, dtype=np.float32)
+    assert back.shape == (1024,)
+    np.testing.assert_array_equal(back, emb)
+
+
+def test_load_embedding_voice_none_for_unknown(voices_env):
+    assert sparktts_voices.load_embedding_voice("clone:nope") is None
+
+
+def test_load_embedding_voice_ignores_global_ids_profile(voices_env):
+    """A SparkTTS global_ids clone is NOT an embedding-profile → returns None."""
+    jb, nb = _profile_bytes("clone:sparky")
+    sparktts_voices.register_from_profile_files(jb, nb)
+    assert sparktts_voices.load_embedding_voice("clone:sparky") is None


### PR DESCRIPTION
`/tts/voices/enroll` was hardcoded to the torch SparkTTS analysis chain → 501 on Jetson. But the trt_edge_llm TTS backend already has a CPU-ONNX `extract_speaker_embedding` (float32[1024]) and the BASE talker already consumes raw speaker embeddings byte-for-byte. This wires them together.

**Server-side resolution (leaner than a voxedge voice registry):**
- `/tts/voices/enroll`: try backend CPU-ONNX `extract_speaker_embedding` → persist an *embedding-profile* (`register_embedding_voice`, npz `speaker_embedding` float32[1024] + json `profile_type:speaker_embedding`); fall back to torch; then 501.
- `_request_voice_kwargs`: a `voice` selector naming an embedding-profile is resolved to a raw `speaker_embedding` (same capability gate as `speaker_embedding_b64`). SparkTTS `global_ids` clones + named speakers pass through unchanged.
- `/tts/capabilities`: emits `supports_voice_enrollment`.

Companion: voxedge#4 (capability signal). New tests + full server suite 551 passed, 2 skipped, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016D5iyrpqJur3s8KVp5oDZt