### PR TITLE
feat: slim image — single asr-b2 engine serves N=1 + N=2 (~670MB smaller)

### DIFF
--- a/configs/leaves/qwen3-asr-nx-v090.yaml
+++ b/configs/leaves/qwen3-asr-nx-v090.yaml
@@ -9,7 +9,7 @@
 # highperf-v080/ = v0.8.0 paths — engines are NOT cross-version compatible).
 #
 # Full highperf-v090 engine tree (P3 build provenance, md5 first-8):
-#   asr_thinker_full_int4       ASR thinker llm.engine        59e221b5
+#   asr_thinker_full_int4_b2    ASR thinker llm.engine (b2)   75f20e77
 #   asr_audio_encoder           ASR audio encoder             9446e727
 #   tts_talker_int4_b2          CustomVoice talker (int4,b2)  0c9645da
 #   tts_code_predictor          CustomVoice code_predictor    49083fb2

--- a/configs/leaves/qwen3-asr-nx-v090.yaml
+++ b/configs/leaves/qwen3-asr-nx-v090.yaml
@@ -55,10 +55,13 @@ leaves:
       repo: harvestsu/qwen3-edgellm-jetson-artifacts
       files:
         # v0.9.0 engine set under highperf-v090/ (see header for md5 map).
-        - engines/orin-nx/highperf-v090/asr_thinker_full_int4
+        # N=1 shares the BATCH-2 thinker (asr-b2) with N=2 — a batch-2 engine
+        # serves batch-1 requests fine, so the ~874 MB batch-1 engine is dropped
+        # (one engine for both concurrency leaves; the image ships only asr-b2).
+        - engines/orin-nx/highperf-v090/asr_thinker_full_int4_b2
         - engines/orin-nx/highperf-v090/asr_audio_encoder
     runtime_env:
-      EDGE_LLM_ASR_ENGINE_DIR: ${QWEN3_ARTIFACT_ROOT}/engines/orin-nx/highperf-v090/asr_thinker_full_int4
+      EDGE_LLM_ASR_ENGINE_DIR: ${QWEN3_ARTIFACT_ROOT}/engines/orin-nx/highperf-v090/asr_thinker_full_int4_b2
       EDGE_LLM_ASR_AUDIO_ENC_DIR: ${QWEN3_ARTIFACT_ROOT}/engines/orin-nx/highperf-v090/asr_audio_encoder
       # v0.9.0: plugin must be an absolute path (cwd-relative resolution fix).
       EDGELLM_PLUGIN_PATH: /opt/edgellm-v090/libNvInfer_edgellm_plugin.so

--- a/docs/deploy-v090.md
+++ b/docs/deploy-v090.md
@@ -5,9 +5,13 @@ CUDA 12.6 / TensorRT 10.3). All engines, workers, and the plugin are **baked in*
 (`/opt/edgellm-v090`) — no host engine mount, no runtime download. Two profiles:
 **N=1** (single session, lowest RAM) and **N=2** (two concurrent sessions).
 
-- **Image**: `sensecraft-missionpack.seeed.cn/solution/seeed-local-voice:v0.9.0-n1n2-baked-20260706`
-- **Digest**: `sha256:6b9c0cb1893fa3d340d75522fae0ac271a90a6dde34f9786482f734f238c776a`
-- **Size**: 7.74 GB (3.18 GB unique over the shared v090 runtime base)
+- **Image**: `sensecraft-missionpack.seeed.cn/solution/seeed-local-voice:v0.9.0-n1n2-baked-20260707`
+- **Digest**: `sha256:4d54b37a57d4c48d1b00648bf677063ee83174c5bc3da9e846755d38e5228059`
+- **Size**: ~2.5 GB pull. Dominated by the baked TensorRT engines; the base
+  runtime (~353 MB) host-mounts the CUDA/TRT libs so they are not in the image.
+  A single ASR thinker engine (`asr-b2`, batch-2) serves both N=1 and N=2 — the
+  redundant batch-1 engine is dropped (~670 MB saved vs the 20260706 build,
+  which is retained for rollback).
 
 ## What's in it
 
@@ -34,7 +38,7 @@ docker run -d --name seeed-voice-v090 \
   -p 8621:8000 \
   -e OVS_PROFILE=jetson-edgellm-v090-customvoice \
   -e EDGE_LLM_BASE_URL=http://172.17.0.1:8000/v1 \
-  sensecraft-missionpack.seeed.cn/solution/seeed-local-voice:v0.9.0-n1n2-baked-20260706
+  sensecraft-missionpack.seeed.cn/solution/seeed-local-voice:v0.9.0-n1n2-baked-20260707
 ```
 
 ## N=2 — two concurrent sessions
@@ -50,7 +54,7 @@ docker run -d --name seeed-voice-v090-n2 \
   -p 8621:8000 \
   -e OVS_PROFILE=jetson-edgellm-v090-n2 \
   -e EDGE_LLM_BASE_URL=http://172.17.0.1:8000/v1 \
-  sensecraft-missionpack.seeed.cn/solution/seeed-local-voice:v0.9.0-n1n2-baked-20260706
+  sensecraft-missionpack.seeed.cn/solution/seeed-local-voice:v0.9.0-n1n2-baked-20260707
 ```
 
 The `-n2` profile carries the session-gate env itself (profile_owned_env), so no

--- a/docs/deploy-v090.md
+++ b/docs/deploy-v090.md
@@ -17,7 +17,7 @@ CUDA 12.6 / TensorRT 10.3). All engines, workers, and the plugin are **baked in*
 
 | Piece | Version / detail |
 |---|---|
-| ASR | Qwen3-ASR 0.6B int4 (streaming; batch-1 for N=1 + batch-2 `asr-b2` for N=2) |
+| ASR | Qwen3-ASR 0.6B int4 (streaming; batch-2 `asr-b2` serves both N=1 and N=2) |
 | TTS | Qwen3-TTS-12Hz-0.6B CustomVoice int4 (native streaming, lean code2wav) |
 | Runtime | TensorRT-Edge-LLM v0.9.0 (`integration/v090-sparktts`), voxedge `0.0.4a0` |
 | Concurrency | N=1 (`-customvoice` profile) or N=2 (`-n2` profile, shared-engine TTS + `asr-b2`) |

--- a/server/tests/test_composition_boot.py
+++ b/server/tests/test_composition_boot.py
@@ -207,10 +207,12 @@ def test_v090_active_sets_env_and_omits_mel_keys():
         }
     })
 
-    # v0.9.0 engine set: highperf-v090, int4 thinker.
+    # v0.9.0 engine set: highperf-v090, int4 thinker. N=2 (and now N=1) use the
+    # batch-2 thinker (asr-b2) — a batch-2 engine serves batch-1 too, so the
+    # redundant batch-1 engine is dropped.
     assert os.environ["EDGE_LLM_ASR_ENGINE_DIR"] == (
         "/opt/models/qwen3-edgellm/engines/orin-nx/highperf-v090/"
-        "asr_thinker_full_int4"
+        "asr_thinker_full_int4_b2"
     )
     # v0.9.0 requires an ABSOLUTE plugin path (cwd-resolution fix).
     assert os.environ["EDGELLM_PLUGIN_PATH"] == (

--- a/server/tests/test_leaf_composition.py
+++ b/server/tests/test_leaf_composition.py
@@ -643,7 +643,7 @@ def test_v090_asr_env_points_at_highperf_v090(registry):
     )
     assert env["EDGE_LLM_ASR_ENGINE_DIR"] == (
         "/opt/models/qwen3-edgellm/engines/orin-nx/highperf-v090/"
-        "asr_thinker_full_int4"
+        "asr_thinker_full_int4_b2"
     )
     assert env["EDGE_LLM_ASR_AUDIO_ENC_DIR"] == (
         "/opt/models/qwen3-edgellm/engines/orin-nx/highperf-v090/"


### PR DESCRIPTION
Drops the redundant batch-1 ASR engine: a batch-2 engine (`asr-b2`) serves batch-1 requests fine, so N=1 and N=2 share one ASR thinker. Image ~3.18GB → ~2.5GB pull.

## Changes
- **n1 ASR leaf** → `asr_thinker_full_int4_b2` (both N=1 and N=2 leaves now use asr-b2).
- **test fixes**: the two v090 ASR composition assertions expected the dropped batch-1 path — updated to `asr_thinker_full_int4_b2`. (These were latent-red on main since the n2 leaf moved to asr-b2 in #33; local-gates does not exercise these composition tests.)
- **deploy README** → new slim image tag `v0.9.0-n1n2-baked-20260707` (digest sha256:4d54b37a), corrected size framing (docker's 7.74GB was virtual; actual pull ~2.5GB, base ~353MB host-mounts GPU libs).

## Verified on-device (orin-nx, 2026-07-07)
Rebuilt without the batch-1 engine, baked ASR engine dir → asr-b2. **N=1** (customvoice): ASR worker runs on `asr_thinker_full_int4_b2`, CER 0, TTS energy OK, 0 CUDA — no regression on the batch-2 engine. **N=2** (n2): 2 concurrent /asr CER 0 no cross-talk, 3rd → 4429, 0 CUDA. Image pushed (digest 4d54b37a); the 20260706 build is retained for rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHEXK41deYx6375K4q3MQb