### PR TITLE
feat(demos): per-kind multi-engine switching + model-name switchers in every demo

### DIFF
--- a/demos/asr-caption/backend/main.py
+++ b/demos/asr-caption/backend/main.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import sys
 from pathlib import Path
 from urllib.parse import urlsplit
 
@@ -34,7 +35,16 @@ _HERE = Path(__file__).resolve().parent          # demos/asr-caption/backend
 _APP_DIR = _HERE.parent                           # demos/asr-caption
 _DEMOS_DIR = _APP_DIR.parent                      # demos/
 
+# Allow running as a plain script (`uv run python asr-caption/backend/main.py`):
+# the demos/ dir must be importable for common.backend.* .
+if str(_DEMOS_DIR) not in sys.path:
+    sys.path.insert(0, str(_DEMOS_DIR))
+
+from common.backend.slv_proxy import SLVProxy  # noqa: E402
+from common.backend.switch_api import register_switch_routes  # noqa: E402
+
 DEFAULT_SLV_URL = "http://127.0.0.1:8621"
+_DEFAULT_PROFILES_DIR = _DEMOS_DIR.parent / "configs" / "profiles"
 _LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1", "0.0.0.0"}
 
 
@@ -56,18 +66,20 @@ def _ws_endpoint(slv_url: str) -> dict:
     }
 
 
-def create_app(slv_url: str | None = None) -> FastAPI:
+def create_app(slv_url: str | None = None, proxy: SLVProxy | None = None) -> FastAPI:
     slv_url = (slv_url or os.environ.get("SLV_URL") or DEFAULT_SLV_URL).rstrip("/")
+    # The model-switch panel proxies SLV admin routes through this backend; the
+    # WS mic/caption path still hits SLV directly from the browser.
+    slv = proxy or SLVProxy(base_url=slv_url)
 
     @contextlib.asynccontextmanager
     async def _lifespan(_app: FastAPI):
-        # No pooled resources yet (the browser connects to SLV directly);
-        # kept for parity with the gallery app factory so future proxy
-        # clients get a teardown home.
         yield
+        await slv.aclose()
 
     app = FastAPI(title="slv-demo-asr-caption", docs_url=None, redoc_url=None,
                   lifespan=_lifespan)
+    profiles_dir = Path(os.environ.get("DEMO_PROFILES_DIR") or _DEFAULT_PROFILES_DIR)
 
     @app.get("/healthz")
     async def healthz() -> dict:
@@ -80,6 +92,13 @@ def create_app(slv_url: str | None = None) -> FastAPI:
             "ws": _ws_endpoint(slv_url),
             "asr_path": "/asr/stream",
         }
+
+    # Shared model-switch API (/api/status, /api/profiles, /api/switch) — this
+    # demo only exercises ASR, but the routes serve every kind; the frontend
+    # panel is pinned to ["asr"]. Registered BEFORE the static mount.
+    register_switch_routes(
+        app, slv, profiles_dir, asr_label=os.environ.get("DEMO_ASR_MODEL_ID")
+    )
 
     # Static frontend (mounted last so /api/* and /healthz win).
     common_frontend = _DEMOS_DIR / "common" / "frontend"

--- a/demos/asr-caption/frontend/index.html
+++ b/demos/asr-caption/frontend/index.html
@@ -166,6 +166,11 @@
     <div class="metrics" id="metrics"></div>
 
     <section class="panel">
+      <h2 data-i18n="switchTitle"></h2>
+      <div id="switch-panel"></div>
+    </section>
+
+    <section class="panel">
       <h2 data-i18n="langBadgeTitle"></h2>
       <div class="lang-badge-row" id="lang-badge-row"></div>
       <p class="muted" style="font-size: var(--fs-small); margin-bottom: 0;" data-i18n="langBadgeHint"></p>
@@ -189,7 +194,7 @@
 <footer class="footer" data-i18n="footer"></footer>
 
 <script type="module">
-import { createStatusPill, createMetricCard } from "/common/ui.js";
+import { createStatusPill, createMetricCard, createModelSwitchPanel } from "/common/ui.js";
 import { ASRStreamClient } from "/common/slv-client.js";
 import { MicCapture } from "/common/mic-capture.js";
 
@@ -203,6 +208,7 @@ const I18N = {
     hintIdle: "点击麦克风按钮，边说边出字。",
     hintStarting: "正在打开麦克风并连接语音服务…",
     hintRecording: "正在聆听 —— 直接说话，停顿后自动定格成句。",
+    switchTitle: "模型切换",
     captionsTitle: "字幕",
     captionsEmpty: "字幕会实时出现在这里",
     metricPartial: "本句首响", metricFinal: "定格延迟",
@@ -229,6 +235,7 @@ const I18N = {
     hintIdle: "Tap the mic button and watch words appear as you speak.",
     hintStarting: "Opening the microphone and connecting to the voice server…",
     hintRecording: "Listening — just talk; a pause settles the sentence.",
+    switchTitle: "Switch model",
     captionsTitle: "Captions",
     captionsEmpty: "Captions will appear here in real time",
     metricPartial: "First partial", metricFinal: "Final settle",
@@ -540,6 +547,10 @@ applyStaticI18n();
 partialCard.setLabel(t("metricPartial"));
 finalCard.setLabel(t("metricFinal"));
 render();
+
+// Inline model switch — this demo only exercises ASR, so pin the panel to it
+// (hides the ASR/TTS toggle). Talks to this backend's shared /api/switch.
+createModelSwitchPanel($("switch-panel"), { kinds: ["asr"] });
 </script>
 </body>
 </html>

--- a/demos/common/backend/switch_api.py
+++ b/demos/common/backend/switch_api.py
@@ -1,0 +1,349 @@
+"""Shared model-switch API for demo backends.
+
+Registers the three endpoints the shared switch panel
+(``common/frontend/ui.js`` → ``createModelSwitchPanel``) talks to:
+
+    GET  {api}/profiles  profiles from ``profiles_dir`` filtered by device
+                         platform + SLV loadable pre-flight, then collapsed to
+                         one entry per distinct model (Qwen3-ASR / Matcha / …).
+    GET  {api}/status    aggregated SLV health + backend status (drives the
+                         "current model" line and the settle poll).
+    POST {api}/switch    validated proxy to SLV /admin/backend/reload.
+
+The logic here was lifted verbatim from the gallery backend so every consumer
+(gallery portal + each demo page) offers an identical switch experience. Do not
+change the model-identity / dedupe behavior — only its home moved.
+
+Usage (in a demo's ``create_app``)::
+
+    slv = SLVProxy()  # reads SLV_URL / SLV_ADMIN_KEY
+    register_switch_routes(app, slv, profiles_dir,
+                           asr_label=os.environ.get("DEMO_ASR_MODEL_ID"))
+    # ... then mount the static frontend LAST so /api/* wins.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Literal, Optional
+
+import httpx
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from .slv_proxy import ProbeResult, SLVProxy
+
+
+# ── profile listing / platform filtering ────────────────────────────────────
+
+
+def _platform_tokens(probe: ProbeResult) -> set[str]:
+    """Derive platform tokens from SLV-reported backend names.
+
+    Backend names follow ``<platform>.<engine>`` (e.g. ``jetson.trt_edge_llm``);
+    the profile files follow ``<platform>-<combo>.json``. We keep this
+    deliberately simple: collect the dotted prefixes; a profile matches when
+    its filename prefix equals a token or starts with one (``rk`` matches
+    ``rk3576``). No tokens derivable => no filtering.
+    """
+    tokens: set[str] = set()
+    sources = []
+    if probe.health:
+        sources += [probe.health.get("asr_backend"), probe.health.get("tts_backend")]
+    if probe.backend_status:
+        for kind in ("asr", "tts"):
+            entry = probe.backend_status.get(kind) or {}
+            sources.append(entry.get("backend_name"))
+            # Live SLV reports undotted backend names (e.g. ``matcha_trt``);
+            # the loaded profile name (``jetson-qwen3asr-matcha-nx``) is the
+            # reliable platform carrier, so derive a token from its prefix too.
+            profile_name = entry.get("profile_name")
+            if isinstance(profile_name, str) and "-" in profile_name:
+                prefix = profile_name.split("-", 1)[0].strip().lower()
+                if prefix:
+                    tokens.add(prefix)
+    for name in sources:
+        if isinstance(name, str) and "." in name:
+            prefix = name.split(".", 1)[0].strip().lower()
+            if prefix:
+                tokens.add(prefix)
+    return tokens
+
+
+# Friendly model names for the switch dropdown. The list shows ENGINES/MODELS,
+# not bundle-profile stems: several profiles share one ASR engine (e.g. every
+# trt_edge_llm profile = the same Qwen3-ASR) and must collapse to one entry.
+# ASR keys off the backend (no per-profile asr_model_id exists); TTS keys off
+# tts_model_id (customvoice vs base are the SAME backend but DIFFERENT models).
+_ASR_MODEL_LABELS = {
+    "jetson.trt_edge_llm": "Qwen3-ASR",
+    "jetson.paraformer_trt": "Paraformer",
+    "jetson.sensevoice_trt": "SenseVoice",
+    "rk.sensevoice": "SenseVoice",
+    "sherpa.sensevoice": "SenseVoice",
+}
+_TTS_MODEL_LABELS = {
+    "qwen3-tts-0.6b-base": "Qwen3-TTS",
+    "qwen3-tts-customvoice": "CustomVoice",
+    "matcha-icefall-zh-en": "Matcha",
+    "kokoro-multi-lang-v1_0": "Kokoro",
+    "moss-tts-nano-v1": "MOSS",
+}
+
+
+def _prettify_key(key: str) -> str:
+    """Fallback label for an unmapped engine/model id."""
+    tail = str(key).split(".")[-1]
+    return tail.replace("_", " ").replace("-", " ").strip().title() or str(key)
+
+
+def _model_identity(entry: dict, kind: str) -> Optional[tuple[str, str]]:
+    """(model_key, display_label) for a profile in ``kind``, or None when the
+    profile declares no backend for that kind (so it never pollutes the list)."""
+    if kind == "asr":
+        be = entry.get("asr_backend")
+        if not be:
+            return None
+        return be, _ASR_MODEL_LABELS.get(be, _prettify_key(be))
+    be = entry.get("tts_backend")
+    if not be:
+        return None
+    mid = entry.get("tts_model_id") or be
+    return mid, _TTS_MODEL_LABELS.get(mid, _prettify_key(mid))
+
+
+def _dedupe_by_model(profiles: list[dict], kind: str, current_profile: Optional[str]) -> list[dict]:
+    """Collapse bundle profiles to one entry per distinct model, labelled by
+    model name. ``name`` stays a representative profile stem to reload; ``label``
+    is what the dropdown shows; ``current`` marks the loaded model."""
+    cur_key = None
+    if current_profile:
+        cur_key_pair = _model_identity(
+            next((p for p in profiles if (p.get("name") == current_profile
+                  or _profile_stem(p) == current_profile)), {}),
+            kind,
+        )
+        cur_key = cur_key_pair[0] if cur_key_pair else None
+    out: list[dict] = []
+    seen: dict[str, dict] = {}
+    for p in profiles:
+        ident = _model_identity(p, kind)
+        if ident is None:
+            continue  # profile provides no backend for this kind
+        key, label = ident
+        if key in seen:
+            continue
+        entry = {
+            "name": _profile_stem(p) or p.get("name"),  # representative profile to reload
+            "label": label,
+            "model_key": key,
+            "description": p.get("description", ""),
+            "current": key == cur_key,
+        }
+        seen[key] = entry
+        out.append(entry)
+    return out
+
+
+def _list_profiles(profiles_dir: Path, probe: ProbeResult) -> dict:
+    if not profiles_dir.is_dir():
+        return {"profiles": [], "filtered": False, "platforms": [],
+                "error": f"profiles dir not found: {profiles_dir}"}
+
+    tokens = _platform_tokens(probe)
+    # Optional operator allowlist: DEMO_SWITCH_PROFILES="a,b,c" restricts the
+    # switch panel to exactly these profile stems (e.g. only the profiles whose
+    # engines are actually loadable on this SLV). When unset, fall back to the
+    # device-platform filter. Matches by filename stem or logical name.
+    allow = {s.strip() for s in (os.environ.get("DEMO_SWITCH_PROFILES") or "").split(",") if s.strip()}
+    profiles = []
+    for path in sorted(profiles_dir.glob("*.json")):
+        prefix = path.stem.split("-", 1)[0].lower()
+        if allow:
+            if path.stem not in allow:
+                continue
+        elif tokens and not any(prefix == t or prefix.startswith(t) for t in tokens):
+            continue
+        entry = {"name": path.stem, "file": path.name}
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            entry["name"] = data.get("name", path.stem)
+            entry["description"] = data.get("description", "")
+            entry["asr_backend"] = data.get("asr_backend")
+            entry["tts_backend"] = data.get("tts_backend")
+            entry["tts_model_id"] = data.get("tts_model_id")
+        except Exception as exc:  # noqa: BLE001 — a broken profile shouldn't hide the rest
+            entry["error"] = f"unreadable: {type(exc).__name__}"
+        profiles.append(entry)
+    return {"profiles": profiles, "filtered": bool(tokens), "platforms": sorted(tokens)}
+
+
+async def _fetch_loadable_names(slv: SLVProxy, kind: str) -> Optional[set[str]]:
+    """Ask SLV which profiles it can actually load for ``kind``.
+
+    Returns the set of loadable profile names on success, or ``None`` when the
+    SLV doesn't expose ``/admin/backend/loadable`` (older image), is
+    unreachable, rejects admin auth, or returns a malformed body — in every
+    such case the caller must fall back to the unfiltered listing.
+    """
+    try:
+        resp = await slv.admin_get("/admin/backend/loadable")
+    except Exception:  # noqa: BLE001 — SLV down / transport error → graceful fallback
+        return None
+    if resp.status_code != 200:
+        return None
+    try:
+        data = resp.json()
+    except ValueError:
+        return None
+    section = data.get(kind)
+    if not isinstance(section, dict):
+        return None
+    loadable = section.get("loadable")
+    if not isinstance(loadable, list):
+        return None
+    return {str(n) for n in loadable}
+
+
+def _profile_stem(entry: dict) -> str:
+    file = entry.get("file") or ""
+    return file[: -len(".json")] if file.endswith(".json") else ""
+
+
+def _allowed_profile_names(profiles_dir: Path) -> set[str]:
+    """Names accepted by /api/switch: every profile JSON in the directory,
+    by logical name and by filename stem (SLV resolves both)."""
+    allowed: set[str] = set()
+    if not profiles_dir.is_dir():
+        return allowed
+    for path in profiles_dir.glob("*.json"):
+        allowed.add(path.stem)
+        try:
+            name = json.loads(path.read_text(encoding="utf-8")).get("name")
+            if isinstance(name, str) and name:
+                allowed.add(name)
+        except Exception:  # noqa: BLE001
+            pass
+    return allowed
+
+
+# ── route registration ───────────────────────────────────────────────────────
+
+
+class SwitchRequest(BaseModel):
+    kind: Literal["tts", "asr"]
+    profile: str
+    drain_timeout_s: Optional[float] = None
+
+
+def register_switch_routes(
+    app: FastAPI,
+    slv: SLVProxy,
+    profiles_dir: Path,
+    *,
+    asr_label: Optional[str] = None,
+    kiosk: bool = False,
+) -> None:
+    """Register ``/api/status``, ``/api/profiles`` and ``/api/switch`` on ``app``.
+
+    ``slv`` is the shared :class:`SLVProxy`; ``profiles_dir`` the directory of
+    profile JSONs offered in the switch panel. ``asr_label`` (typically
+    ``DEMO_ASR_MODEL_ID``) is surfaced as the ASR status pill model when SLV
+    reports no ``model_id``. ``kiosk`` is echoed on ``/api/status`` for parity
+    with the gallery.
+
+    MUST be called BEFORE mounting the static frontend at ``/`` so the /api/*
+    routes take precedence over the ``html=True`` catch-all.
+    """
+    profiles_dir = Path(profiles_dir)
+
+    @app.get("/api/status")
+    async def api_status() -> dict:
+        probe = await slv.probe()
+        slv_dict = probe.to_dict()
+        # Presentation label: the SLV doesn't expose an ASR model_id (only the
+        # engine name). If the operator sets DEMO_ASR_MODEL_ID, surface it so the
+        # ASR status pill shows the model instead of the raw engine. (The proper
+        # fix is server-side /asr/capabilities model_id; this is the demo-layer
+        # fallback until images ship that.)
+        label = (asr_label or "").strip()
+        if label:
+            ac = slv_dict.get("asr_capabilities")
+            if isinstance(ac, dict) and not ac.get("model_id"):
+                ac["model_id"] = label
+        return {
+            "kiosk": kiosk,
+            "slv_url": slv.base_url,
+            "degraded": bool(probe.errors),
+            "slv": slv_dict,
+        }
+
+    @app.get("/api/profiles")
+    async def api_profiles(kind: Optional[str] = None) -> dict:
+        probe = await slv.probe()
+        result = _list_profiles(profiles_dir, probe)
+        result["slv_reachable"] = probe.reachable
+        result["loadable_filtered"] = False
+        # When a kind is requested, narrow the listing to profiles the SLV can
+        # actually load for that kind (real artifact pre-flight). If the SLV
+        # can't answer (old image / down / no admin key), keep the existing
+        # platform-filtered listing untouched.
+        if kind in ("tts", "asr"):
+            loadable = await _fetch_loadable_names(slv, kind)
+            if loadable is not None:
+                result["profiles"] = [
+                    p for p in result.get("profiles", [])
+                    if (p.get("name") or "") in loadable
+                    or (_profile_stem(p) and _profile_stem(p) in loadable)
+                ]
+                result["loadable_filtered"] = True
+            # Collapse bundle profiles into one entry per distinct model, shown
+            # by model name (Qwen3-ASR / Paraformer / Matcha / …) rather than
+            # bundle stem. Also drops profiles that don't provide this kind.
+            cur = ((probe.backend_status or {}).get(kind) or {}).get("profile_name")
+            result["profiles"] = _dedupe_by_model(result.get("profiles", []), kind, cur)
+        return result
+
+    @app.post("/api/switch")
+    async def api_switch(req: SwitchRequest):
+        # Allow only what /api/profiles offers: platform-filtered when the
+        # device platform is derivable, so a jetson-* profile can't be sent
+        # to an RK box (and vice versa) just by crafting the POST.
+        probe = await slv.probe()
+        listing = _list_profiles(profiles_dir, probe)
+        allowed: set[str] = set()
+        for p in listing.get("profiles", []):
+            allowed.add(p.get("name") or "")
+            file = p.get("file") or ""
+            if file.endswith(".json"):
+                allowed.add(file[: -len(".json")])
+        allowed.discard("")
+        if not listing.get("filtered"):
+            allowed |= _allowed_profile_names(profiles_dir)
+        if req.profile not in allowed:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": "profile_not_allowed",
+                    "profile": req.profile,
+                    "hint": "profile must be one of GET /api/profiles",
+                },
+            )
+        try:
+            resp = await slv.reload_backend(
+                req.kind, req.profile, drain_timeout_s=req.drain_timeout_s
+            )
+        except httpx.HTTPError as exc:
+            raise HTTPException(
+                status_code=502,
+                detail={"error": "slv_unreachable", "message": str(exc)},
+            ) from exc
+        # Pass SLV's verdict (reloaded / rolled_back / 4xx detail) through as-is.
+        try:
+            body = resp.json()
+        except ValueError:
+            body = {"error": "invalid_slv_response", "text": resp.text[:500]}
+        return JSONResponse(body, status_code=resp.status_code)

--- a/demos/common/frontend/ui.js
+++ b/demos/common/frontend/ui.js
@@ -153,9 +153,12 @@ export function createModelSwitchPanel(container, opts = {}) {
   let lastStatus = null;
   function renderCurrent() {
     const entry = lastStatus?.slv?.backend_status?.[kind];
-    currentLine.textContent = entry
-      ? `${S.current}: ${entry.profile_name || "?"} (${entry.backend_name || "?"}, ${entry.state || "?"})`
-      : "";
+    if (!entry) { currentLine.textContent = ""; return; }
+    // Prefer the friendly model name (the deduped list marks the loaded one);
+    // fall back to the raw backend name when the list hasn't loaded yet.
+    const cur = profiles.find((p) => p.current);
+    const model = cur?.label || entry.backend_name || "?";
+    currentLine.textContent = `${S.current}: ${model} (${entry.state || "?"})`;
   }
 
   async function refresh() {
@@ -178,8 +181,11 @@ export function createModelSwitchPanel(container, opts = {}) {
         switchBtn.disabled = true;
       } else {
         for (const p of profiles) {
-          const opt = el("option", "", p.name);
+          // Show the MODEL name (Qwen3-ASR / Matcha / …), not the bundle stem;
+          // value stays the representative profile the SLV reloads.
+          const opt = el("option", "", p.label || p.name);
           opt.value = p.name;
+          if (p.current) opt.selected = true;
           select.appendChild(opt);
         }
         switchBtn.disabled = noReload[kind];

--- a/demos/common/frontend/ui.js
+++ b/demos/common/frontend/ui.js
@@ -93,6 +93,7 @@ const DEFAULT_STRINGS = {
   unreachable: "语音服务不可达",
   current: "当前",
   noProfiles: "没有可用的模型组合",
+  noLoadable: "该设备无可切换的 {kind} 模型",
   noHotReload: "该设备的引擎不支持运行时切换（更换模型需重启容器）",
 };
 
@@ -125,16 +126,19 @@ export function createModelSwitchPanel(container, opts = {}) {
 
   let kind = "tts";
   let profiles = [];
+  let loadableFiltered = false;
   let pollTimer = null;
 
   function setKind(newKind) {
     kind = newKind;
     btnTts.classList.toggle("active", kind === "tts");
     btnAsr.classList.toggle("active", kind === "asr");
-    switchBtn.disabled = noReload[kind] || !profiles.length;
     result.className = noReload[kind] ? "switch-result warn" : "switch-result";
     result.textContent = noReload[kind] ? S.noHotReload : "";
     renderCurrent();
+    // Each kind has its own loadable set — re-fetch scoped to this kind so the
+    // dropdown only lists profiles the device can actually load for it.
+    refresh();
   }
   btnTts.addEventListener("click", () => setKind("tts"));
   btnAsr.addEventListener("click", () => setKind("asr"));
@@ -157,14 +161,20 @@ export function createModelSwitchPanel(container, opts = {}) {
   async function refresh() {
     try {
       const [pRes, sRes] = await Promise.all([
-        fetch(`${api}/profiles`).then((r) => r.json()),
+        fetch(`${api}/profiles?kind=${encodeURIComponent(kind)}`).then((r) => r.json()),
         fetch(`${api}/status`).then((r) => r.json()),
       ]);
       profiles = pRes.profiles || [];
+      loadableFiltered = !!pRes.loadable_filtered;
       lastStatus = sRes;
       select.innerHTML = "";
       if (!profiles.length) {
-        select.appendChild(el("option", "", S.noProfiles));
+        // When the SLV answered the loadable pre-flight (loadable_filtered) and
+        // still nothing survived, this device genuinely can't switch this kind.
+        const msg = loadableFiltered
+          ? S.noLoadable.replace("{kind}", kind.toUpperCase())
+          : S.noProfiles;
+        select.appendChild(el("option", "", msg));
         switchBtn.disabled = true;
       } else {
         for (const p of profiles) {

--- a/demos/common/frontend/ui.js
+++ b/demos/common/frontend/ui.js
@@ -71,6 +71,11 @@ export function createMetricCard(container, { label = "", unit = "s", digits = 2
  *
  * opts:
  *   api            base path of the demo backend API (default "/api")
+ *   kinds          array of switchable kinds, e.g. ["asr"] / ["tts"] /
+ *                  ["asr","tts"] (default both). A single kind hides the
+ *                  ASR/TTS toggle row and pins the panel to that kind — used
+ *                  by demos that only exercise one side (asr-caption → ["asr"],
+ *                  tts-playground → ["tts"]). The gallery passes both (tabs).
  *   strings        i18n overrides, see DEFAULT_STRINGS below
  *   pollMs         status poll interval during a switch (default 600)
  *   onSwitched(kind, result)  optional callback after a settled switch
@@ -101,6 +106,12 @@ export function createModelSwitchPanel(container, opts = {}) {
   const api = (opts.api || "/api").replace(/\/$/, "");
   const S = { ...DEFAULT_STRINGS, ...(opts.strings || {}) };
   const pollMs = opts.pollMs || 600;
+  // Which kinds this demo exposes. A single kind pins the panel to it and
+  // hides the toggle row; both keeps the ASR/TTS tabs (gallery default).
+  const kinds = Array.isArray(opts.kinds) && opts.kinds.length
+    ? opts.kinds.filter((k) => k === "tts" || k === "asr")
+    : ["tts", "asr"];
+  const singleKind = kinds.length === 1;
   // Hard device trait per kind (e.g. RK NPU engines): once SLV answers
   // hot_reload_not_supported, stop offering the switch for that kind.
   const noReload = { tts: false, asr: false };
@@ -110,6 +121,8 @@ export function createModelSwitchPanel(container, opts = {}) {
   const btnTts = el("button", "active", S.kindTts);
   const btnAsr = el("button", "", S.kindAsr);
   kindRow.append(btnTts, btnAsr);
+  // Single-kind demos never switch kinds — drop the toggle row entirely.
+  if (singleKind) kindRow.style.display = "none";
 
   const currentLine = el("div", "muted switch-current", "");
   const select = document.createElement("select");
@@ -124,7 +137,9 @@ export function createModelSwitchPanel(container, opts = {}) {
   root.append(kindRow, currentLine, select, desc, switchBtn, progress, result);
   container.appendChild(root);
 
-  let kind = "tts";
+  // Default to TTS when available (preserves the gallery's initial tab),
+  // otherwise the sole pinned kind.
+  let kind = kinds.includes("tts") ? "tts" : kinds[0];
   let profiles = [];
   let loadableFiltered = false;
   let pollTimer = null;

--- a/demos/diarization/backend/main.py
+++ b/demos/diarization/backend/main.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import sys
 from pathlib import Path
 from urllib.parse import urlsplit
 
@@ -42,7 +43,16 @@ _HERE = Path(__file__).resolve().parent          # demos/diarization/backend
 _APP_DIR = _HERE.parent                           # demos/diarization
 _DEMOS_DIR = _APP_DIR.parent                      # demos/
 
+# Allow running as a plain script (`uv run python diarization/backend/main.py`):
+# the demos/ dir must be importable for common.backend.* .
+if str(_DEMOS_DIR) not in sys.path:
+    sys.path.insert(0, str(_DEMOS_DIR))
+
+from common.backend.slv_proxy import SLVProxy  # noqa: E402
+from common.backend.switch_api import register_switch_routes  # noqa: E402
+
 DEFAULT_SLV_URL = "http://127.0.0.1:8621"
+_DEFAULT_PROFILES_DIR = _DEMOS_DIR.parent / "configs" / "profiles"
 _LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1", "0.0.0.0"}
 
 
@@ -64,17 +74,20 @@ def _ws_endpoint(slv_url: str) -> dict:
     }
 
 
-def create_app(slv_url: str | None = None) -> FastAPI:
+def create_app(slv_url: str | None = None, proxy: SLVProxy | None = None) -> FastAPI:
     slv_url = (slv_url or os.environ.get("SLV_URL") or DEFAULT_SLV_URL).rstrip("/")
+    # The model-switch panel proxies SLV admin routes through this backend; the
+    # WS diarization/caption path still hits SLV directly from the browser.
+    slv = proxy or SLVProxy(base_url=slv_url)
 
     @contextlib.asynccontextmanager
     async def _lifespan(_app: FastAPI):
-        # No pooled resources (the browser connects to SLV directly); kept
-        # for parity with the gallery app factory.
         yield
+        await slv.aclose()
 
     app = FastAPI(title="slv-demo-diarization", docs_url=None, redoc_url=None,
                   lifespan=_lifespan)
+    profiles_dir = Path(os.environ.get("DEMO_PROFILES_DIR") or _DEFAULT_PROFILES_DIR)
 
     @app.get("/healthz")
     async def healthz() -> dict:
@@ -91,6 +104,12 @@ def create_app(slv_url: str | None = None) -> FastAPI:
             # flag is all the browser needs.
             "asr_query": {"diarize": "true"},
         }
+
+    # Shared model-switch API (/api/status, /api/profiles, /api/switch). This
+    # demo's frontend panel is pinned to ["asr"]. Registered BEFORE the mount.
+    register_switch_routes(
+        app, slv, profiles_dir, asr_label=os.environ.get("DEMO_ASR_MODEL_ID")
+    )
 
     # Static frontend (mounted last so /api/* and /healthz win).
     common_frontend = _DEMOS_DIR / "common" / "frontend"

--- a/demos/diarization/frontend/index.html
+++ b/demos/diarization/frontend/index.html
@@ -219,6 +219,11 @@
     <div class="metrics" id="metrics"></div>
 
     <section class="panel">
+      <h2 data-i18n="switchTitle"></h2>
+      <div id="switch-panel"></div>
+    </section>
+
+    <section class="panel">
       <h2 data-i18n="statsTitle"></h2>
       <div class="spk-stats" id="spk-stats">
         <div class="spk-stats-empty" id="spk-stats-empty" data-i18n="statsEmpty"></div>
@@ -244,7 +249,7 @@
 <footer class="footer" data-i18n="footer"></footer>
 
 <script type="module">
-import { createStatusPill, createMetricCard } from "/common/ui.js";
+import { createStatusPill, createMetricCard, createModelSwitchPanel } from "/common/ui.js";
 import { ASRStreamClient } from "/common/slv-client.js";
 import { MicCapture } from "/common/mic-capture.js";
 
@@ -262,6 +267,7 @@ const I18N = {
     captionsTitle: "分色字幕",
     captionsEmpty: "字幕会实时出现在这里，每个说话人一种颜色",
     metricSpeakers: "说话人数", metricPartial: "本句首响",
+    switchTitle: "模型切换",
     statsTitle: "说话人统计",
     statsEmpty: "谁说了多少，实时统计在这里",
     summaryNote: "已按整段回放重新校准说话人标签。",
@@ -293,6 +299,7 @@ const I18N = {
     captionsTitle: "Colored captions",
     captionsEmpty: "Captions appear here in real time, one color per speaker",
     metricSpeakers: "Speakers", metricPartial: "First partial",
+    switchTitle: "Switch model",
     statsTitle: "Speaker stats",
     statsEmpty: "Who talked how much shows up here, live",
     summaryNote: "Speaker labels recalibrated from the full-session summary.",
@@ -784,6 +791,9 @@ speakersCard.setLabel(t("metricSpeakers"));
 partialCard.setLabel(t("metricPartial"));
 renderStats();
 render();
+
+// Inline model switch — diarization runs on the ASR path, so pin to ["asr"].
+createModelSwitchPanel($("switch-panel"), { kinds: ["asr"] });
 </script>
 </body>
 </html>

--- a/demos/gallery/backend/main.py
+++ b/demos/gallery/backend/main.py
@@ -88,10 +88,18 @@ def _list_profiles(profiles_dir: Path, probe: ProbeResult) -> dict:
                 "error": f"profiles dir not found: {profiles_dir}"}
 
     tokens = _platform_tokens(probe)
+    # Optional operator allowlist: DEMO_SWITCH_PROFILES="a,b,c" restricts the
+    # switch panel to exactly these profile stems (e.g. only the profiles whose
+    # engines are actually loadable on this SLV). When unset, fall back to the
+    # device-platform filter. Matches by filename stem or logical name.
+    allow = {s.strip() for s in (os.environ.get("DEMO_SWITCH_PROFILES") or "").split(",") if s.strip()}
     profiles = []
     for path in sorted(profiles_dir.glob("*.json")):
         prefix = path.stem.split("-", 1)[0].lower()
-        if tokens and not any(prefix == t or prefix.startswith(t) for t in tokens):
+        if allow:
+            if path.stem not in allow:
+                continue
+        elif tokens and not any(prefix == t or prefix.startswith(t) for t in tokens):
             continue
         entry = {"name": path.stem, "file": path.name}
         try:
@@ -242,11 +250,22 @@ def create_app(
     @app.get("/api/status")
     async def api_status() -> dict:
         probe = await slv.probe()
+        slv_dict = probe.to_dict()
+        # Presentation label: the SLV doesn't expose an ASR model_id (only the
+        # engine name). If the operator sets DEMO_ASR_MODEL_ID, surface it so the
+        # ASR status pill shows the model instead of the raw engine. (The proper
+        # fix is server-side /asr/capabilities model_id; this is the demo-layer
+        # fallback until images ship that.)
+        asr_label = (os.environ.get("DEMO_ASR_MODEL_ID") or "").strip()
+        if asr_label:
+            ac = slv_dict.get("asr_capabilities")
+            if isinstance(ac, dict) and not ac.get("model_id"):
+                ac["model_id"] = asr_label
         return {
             "kiosk": kiosk_mode,
             "slv_url": slv.base_url,
             "degraded": bool(probe.errors),
-            "slv": probe.to_dict(),
+            "slv": slv_dict,
         }
 
     @app.get("/api/catalog")

--- a/demos/gallery/backend/main.py
+++ b/demos/gallery/backend/main.py
@@ -82,6 +82,81 @@ def _platform_tokens(probe: ProbeResult) -> set[str]:
     return tokens
 
 
+# Friendly model names for the switch dropdown. The list shows ENGINES/MODELS,
+# not bundle-profile stems: several profiles share one ASR engine (e.g. every
+# trt_edge_llm profile = the same Qwen3-ASR) and must collapse to one entry.
+# ASR keys off the backend (no per-profile asr_model_id exists); TTS keys off
+# tts_model_id (customvoice vs base are the SAME backend but DIFFERENT models).
+_ASR_MODEL_LABELS = {
+    "jetson.trt_edge_llm": "Qwen3-ASR",
+    "jetson.paraformer_trt": "Paraformer",
+    "jetson.sensevoice_trt": "SenseVoice",
+    "rk.sensevoice": "SenseVoice",
+    "sherpa.sensevoice": "SenseVoice",
+}
+_TTS_MODEL_LABELS = {
+    "qwen3-tts-0.6b-base": "Qwen3-TTS",
+    "qwen3-tts-customvoice": "CustomVoice",
+    "matcha-icefall-zh-en": "Matcha",
+    "kokoro-multi-lang-v1_0": "Kokoro",
+    "moss-tts-nano-v1": "MOSS",
+}
+
+
+def _prettify_key(key: str) -> str:
+    """Fallback label for an unmapped engine/model id."""
+    tail = str(key).split(".")[-1]
+    return tail.replace("_", " ").replace("-", " ").strip().title() or str(key)
+
+
+def _model_identity(entry: dict, kind: str) -> Optional[tuple[str, str]]:
+    """(model_key, display_label) for a profile in ``kind``, or None when the
+    profile declares no backend for that kind (so it never pollutes the list)."""
+    if kind == "asr":
+        be = entry.get("asr_backend")
+        if not be:
+            return None
+        return be, _ASR_MODEL_LABELS.get(be, _prettify_key(be))
+    be = entry.get("tts_backend")
+    if not be:
+        return None
+    mid = entry.get("tts_model_id") or be
+    return mid, _TTS_MODEL_LABELS.get(mid, _prettify_key(mid))
+
+
+def _dedupe_by_model(profiles: list[dict], kind: str, current_profile: Optional[str]) -> list[dict]:
+    """Collapse bundle profiles to one entry per distinct model, labelled by
+    model name. ``name`` stays a representative profile stem to reload; ``label``
+    is what the dropdown shows; ``current`` marks the loaded model."""
+    cur_key = None
+    if current_profile:
+        cur_key_pair = _model_identity(
+            next((p for p in profiles if (p.get("name") == current_profile
+                  or _profile_stem(p) == current_profile)), {}),
+            kind,
+        )
+        cur_key = cur_key_pair[0] if cur_key_pair else None
+    out: list[dict] = []
+    seen: dict[str, dict] = {}
+    for p in profiles:
+        ident = _model_identity(p, kind)
+        if ident is None:
+            continue  # profile provides no backend for this kind
+        key, label = ident
+        if key in seen:
+            continue
+        entry = {
+            "name": _profile_stem(p) or p.get("name"),  # representative profile to reload
+            "label": label,
+            "model_key": key,
+            "description": p.get("description", ""),
+            "current": key == cur_key,
+        }
+        seen[key] = entry
+        out.append(entry)
+    return out
+
+
 def _list_profiles(profiles_dir: Path, probe: ProbeResult) -> dict:
     if not profiles_dir.is_dir():
         return {"profiles": [], "filtered": False, "platforms": [],
@@ -108,6 +183,7 @@ def _list_profiles(profiles_dir: Path, probe: ProbeResult) -> dict:
             entry["description"] = data.get("description", "")
             entry["asr_backend"] = data.get("asr_backend")
             entry["tts_backend"] = data.get("tts_backend")
+            entry["tts_model_id"] = data.get("tts_model_id")
         except Exception as exc:  # noqa: BLE001 — a broken profile shouldn't hide the rest
             entry["error"] = f"unreadable: {type(exc).__name__}"
         profiles.append(entry)
@@ -336,6 +412,11 @@ def create_app(
                     or (_profile_stem(p) and _profile_stem(p) in loadable)
                 ]
                 result["loadable_filtered"] = True
+            # Collapse bundle profiles into one entry per distinct model, shown
+            # by model name (Qwen3-ASR / Paraformer / Matcha / …) rather than
+            # bundle stem. Also drops profiles that don't provide this kind.
+            cur = (probe.backend_status.get(kind) or {}).get("profile_name")
+            result["profiles"] = _dedupe_by_model(result.get("profiles", []), kind, cur)
         return result
 
     @app.post("/api/switch")

--- a/demos/gallery/backend/main.py
+++ b/demos/gallery/backend/main.py
@@ -7,11 +7,16 @@ Endpoints:
     GET  /api/profiles  profiles from DEMO_PROFILES_DIR filtered by device platform
     POST /api/switch    validated proxy to SLV /admin/backend/reload
 
+``/api/status``, ``/api/profiles`` and ``/api/switch`` are the shared model-switch
+API (``common.backend.switch_api``) — the exact same routes every demo page now
+mounts. Only ``/api/catalog`` + card annotation is gallery-specific.
+
 Environment:
     SLV_URL            SLV server base URL (default http://127.0.0.1:8621)
     SLV_ADMIN_KEY      forwarded as X-Admin-Key on admin calls (optional)
     DEMO_PROFILES_DIR  directory of profile JSONs offered in the switch panel
                        (default: <repo>/configs/profiles when run from the repo)
+    DEMO_ASR_MODEL_ID  presentation label for the ASR status pill (optional)
     DEMO_KIOSK         truthy => kiosk mode (frontend hides debug details)
 
 Run locally:  uv run uvicorn gallery.backend.main:app --port 8700
@@ -23,15 +28,14 @@ import contextlib
 import json
 import os
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Optional
 
-import httpx
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
-from pydantic import BaseModel
 
 from common.backend.slv_proxy import SLVProxy, ProbeResult
+from common.backend.switch_api import register_switch_routes
 
 _HERE = Path(__file__).resolve().parent          # demos/gallery/backend
 _GALLERY_DIR = _HERE.parent                       # demos/gallery
@@ -44,199 +48,6 @@ _TRUTHY = {"1", "true", "yes", "on"}
 
 def _env_truthy(name: str) -> bool:
     return (os.environ.get(name) or "").strip().lower() in _TRUTHY
-
-
-# ── profile listing / platform filtering ────────────────────────────────────
-
-
-def _platform_tokens(probe: ProbeResult) -> set[str]:
-    """Derive platform tokens from SLV-reported backend names.
-
-    Backend names follow ``<platform>.<engine>`` (e.g. ``jetson.trt_edge_llm``);
-    the profile files follow ``<platform>-<combo>.json``. We keep this
-    deliberately simple: collect the dotted prefixes; a profile matches when
-    its filename prefix equals a token or starts with one (``rk`` matches
-    ``rk3576``). No tokens derivable => no filtering.
-    """
-    tokens: set[str] = set()
-    sources = []
-    if probe.health:
-        sources += [probe.health.get("asr_backend"), probe.health.get("tts_backend")]
-    if probe.backend_status:
-        for kind in ("asr", "tts"):
-            entry = probe.backend_status.get(kind) or {}
-            sources.append(entry.get("backend_name"))
-            # Live SLV reports undotted backend names (e.g. ``matcha_trt``);
-            # the loaded profile name (``jetson-qwen3asr-matcha-nx``) is the
-            # reliable platform carrier, so derive a token from its prefix too.
-            profile_name = entry.get("profile_name")
-            if isinstance(profile_name, str) and "-" in profile_name:
-                prefix = profile_name.split("-", 1)[0].strip().lower()
-                if prefix:
-                    tokens.add(prefix)
-    for name in sources:
-        if isinstance(name, str) and "." in name:
-            prefix = name.split(".", 1)[0].strip().lower()
-            if prefix:
-                tokens.add(prefix)
-    return tokens
-
-
-# Friendly model names for the switch dropdown. The list shows ENGINES/MODELS,
-# not bundle-profile stems: several profiles share one ASR engine (e.g. every
-# trt_edge_llm profile = the same Qwen3-ASR) and must collapse to one entry.
-# ASR keys off the backend (no per-profile asr_model_id exists); TTS keys off
-# tts_model_id (customvoice vs base are the SAME backend but DIFFERENT models).
-_ASR_MODEL_LABELS = {
-    "jetson.trt_edge_llm": "Qwen3-ASR",
-    "jetson.paraformer_trt": "Paraformer",
-    "jetson.sensevoice_trt": "SenseVoice",
-    "rk.sensevoice": "SenseVoice",
-    "sherpa.sensevoice": "SenseVoice",
-}
-_TTS_MODEL_LABELS = {
-    "qwen3-tts-0.6b-base": "Qwen3-TTS",
-    "qwen3-tts-customvoice": "CustomVoice",
-    "matcha-icefall-zh-en": "Matcha",
-    "kokoro-multi-lang-v1_0": "Kokoro",
-    "moss-tts-nano-v1": "MOSS",
-}
-
-
-def _prettify_key(key: str) -> str:
-    """Fallback label for an unmapped engine/model id."""
-    tail = str(key).split(".")[-1]
-    return tail.replace("_", " ").replace("-", " ").strip().title() or str(key)
-
-
-def _model_identity(entry: dict, kind: str) -> Optional[tuple[str, str]]:
-    """(model_key, display_label) for a profile in ``kind``, or None when the
-    profile declares no backend for that kind (so it never pollutes the list)."""
-    if kind == "asr":
-        be = entry.get("asr_backend")
-        if not be:
-            return None
-        return be, _ASR_MODEL_LABELS.get(be, _prettify_key(be))
-    be = entry.get("tts_backend")
-    if not be:
-        return None
-    mid = entry.get("tts_model_id") or be
-    return mid, _TTS_MODEL_LABELS.get(mid, _prettify_key(mid))
-
-
-def _dedupe_by_model(profiles: list[dict], kind: str, current_profile: Optional[str]) -> list[dict]:
-    """Collapse bundle profiles to one entry per distinct model, labelled by
-    model name. ``name`` stays a representative profile stem to reload; ``label``
-    is what the dropdown shows; ``current`` marks the loaded model."""
-    cur_key = None
-    if current_profile:
-        cur_key_pair = _model_identity(
-            next((p for p in profiles if (p.get("name") == current_profile
-                  or _profile_stem(p) == current_profile)), {}),
-            kind,
-        )
-        cur_key = cur_key_pair[0] if cur_key_pair else None
-    out: list[dict] = []
-    seen: dict[str, dict] = {}
-    for p in profiles:
-        ident = _model_identity(p, kind)
-        if ident is None:
-            continue  # profile provides no backend for this kind
-        key, label = ident
-        if key in seen:
-            continue
-        entry = {
-            "name": _profile_stem(p) or p.get("name"),  # representative profile to reload
-            "label": label,
-            "model_key": key,
-            "description": p.get("description", ""),
-            "current": key == cur_key,
-        }
-        seen[key] = entry
-        out.append(entry)
-    return out
-
-
-def _list_profiles(profiles_dir: Path, probe: ProbeResult) -> dict:
-    if not profiles_dir.is_dir():
-        return {"profiles": [], "filtered": False, "platforms": [],
-                "error": f"profiles dir not found: {profiles_dir}"}
-
-    tokens = _platform_tokens(probe)
-    # Optional operator allowlist: DEMO_SWITCH_PROFILES="a,b,c" restricts the
-    # switch panel to exactly these profile stems (e.g. only the profiles whose
-    # engines are actually loadable on this SLV). When unset, fall back to the
-    # device-platform filter. Matches by filename stem or logical name.
-    allow = {s.strip() for s in (os.environ.get("DEMO_SWITCH_PROFILES") or "").split(",") if s.strip()}
-    profiles = []
-    for path in sorted(profiles_dir.glob("*.json")):
-        prefix = path.stem.split("-", 1)[0].lower()
-        if allow:
-            if path.stem not in allow:
-                continue
-        elif tokens and not any(prefix == t or prefix.startswith(t) for t in tokens):
-            continue
-        entry = {"name": path.stem, "file": path.name}
-        try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-            entry["name"] = data.get("name", path.stem)
-            entry["description"] = data.get("description", "")
-            entry["asr_backend"] = data.get("asr_backend")
-            entry["tts_backend"] = data.get("tts_backend")
-            entry["tts_model_id"] = data.get("tts_model_id")
-        except Exception as exc:  # noqa: BLE001 — a broken profile shouldn't hide the rest
-            entry["error"] = f"unreadable: {type(exc).__name__}"
-        profiles.append(entry)
-    return {"profiles": profiles, "filtered": bool(tokens), "platforms": sorted(tokens)}
-
-
-async def _fetch_loadable_names(slv: SLVProxy, kind: str) -> Optional[set[str]]:
-    """Ask SLV which profiles it can actually load for ``kind``.
-
-    Returns the set of loadable profile names on success, or ``None`` when the
-    SLV doesn't expose ``/admin/backend/loadable`` (older image), is
-    unreachable, rejects admin auth, or returns a malformed body — in every
-    such case the caller must fall back to the unfiltered listing.
-    """
-    try:
-        resp = await slv.admin_get("/admin/backend/loadable")
-    except Exception:  # noqa: BLE001 — SLV down / transport error → graceful fallback
-        return None
-    if resp.status_code != 200:
-        return None
-    try:
-        data = resp.json()
-    except ValueError:
-        return None
-    section = data.get(kind)
-    if not isinstance(section, dict):
-        return None
-    loadable = section.get("loadable")
-    if not isinstance(loadable, list):
-        return None
-    return {str(n) for n in loadable}
-
-
-def _profile_stem(entry: dict) -> str:
-    file = entry.get("file") or ""
-    return file[: -len(".json")] if file.endswith(".json") else ""
-
-
-def _allowed_profile_names(profiles_dir: Path) -> set[str]:
-    """Names accepted by /api/switch: every profile JSON in the directory,
-    by logical name and by filename stem (SLV resolves both)."""
-    allowed: set[str] = set()
-    if not profiles_dir.is_dir():
-        return allowed
-    for path in profiles_dir.glob("*.json"):
-        allowed.add(path.stem)
-        try:
-            name = json.loads(path.read_text(encoding="utf-8")).get("name")
-            if isinstance(name, str) and name:
-                allowed.add(name)
-        except Exception:  # noqa: BLE001
-            pass
-    return allowed
 
 
 # ── catalog ─────────────────────────────────────────────────────────────────
@@ -322,12 +133,6 @@ def _annotate_card(demo: dict, probe: ProbeResult) -> dict:
 # ── app factory ──────────────────────────────────────────────────────────────
 
 
-class SwitchRequest(BaseModel):
-    kind: Literal["tts", "asr"]
-    profile: str
-    drain_timeout_s: Optional[float] = None
-
-
 def create_app(
     proxy: SLVProxy | None = None,
     registry_path: Path | None = None,
@@ -355,27 +160,6 @@ def create_app(
     async def healthz() -> dict:
         return {"ok": True, "service": "slv-demo-gallery", "kiosk": kiosk_mode}
 
-    @app.get("/api/status")
-    async def api_status() -> dict:
-        probe = await slv.probe()
-        slv_dict = probe.to_dict()
-        # Presentation label: the SLV doesn't expose an ASR model_id (only the
-        # engine name). If the operator sets DEMO_ASR_MODEL_ID, surface it so the
-        # ASR status pill shows the model instead of the raw engine. (The proper
-        # fix is server-side /asr/capabilities model_id; this is the demo-layer
-        # fallback until images ship that.)
-        asr_label = (os.environ.get("DEMO_ASR_MODEL_ID") or "").strip()
-        if asr_label:
-            ac = slv_dict.get("asr_capabilities")
-            if isinstance(ac, dict) and not ac.get("model_id"):
-                ac["model_id"] = asr_label
-        return {
-            "kiosk": kiosk_mode,
-            "slv_url": slv.base_url,
-            "degraded": bool(probe.errors),
-            "slv": slv_dict,
-        }
-
     @app.get("/api/catalog")
     async def api_catalog() -> dict:
         try:
@@ -393,72 +177,14 @@ def create_app(
             "demos": [_annotate_card(d, probe) for d in demos],
         }
 
-    @app.get("/api/profiles")
-    async def api_profiles(kind: Optional[str] = None) -> dict:
-        probe = await slv.probe()
-        result = _list_profiles(profiles_dir, probe)
-        result["slv_reachable"] = probe.reachable
-        result["loadable_filtered"] = False
-        # When a kind is requested, narrow the listing to profiles the SLV can
-        # actually load for that kind (real artifact pre-flight). If the SLV
-        # can't answer (old image / down / no admin key), keep the existing
-        # platform-filtered listing untouched.
-        if kind in ("tts", "asr"):
-            loadable = await _fetch_loadable_names(slv, kind)
-            if loadable is not None:
-                result["profiles"] = [
-                    p for p in result.get("profiles", [])
-                    if (p.get("name") or "") in loadable
-                    or (_profile_stem(p) and _profile_stem(p) in loadable)
-                ]
-                result["loadable_filtered"] = True
-            # Collapse bundle profiles into one entry per distinct model, shown
-            # by model name (Qwen3-ASR / Paraformer / Matcha / …) rather than
-            # bundle stem. Also drops profiles that don't provide this kind.
-            cur = (probe.backend_status.get(kind) or {}).get("profile_name")
-            result["profiles"] = _dedupe_by_model(result.get("profiles", []), kind, cur)
-        return result
-
-    @app.post("/api/switch")
-    async def api_switch(req: SwitchRequest):
-        # Allow only what /api/profiles offers: platform-filtered when the
-        # device platform is derivable, so a jetson-* profile can't be sent
-        # to an RK box (and vice versa) just by crafting the POST.
-        probe = await slv.probe()
-        listing = _list_profiles(profiles_dir, probe)
-        allowed: set[str] = set()
-        for p in listing.get("profiles", []):
-            allowed.add(p.get("name") or "")
-            file = p.get("file") or ""
-            if file.endswith(".json"):
-                allowed.add(file[: -len(".json")])
-        allowed.discard("")
-        if not listing.get("filtered"):
-            allowed |= _allowed_profile_names(profiles_dir)
-        if req.profile not in allowed:
-            raise HTTPException(
-                status_code=400,
-                detail={
-                    "error": "profile_not_allowed",
-                    "profile": req.profile,
-                    "hint": "profile must be one of GET /api/profiles",
-                },
-            )
-        try:
-            resp = await slv.reload_backend(
-                req.kind, req.profile, drain_timeout_s=req.drain_timeout_s
-            )
-        except httpx.HTTPError as exc:
-            raise HTTPException(
-                status_code=502,
-                detail={"error": "slv_unreachable", "message": str(exc)},
-            ) from exc
-        # Pass SLV's verdict (reloaded / rolled_back / 4xx detail) through as-is.
-        try:
-            body = resp.json()
-        except ValueError:
-            body = {"error": "invalid_slv_response", "text": resp.text[:500]}
-        return JSONResponse(body, status_code=resp.status_code)
+    # Shared model-switch API: /api/status, /api/profiles, /api/switch. Same
+    # routes every demo page mounts — registered BEFORE the static mount so
+    # /api/* wins over the html=True catch-all.
+    register_switch_routes(
+        app, slv, profiles_dir,
+        asr_label=os.environ.get("DEMO_ASR_MODEL_ID"),
+        kiosk=kiosk_mode,
+    )
 
     # Static frontend (mounted last so /api/* wins).
     common_frontend = _DEMOS_DIR / "common" / "frontend"

--- a/demos/gallery/backend/main.py
+++ b/demos/gallery/backend/main.py
@@ -114,6 +114,38 @@ def _list_profiles(profiles_dir: Path, probe: ProbeResult) -> dict:
     return {"profiles": profiles, "filtered": bool(tokens), "platforms": sorted(tokens)}
 
 
+async def _fetch_loadable_names(slv: SLVProxy, kind: str) -> Optional[set[str]]:
+    """Ask SLV which profiles it can actually load for ``kind``.
+
+    Returns the set of loadable profile names on success, or ``None`` when the
+    SLV doesn't expose ``/admin/backend/loadable`` (older image), is
+    unreachable, rejects admin auth, or returns a malformed body — in every
+    such case the caller must fall back to the unfiltered listing.
+    """
+    try:
+        resp = await slv.admin_get("/admin/backend/loadable")
+    except Exception:  # noqa: BLE001 — SLV down / transport error → graceful fallback
+        return None
+    if resp.status_code != 200:
+        return None
+    try:
+        data = resp.json()
+    except ValueError:
+        return None
+    section = data.get(kind)
+    if not isinstance(section, dict):
+        return None
+    loadable = section.get("loadable")
+    if not isinstance(loadable, list):
+        return None
+    return {str(n) for n in loadable}
+
+
+def _profile_stem(entry: dict) -> str:
+    file = entry.get("file") or ""
+    return file[: -len(".json")] if file.endswith(".json") else ""
+
+
 def _allowed_profile_names(profiles_dir: Path) -> set[str]:
     """Names accepted by /api/switch: every profile JSON in the directory,
     by logical name and by filename stem (SLV resolves both)."""
@@ -286,10 +318,24 @@ def create_app(
         }
 
     @app.get("/api/profiles")
-    async def api_profiles() -> dict:
+    async def api_profiles(kind: Optional[str] = None) -> dict:
         probe = await slv.probe()
         result = _list_profiles(profiles_dir, probe)
         result["slv_reachable"] = probe.reachable
+        result["loadable_filtered"] = False
+        # When a kind is requested, narrow the listing to profiles the SLV can
+        # actually load for that kind (real artifact pre-flight). If the SLV
+        # can't answer (old image / down / no admin key), keep the existing
+        # platform-filtered listing untouched.
+        if kind in ("tts", "asr"):
+            loadable = await _fetch_loadable_names(slv, kind)
+            if loadable is not None:
+                result["profiles"] = [
+                    p for p in result.get("profiles", [])
+                    if (p.get("name") or "") in loadable
+                    or (_profile_stem(p) and _profile_stem(p) in loadable)
+                ]
+                result["loadable_filtered"] = True
         return result
 
     @app.post("/api/switch")

--- a/demos/gallery/frontend/index.html
+++ b/demos/gallery/frontend/index.html
@@ -189,8 +189,12 @@ function renderStatus(s) {
     ttsPill.set("idle", `${t("tts")} —`);
   } else {
     slvPill.set(s.degraded ? "warn" : "ok", s.degraded ? "SLV degraded" : "SLV online");
-    asrPill.set(h.asr ? "ok" : "err", `${t("asr")} ${h.asr_backend || t("notReady")}`);
-    ttsPill.set(h.tts ? "ok" : "err", `${t("tts")} ${h.tts_backend || t("notReady")}`);
+    // Prefer the concrete model name (model_id) over the raw engine name;
+    // fall back to the engine when the backend doesn't report a model_id.
+    const asrModel = s.slv?.asr_capabilities?.model_id || h.asr_backend;
+    const ttsModel = s.slv?.tts_capabilities?.model_id || h.tts_backend;
+    asrPill.set(h.asr ? "ok" : "err", `${t("asr")} ${asrModel || t("notReady")}`);
+    ttsPill.set(h.tts ? "ok" : "err", `${t("tts")} ${ttsModel || t("notReady")}`);
   }
   if (!kioskMode) {
     document.getElementById("debug-json").textContent = JSON.stringify(s, null, 2);

--- a/demos/run-local.sh
+++ b/demos/run-local.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Run the Demo Gallery frontends LOCALLY (localhost = secure context, so the
+# browser mic works without HTTPS) while talking to a REMOTE SLV backend.
+#
+# ── Configure here (the one place) ──────────────────────────────────────────
+SLV_HOST="${SLV_HOST:-100.82.225.102}"   # device running the SLV server (Tailscale/LAN IP)
+SLV_PORT="${SLV_PORT:-18765}"            # SLV port on that device
+SSH_USER="${SSH_USER:-harvest}"          # ssh user for the tunnel
+SLV_ADMIN_KEY="${SLV_ADMIN_KEY:-}"       # admin key (model-switch panel); empty = panel read-only
+# Presentation labels + switch allowlist (optional):
+DEMO_ASR_MODEL_ID="${DEMO_ASR_MODEL_ID:-}"          # e.g. qwen3-asr-0.6b (ASR pill label; SLV has no asr model_id)
+DEMO_SWITCH_PROFILES="${DEMO_SWITCH_PROFILES:-}"    # e.g. jetson-edgellm-v090-qwen3ttsbase,...  (empty = platform filter)
+# Whether to tunnel the SLV port to localhost (recommended: WS also stays proxy-free).
+USE_TUNNEL="${USE_TUNNEL:-1}"
+# ─────────────────────────────────────────────────────────────────────────────
+
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+LOGDIR="/tmp/slv-demos-local-logs"; mkdir -p "$LOGDIR"
+
+if [ "$USE_TUNNEL" = "1" ]; then
+  # Point the demos at localhost so both the HTTP proxy AND the browser WS go
+  # through the tunnel (no system proxy / Clash interference, no HTTPS needed).
+  pkill -f "ssh -f -N.*${SLV_PORT}:localhost:${SLV_PORT}" 2>/dev/null || true
+  ssh -f -N -o StrictHostKeyChecking=no -o ExitOnForwardFailure=yes \
+      -o ServerAliveInterval=30 -o ServerAliveCountMax=3 \
+      -L "${SLV_PORT}:localhost:${SLV_PORT}" "${SSH_USER}@${SLV_HOST}"
+  SLV_URL="http://localhost:${SLV_PORT}"
+  echo "tunnel: localhost:${SLV_PORT} -> ${SSH_USER}@${SLV_HOST} (pid $(pgrep -f "ssh -f -N.*${SLV_PORT}" | head -1))"
+else
+  # Direct: HTTP proxy bypasses the system proxy (trust_env=False); the browser
+  # WS goes to the device IP (needs your proxy to allow that IP, e.g. Tailscale).
+  SLV_URL="http://${SLV_HOST}:${SLV_PORT}"
+fi
+echo "SLV_URL = ${SLV_URL}"
+
+cd "$HERE"
+uv sync -q
+pkill -f "slv-demos-local.*backend/main" 2>/dev/null || true
+pkill -f "uvicorn gallery.backend.main" 2>/dev/null || true
+sleep 1
+
+export SLV_URL SLV_ADMIN_KEY DEMO_ASR_MODEL_ID DEMO_SWITCH_PROFILES
+export DEMO_PROFILES_DIR="${DEMO_PROFILES_DIR:-$(cd "$HERE/../configs/profiles" && pwd)}"
+
+SLV_URL="$SLV_URL" SLV_ADMIN_KEY="$SLV_ADMIN_KEY" DEMO_PROFILES_DIR="$DEMO_PROFILES_DIR" \
+DEMO_SWITCH_PROFILES="$DEMO_SWITCH_PROFILES" DEMO_ASR_MODEL_ID="$DEMO_ASR_MODEL_ID" PORT=8700 \
+  nohup uv run python -m uvicorn gallery.backend.main:app --host 127.0.0.1 --port 8700 \
+  > "$LOGDIR/gallery.log" 2>&1 &
+
+for pair in "asr-caption:8701" "tts-playground:8702" "v2v-chat:8703" "diarization:8704" "voice-clone:8705"; do
+  app="${pair%%:*}"; port="${pair##*:}"
+  SLV_URL="$SLV_URL" PORT="$port" nohup uv run python "$app/backend/main.py" \
+    > "$LOGDIR/$app.log" 2>&1 &
+done
+
+sleep 10
+echo "── health ──"
+for p in 8700 8701 8702 8703 8704 8705; do
+  printf "  localhost:%s " "$p"
+  curl -s -m 5 "http://127.0.0.1:$p/healthz" >/dev/null 2>&1 && echo ok || echo DOWN
+done
+echo
+echo "open  http://localhost:8700"

--- a/demos/tests/mock_slv.py
+++ b/demos/tests/mock_slv.py
@@ -37,6 +37,9 @@ def default_state() -> dict:
         "admin_key": None,
         "received": [],
         "reload_status": 200,
+        # Loadable pre-flight: None simulates an SLV image without the
+        # /admin/backend/loadable endpoint (→ 404). A dict is returned as-is.
+        "loadable": None,
         "reload_response": {
             "status": "reloaded",
             "kind": "tts",
@@ -116,6 +119,17 @@ def create_mock_slv(state: dict | None = None) -> tuple[FastAPI, dict]:
             or _check_admin(request)
             or JSONResponse(state["backend_status"])
         )
+
+    @app.get("/admin/backend/loadable")
+    async def backend_loadable(request: Request) -> Any:
+        failed = _maybe_fail("loadable") or _check_admin(request)
+        if failed:
+            return failed
+        loadable = state.get("loadable")
+        if loadable is None:
+            # Old SLV image without this endpoint.
+            return JSONResponse({"detail": "Not Found"}, status_code=404)
+        return JSONResponse(loadable)
 
     @app.post("/admin/backend/reload")
     async def backend_reload(request: Request) -> Any:

--- a/demos/tests/test_loadable_filter.py
+++ b/demos/tests/test_loadable_filter.py
@@ -1,0 +1,101 @@
+"""Gallery /api/profiles?kind= loadable-filtering + graceful fallback.
+
+The gallery narrows the switch listing to profiles the SLV reports it can
+actually load for the requested kind (via /admin/backend/loadable). When the
+SLV can't answer (missing endpoint / down / bad admin key), the gallery must
+fall back to the existing platform-filtered listing untouched.
+"""
+
+from __future__ import annotations
+
+from tests.conftest import gallery_client
+
+
+def _loadable_body(tts, asr):
+    return {
+        "tts": {"loadable": tts, "unloadable": [], "invalid": []},
+        "asr": {"loadable": asr, "unloadable": [], "invalid": []},
+    }
+
+
+async def test_filters_by_kind_when_loadable_present(mock_slv, profiles_dir):
+    app, state = mock_slv
+    # Platform filter keeps the two jetson-* profiles; loadable narrows further.
+    state["loadable"] = _loadable_body(
+        tts=["jetson-qwen3asr-moss-nx"],
+        asr=["jetson-qwen3asr-moss-nx", "jetson-kokoro-trt"],
+    )
+    async with gallery_client(app, profiles_dir) as client:
+        tts = (await client.get("/api/profiles?kind=tts")).json()
+        asr = (await client.get("/api/profiles?kind=asr")).json()
+
+    assert tts["loadable_filtered"] is True
+    assert [p["name"] for p in tts["profiles"]] == ["jetson-qwen3asr-moss-nx"]
+
+    assert asr["loadable_filtered"] is True
+    assert {p["name"] for p in asr["profiles"]} == {
+        "jetson-qwen3asr-moss-nx", "jetson-kokoro-trt"
+    }
+
+
+async def test_empty_loadable_for_kind_yields_empty_filtered(mock_slv, profiles_dir):
+    app, state = mock_slv
+    state["loadable"] = _loadable_body(tts=[], asr=["jetson-kokoro-trt"])
+    async with gallery_client(app, profiles_dir) as client:
+        tts = (await client.get("/api/profiles?kind=tts")).json()
+
+    # Device can't load any TTS profile → empty list, but the pre-flight DID run.
+    assert tts["loadable_filtered"] is True
+    assert tts["profiles"] == []
+
+
+async def test_no_kind_param_does_not_filter(mock_slv, profiles_dir):
+    app, state = mock_slv
+    state["loadable"] = _loadable_body(tts=["jetson-qwen3asr-moss-nx"], asr=[])
+    async with gallery_client(app, profiles_dir) as client:
+        body = (await client.get("/api/profiles")).json()
+
+    # No kind → unfiltered platform listing (both jetson profiles), no pre-flight.
+    assert body["loadable_filtered"] is False
+    assert {p["name"] for p in body["profiles"]} == {
+        "jetson-qwen3asr-moss-nx", "jetson-kokoro-trt"
+    }
+
+
+async def test_fallback_when_loadable_endpoint_absent(mock_slv, profiles_dir):
+    app, state = mock_slv
+    state["loadable"] = None  # old SLV image → 404
+    async with gallery_client(app, profiles_dir) as client:
+        body = (await client.get("/api/profiles?kind=tts")).json()
+
+    assert body["loadable_filtered"] is False
+    assert {p["name"] for p in body["profiles"]} == {
+        "jetson-qwen3asr-moss-nx", "jetson-kokoro-trt"
+    }
+
+
+async def test_fallback_when_slv_errors(mock_slv, profiles_dir):
+    app, state = mock_slv
+    state["loadable"] = _loadable_body(tts=["jetson-qwen3asr-moss-nx"], asr=[])
+    state["fail"].add("loadable")  # SLV returns 500 for the pre-flight
+    async with gallery_client(app, profiles_dir) as client:
+        body = (await client.get("/api/profiles?kind=tts")).json()
+
+    assert body["loadable_filtered"] is False
+    assert {p["name"] for p in body["profiles"]} == {
+        "jetson-qwen3asr-moss-nx", "jetson-kokoro-trt"
+    }
+
+
+async def test_fallback_when_admin_key_rejected(mock_slv, profiles_dir):
+    app, state = mock_slv
+    state["admin_key"] = "needed"  # SLV requires admin key
+    state["loadable"] = _loadable_body(tts=["jetson-qwen3asr-moss-nx"], asr=[])
+    # gallery proxy has NO admin key → /admin/backend/loadable → 401 → fallback.
+    async with gallery_client(app, profiles_dir, admin_key=None) as client:
+        body = (await client.get("/api/profiles?kind=tts")).json()
+
+    assert body["loadable_filtered"] is False
+    assert {p["name"] for p in body["profiles"]} == {
+        "jetson-qwen3asr-moss-nx", "jetson-kokoro-trt"
+    }

--- a/demos/tests/test_loadable_filter.py
+++ b/demos/tests/test_loadable_filter.py
@@ -33,9 +33,10 @@ async def test_filters_by_kind_when_loadable_present(mock_slv, profiles_dir):
     assert [p["name"] for p in tts["profiles"]] == ["jetson-qwen3asr-moss-nx"]
 
     assert asr["loadable_filtered"] is True
-    assert {p["name"] for p in asr["profiles"]} == {
-        "jetson-qwen3asr-moss-nx", "jetson-kokoro-trt"
-    }
+    # kokoro-trt is TTS-only (asr_backend=None) so the model-dedup layer drops
+    # it from the ASR list even though the SLV vacuously reports it asr-loadable
+    # — a TTS profile is not a meaningful ASR choice.
+    assert {p["name"] for p in asr["profiles"]} == {"jetson-qwen3asr-moss-nx"}
 
 
 async def test_empty_loadable_for_kind_yields_empty_filtered(mock_slv, profiles_dir):

--- a/demos/tts-playground/backend/main.py
+++ b/demos/tts-playground/backend/main.py
@@ -49,8 +49,10 @@ if str(_DEMOS_DIR) not in sys.path:
     sys.path.insert(0, str(_DEMOS_DIR))
 
 from common.backend.slv_proxy import SLVProxy  # noqa: E402
+from common.backend.switch_api import register_switch_routes  # noqa: E402
 
 _TRUTHY = {"1", "true", "yes", "on"}
+_DEFAULT_PROFILES_DIR = _DEMOS_DIR.parent / "configs" / "profiles"
 
 
 class TTSProxyRequest(BaseModel):
@@ -145,6 +147,13 @@ def create_app(proxy: SLVProxy | None = None, kiosk: bool | None = None) -> Fast
     app.post("/api/tts/stream")(_tts_stream)
     # Alias for the shared TTSStreamPlayer, which POSTs {origin}/tts/stream.
     app.post("/tts/stream")(_tts_stream)
+
+    # Shared model-switch API (/api/status, /api/profiles, /api/switch). This
+    # demo's frontend panel is pinned to ["tts"]. Registered BEFORE the mount.
+    profiles_dir = Path(os.environ.get("DEMO_PROFILES_DIR") or _DEFAULT_PROFILES_DIR)
+    register_switch_routes(
+        app, slv, profiles_dir, asr_label=os.environ.get("DEMO_ASR_MODEL_ID")
+    )
 
     # Static frontend (mounted last so /api/* wins).
     common_frontend = _DEMOS_DIR / "common" / "frontend"

--- a/demos/tts-playground/frontend/index.html
+++ b/demos/tts-playground/frontend/index.html
@@ -231,13 +231,17 @@
     <section class="panel">
       <p class="muted" style="font-size:var(--fs-small); margin:0" data-i18n="aboutTtfa"></p>
     </section>
+    <section class="panel">
+      <h2 data-i18n="switchTitle"></h2>
+      <div id="switch-panel"></div>
+    </section>
   </aside>
 </div>
 
 <footer class="footer" data-i18n="footer"></footer>
 
 <script type="module">
-import { createStatusPill, createMetricCard } from "/common/ui.js";
+import { createStatusPill, createMetricCard, createModelSwitchPanel } from "/common/ui.js";
 import { TTSStreamPlayer } from "/common/slv-client.js";
 
 /* ── i18n (default zh, shared localStorage key with the gallery) ──── */
@@ -248,6 +252,7 @@ const I18N = {
     step2: "输入或选一句话",
     step3: "点播放",
     placeholder: "输入任意文本，或点击下方示例句…",
+    switchTitle: "模型切换",
     voiceLabel: "音色",
     speedLabel: "语速",
     pitchLabel: "音高",
@@ -278,6 +283,7 @@ const I18N = {
     step2: "Type or pick a sentence",
     step3: "Press play",
     placeholder: "Type anything, or tap a sample sentence below…",
+    switchTitle: "Switch model",
     voiceLabel: "Voice",
     speedLabel: "Speed",
     pitchLabel: "Pitch",
@@ -572,6 +578,9 @@ $("lang-btn").addEventListener("click", () => {
 applyStaticI18n();
 updateSteps();
 loadSpeakers();
+
+// Inline model switch — this demo only exercises TTS, so pin the panel to it.
+createModelSwitchPanel($("switch-panel"), { kinds: ["tts"] });
 </script>
 </body>
 </html>

--- a/demos/v2v-chat/backend/main.py
+++ b/demos/v2v-chat/backend/main.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import sys
 from pathlib import Path
 from urllib.parse import urlsplit
 
@@ -34,7 +35,16 @@ _HERE = Path(__file__).resolve().parent          # demos/v2v-chat/backend
 _APP_DIR = _HERE.parent                           # demos/v2v-chat
 _DEMOS_DIR = _APP_DIR.parent                      # demos/
 
+# Allow running as a plain script (`uv run python v2v-chat/backend/main.py`):
+# the demos/ dir must be importable for common.backend.* .
+if str(_DEMOS_DIR) not in sys.path:
+    sys.path.insert(0, str(_DEMOS_DIR))
+
+from common.backend.slv_proxy import SLVProxy  # noqa: E402
+from common.backend.switch_api import register_switch_routes  # noqa: E402
+
 DEFAULT_SLV_URL = "http://127.0.0.1:8621"
+_DEFAULT_PROFILES_DIR = _DEMOS_DIR.parent / "configs" / "profiles"
 _LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1", "0.0.0.0"}
 
 
@@ -56,18 +66,20 @@ def _ws_endpoint(slv_url: str) -> dict:
     }
 
 
-def create_app(slv_url: str | None = None) -> FastAPI:
+def create_app(slv_url: str | None = None, proxy: SLVProxy | None = None) -> FastAPI:
     slv_url = (slv_url or os.environ.get("SLV_URL") or DEFAULT_SLV_URL).rstrip("/")
+    # The model-switch panel proxies SLV admin routes through this backend; the
+    # WS voice-chat path still hits SLV directly from the browser.
+    slv = proxy or SLVProxy(base_url=slv_url)
 
     @contextlib.asynccontextmanager
     async def _lifespan(_app: FastAPI):
-        # No pooled resources yet (the browser connects to SLV directly);
-        # kept for parity with the gallery app factory so future proxy
-        # clients get a teardown home.
         yield
+        await slv.aclose()
 
     app = FastAPI(title="slv-demo-v2v-chat", docs_url=None, redoc_url=None,
                   lifespan=_lifespan)
+    profiles_dir = Path(os.environ.get("DEMO_PROFILES_DIR") or _DEFAULT_PROFILES_DIR)
 
     @app.get("/healthz")
     async def healthz() -> dict:
@@ -80,6 +92,13 @@ def create_app(slv_url: str | None = None) -> FastAPI:
             "ws": _ws_endpoint(slv_url),
             "v2v_path": "/v2v/stream",
         }
+
+    # Shared model-switch API (/api/status, /api/profiles, /api/switch). This
+    # demo runs the full ASR→LLM→TTS loop, so its frontend panel exposes both
+    # ["asr","tts"] tabs. Registered BEFORE the static mount.
+    register_switch_routes(
+        app, slv, profiles_dir, asr_label=os.environ.get("DEMO_ASR_MODEL_ID")
+    )
 
     # Static frontend (mounted last so /api/* and /healthz win).
     common_frontend = _DEMOS_DIR / "common" / "frontend"

--- a/demos/v2v-chat/frontend/app.js
+++ b/demos/v2v-chat/frontend/app.js
@@ -25,7 +25,7 @@
  *     vad_event speech_start arrives while speaking. ⏹ still works too.
  */
 
-import { createStatusPill, createMetricCard } from "/common/ui.js";
+import { createStatusPill, createMetricCard, createModelSwitchPanel } from "/common/ui.js";
 import { MicCapture } from "/common/mic-capture.js";
 import { V2VStreamClient } from "/common/v2v-client.js";
 
@@ -55,6 +55,7 @@ const I18N = {
     duplexHalfState: "回答播放时麦克风静音，用 ⏹ 按钮打断",
     duplexFullState: "回答播放时麦克风保持开启，开口即打断",
     duplexTip: "戴耳机或使用带 AEC 的 reSpeaker 麦克风可开启全双工语音打断；笔记本外放请保持半双工，避免回声误触发。",
+    switchTitle: "模型切换",
     settingsTitle: "模型 / 语言",
     asrLangLabel: "识别语言", ttsLangLabel: "回答语言",
     langAuto: "自动", langZh: "中文", langEn: "英文",
@@ -97,6 +98,7 @@ const I18N = {
     duplexHalfState: "Mic muted while the reply plays; interrupt with ⏹",
     duplexFullState: "Mic stays open while the reply plays; speak to barge in",
     duplexTip: "Wear headphones or use an AEC microphone (e.g. reSpeaker) to enable full-duplex voice barge-in. On laptop speakers keep half duplex to avoid echo-triggered false interrupts.",
+    switchTitle: "Switch model",
     settingsTitle: "Model / Language",
     asrLangLabel: "Recognition language", ttsLangLabel: "Reply language",
     langAuto: "Auto", langZh: "Chinese", langEn: "English",
@@ -135,6 +137,10 @@ const connPill = createStatusPill($("pills"), { state: "idle", text: "…" });
 const totalCard = createMetricCard($("metrics"), { label: "", unit: "s", digits: 2 });
 
 $("gallery-link").href = `//${window.location.hostname}:8700/`;
+
+// Inline model switch — v2v runs the full ASR→LLM→TTS loop, so expose both
+// kinds (ASR/TTS tabs). Talks to this backend's shared /api/switch.
+createModelSwitchPanel($("switch-panel"), { kinds: ["asr", "tts"] });
 
 /* ── state ─────────────────────────────────────────────────────────── */
 let state = "idle";        // "idle" | "connecting" | "live"

--- a/demos/v2v-chat/frontend/index.html
+++ b/demos/v2v-chat/frontend/index.html
@@ -279,6 +279,11 @@
     </section>
 
     <section class="panel">
+      <h2 data-i18n="switchTitle"></h2>
+      <div id="switch-panel"></div>
+    </section>
+
+    <section class="panel">
       <h2 data-i18n="settingsTitle"></h2>
       <label class="muted" style="font-size: var(--fs-small);" for="asr-lang" data-i18n="asrLangLabel"></label>
       <select id="asr-lang" style="width: 100%; margin-top: 6px; margin-bottom: 12px;">

--- a/demos/voice-clone/backend/main.py
+++ b/demos/voice-clone/backend/main.py
@@ -74,8 +74,10 @@ if str(_DEMOS_DIR) not in sys.path:
     sys.path.insert(0, str(_DEMOS_DIR))
 
 from common.backend.slv_proxy import SLVProxy  # noqa: E402
+from common.backend.switch_api import register_switch_routes  # noqa: E402
 
 _TRUTHY = {"1", "true", "yes", "on"}
+_DEFAULT_PROFILES_DIR = _DEMOS_DIR.parent / "configs" / "profiles"
 
 # Server-side enroll contract: "reference wav (3-15s, single speaker)".
 # 44-byte WAV header + 1 s of 16 kHz mono int16 is a generous lower bound for
@@ -254,6 +256,13 @@ def create_app(proxy: SLVProxy | None = None, kiosk: bool | None = None) -> Fast
     # CloneStreamProxyRequest still applies: this demo always synthesizes with
     # an enrolled voice, so `voice` stays required on the alias too.
     app.post("/tts/stream")(_clone_stream)
+
+    # Shared model-switch API (/api/status, /api/profiles, /api/switch). This
+    # demo's frontend panel is pinned to ["tts"]. Registered BEFORE the mount.
+    profiles_dir = Path(os.environ.get("DEMO_PROFILES_DIR") or _DEFAULT_PROFILES_DIR)
+    register_switch_routes(
+        app, slv, profiles_dir, asr_label=os.environ.get("DEMO_ASR_MODEL_ID")
+    )
 
     # Static frontend (mounted last so /api/* wins).
     common_frontend = _DEMOS_DIR / "common" / "frontend"

--- a/demos/voice-clone/frontend/app.js
+++ b/demos/voice-clone/frontend/app.js
@@ -23,7 +23,7 @@
  * the backend forwards it to SLV /tts/stream (VoiceProfile `voice` selector).
  */
 
-import { createStatusPill, createMetricCard } from "/common/ui.js";
+import { createStatusPill, createMetricCard, createModelSwitchPanel } from "/common/ui.js";
 import { TTSStreamPlayer } from "/common/slv-client.js";
 import { MicCapture } from "/common/mic-capture.js";
 
@@ -59,6 +59,7 @@ const I18N = {
     gateNotReadyMsg: "TTS 引擎尚未就绪，请稍候片刻再试。",
     gateDownTitle: "语音服务不可达",
     gateDownMsg: "连不上本机语音服务。请确认设备电源与网络后重试。",
+    switchTitle: "模型切换",
     voicesLabel: "已注册声音",
     voicesNone: "还没有注册的声音",
     voicesLoaded: (n) => `${n} 个已注册声音`,
@@ -104,6 +105,7 @@ const I18N = {
     gateNotReadyMsg: "The TTS engine isn't ready yet. Give it a moment and retry.",
     gateDownTitle: "Voice server unreachable",
     gateDownMsg: "Can't reach the on-device voice server. Check the device power/network and retry.",
+    switchTitle: "Switch model",
     voicesLabel: "Enrolled voices",
     voicesNone: "No enrolled voices yet",
     voicesLoaded: (n) => `${n} enrolled voice${n === 1 ? "" : "s"}`,
@@ -644,3 +646,6 @@ $("lang-btn").addEventListener("click", () => {
 
 applyStaticI18n();
 probeCapabilities();
+
+// Inline model switch — voice clone rides the TTS engine, so pin to ["tts"].
+createModelSwitchPanel($("switch-panel"), { kinds: ["tts"] });

--- a/demos/voice-clone/frontend/index.html
+++ b/demos/voice-clone/frontend/index.html
@@ -340,6 +340,10 @@
     <section class="panel">
       <p class="muted" style="font-size:var(--fs-small); margin:0" data-i18n="aboutClone"></p>
     </section>
+    <section class="panel">
+      <h2 data-i18n="switchTitle"></h2>
+      <div id="switch-panel"></div>
+    </section>
   </aside>
 </div>
 

--- a/server/core/backend_manager.py
+++ b/server/core/backend_manager.py
@@ -428,7 +428,9 @@ class BackendManager(Generic[T]):
                     )
 
                 if profile_ref is not None:
-                    profile_loader.apply_profile(profile_ref, resolve_engines=True)
+                    profile_loader.apply_profile(
+                        profile_ref, resolve_engines=True, kind=self.name
+                    )
 
                 new_backend = self._factory()
                 self._preloader(new_backend)
@@ -492,7 +494,7 @@ class BackendManager(Generic[T]):
                         # reload's injected engine keys cleared via the unified
                         # _APPLIED_KEYS reconciliation (avoids env pollution).
                         profile_loader.apply_profile(
-                            old_profile_ref, resolve_engines=True
+                            old_profile_ref, resolve_engines=True, kind=self.name
                         )
                     restored = self._factory()
                     self._preloader(restored)

--- a/server/core/backend_manager.py
+++ b/server/core/backend_manager.py
@@ -385,7 +385,9 @@ class BackendManager(Generic[T]):
                 # this, a missing engine path forces a failed preload + rollback
                 # dance (see commit fd19877 and memory:
                 # backend_manager_rollback_env_pollution).
-                missing = profile_loader.find_missing_artifacts(new_profile_preview)
+                missing = profile_loader.find_missing_artifacts(
+                    new_profile_preview, kind=self.name
+                )
                 if missing:
                     raise HTTPException(
                         status_code=400,

--- a/server/core/engine_resolver.py
+++ b/server/core/engine_resolver.py
@@ -640,20 +640,10 @@ def format_report_text(report: ProvisioningReport) -> str:
 # provisions its own modality's engines and never drags in the paired backend's
 # (a TTS-only reload must not fetch the profile's ASR engines and vice versa —
 # bundled profiles are just upper-layer "recommended pairings", the underlying
-# swap is per-kind). Markers mirror profile_loader._key_kind.
-_ASR_ENGINE_MARKERS = ("ASR", "PARAFORMER", "SENSEVOICE")
-_TTS_ENGINE_MARKERS = ("TTS", "MATCHA", "KOKORO", "VOCOS", "SPARK", "SPEAKER_ENCODER")
-
-
-def _entry_kind(env_var: str) -> Optional[str]:
-    ku = (env_var or "").upper()
-    is_asr = any(m in ku for m in _ASR_ENGINE_MARKERS)
-    is_tts = any(m in ku for m in _TTS_ENGINE_MARKERS)
-    if is_asr and not is_tts:
-        return "asr"
-    if is_tts and not is_asr:
-        return "tts"
-    return None
+# swap is per-kind). Kind attribution is defined ONCE in profile_loader and
+# imported here so the resolver and the artifact pre-flight can never disagree
+# on which engine family belongs to which modality.
+from server.core.profile_loader import _key_kind as _entry_kind  # noqa: E402
 
 
 def build_report(

--- a/server/core/engine_resolver.py
+++ b/server/core/engine_resolver.py
@@ -636,13 +636,44 @@ def format_report_text(report: ProvisioningReport) -> str:
     return "\n".join(lines)
 
 
-def build_report(profile: dict, *, export_ok: bool = False) -> ProvisioningReport:
+# Kind attribution for required_engines entries, so a kind-scoped reload only
+# provisions its own modality's engines and never drags in the paired backend's
+# (a TTS-only reload must not fetch the profile's ASR engines and vice versa —
+# bundled profiles are just upper-layer "recommended pairings", the underlying
+# swap is per-kind). Markers mirror profile_loader._key_kind.
+_ASR_ENGINE_MARKERS = ("ASR", "PARAFORMER", "SENSEVOICE")
+_TTS_ENGINE_MARKERS = ("TTS", "MATCHA", "KOKORO", "VOCOS", "SPARK", "SPEAKER_ENCODER")
+
+
+def _entry_kind(env_var: str) -> Optional[str]:
+    ku = (env_var or "").upper()
+    is_asr = any(m in ku for m in _ASR_ENGINE_MARKERS)
+    is_tts = any(m in ku for m in _TTS_ENGINE_MARKERS)
+    if is_asr and not is_tts:
+        return "asr"
+    if is_tts and not is_asr:
+        return "tts"
+    return None
+
+
+def build_report(
+    profile: dict, *, export_ok: bool = False, kind: Optional[str] = None
+) -> ProvisioningReport:
     """Resolve every required engine in ONE pass, collecting all outcomes.
+
+    When ``kind`` is 'tts' or 'asr', only that modality's engines are resolved
+    (entries belonging exclusively to the other kind are skipped) — a kind-
+    scoped reload never provisions the paired backend's engines.
 
     Never crashes on the first failure. When ``export_ok`` is True, successfully
     resolved engines have their env_var exported (used by resolve_all)."""
     global _LAST_REPORT
     entries = profile.get("required_engines") or []
+    if kind is not None:
+        entries = [
+            e for e in entries
+            if _entry_kind(e.get("env_var", "")) in (None, kind)
+        ]
     host = detect_host_signature()
     force_rebuild = (_env(ENV_FORCE_REBUILD, "0") or "0") in ("1", "true", "yes")
 
@@ -672,7 +703,7 @@ def build_report(profile: dict, *, export_ok: bool = False) -> ProvisioningRepor
     return report
 
 
-def resolve_all(profile: dict) -> dict[str, Path]:
+def resolve_all(profile: dict, kind: Optional[str] = None) -> dict[str, Path]:
     """Resolve every engine declared by ``profile['required_engines']``.
 
     On success, returns a dict of ``env_var → engine_path`` and also injects
@@ -689,7 +720,7 @@ def resolve_all(profile: dict) -> dict[str, Path]:
 
     fd = _acquire_lock()
     try:
-        report = build_report(profile, export_ok=True)
+        report = build_report(profile, export_ok=True, kind=kind)
     finally:
         _release_lock(fd)
 

--- a/server/core/profile_loader.py
+++ b/server/core/profile_loader.py
@@ -195,6 +195,7 @@ def apply_profile(
     *,
     overrides: Mapping[str, str] | None = None,
     resolve_engines: bool = False,
+    kind: str | None = None,
 ) -> dict:
     """Load a profile and reconcile process env against it.
 
@@ -300,7 +301,7 @@ def apply_profile(
             # (cf. backend_manager rollback env-pollution class of bug).
             try:
                 from server.core.engine_resolver import resolve_all
-                injected = resolve_all(profile)
+                injected = resolve_all(profile, kind=kind)
                 _APPLIED_KEYS.update(
                     k for k in injected if k not in _OPERATOR_KEYS
                 )

--- a/server/core/profile_loader.py
+++ b/server/core/profile_loader.py
@@ -245,6 +245,20 @@ def apply_profile(
             for k, v in overrides.items():
                 merged[k] = str(v)
 
+        # Kind-scoped reload (swap only ASR or only TTS): touch ONLY this
+        # modality's own env keys. Shared keys (roots/labels used by both
+        # backends) and the OTHER kind's keys are left exactly as the last
+        # full / other-kind reload set them. Without this, switching ASR to a
+        # bundle would stomp OVS_TTS_MODEL_ID / *_TTS_* / MOSS_* etc., and the
+        # live TTS backend (whose model_id is read from env) would drift; a
+        # failed kind reload's rollback could likewise clobber a concurrently
+        # reloaded other kind.
+        def _in_scope(k: str) -> bool:
+            return kind is None or _key_kind(k) == kind
+
+        if kind is not None:
+            merged = {k: v for k, v in merged.items() if _in_scope(k)}
+
         new_keys = set(merged.keys())
 
         # Profile-owned operator keys: a profile may declare operator-prefixed
@@ -259,11 +273,13 @@ def apply_profile(
         eff_operator = _OPERATOR_KEYS - owned
 
         # 1. Clear stale keys (in previous profile but not in this one),
-        #    skipping operator-owned keys.
+        #    skipping operator-owned keys AND (for a kind-scoped reload) any key
+        #    outside this modality's scope — those belong to the other backend.
         stale = _APPLIED_KEYS - new_keys
         for k in stale:
-            if k not in eff_operator:
-                os.environ.pop(k, None)
+            if k in eff_operator or not _in_scope(k):
+                continue
+            os.environ.pop(k, None)
 
         # 2. Write new values, unconditionally overwriting unless operator-owned.
         for k, v in merged.items():
@@ -285,8 +301,14 @@ def apply_profile(
                 continue
             os.environ[k] = v
 
-        # 3. Update bookkeeping.
-        _APPLIED_KEYS.clear()
+        # 3. Update bookkeeping. For a kind-scoped reload only replace this
+        #    modality's tracked keys; the other kind's stay recorded so a later
+        #    full reload can still reconcile them.
+        if kind is None:
+            _APPLIED_KEYS.clear()
+        else:
+            for k in [k for k in _APPLIED_KEYS if _in_scope(k)]:
+                _APPLIED_KEYS.discard(k)
         _APPLIED_KEYS.update(k for k in new_keys if k not in eff_operator)
         _CURRENT_PROFILE = profile
 
@@ -399,9 +421,15 @@ def _expand_with_profile_env(value: str, profile_env: Mapping[str, object]) -> s
 # Kind attribution for path-like env keys, so a *kind-scoped* reload (swap
 # only TTS, or only ASR) validates just that modality's engines and ignores
 # the other half of a bundled profile. Keys matching neither marker set are
-# treated as shared and always validated.
+# treated as shared and always validated. This is the SINGLE source of truth
+# for kind attribution — engine_resolver imports _key_kind from here so the two
+# kind-scoping call sites can never drift (a missed engine family, e.g. MOSS,
+# would otherwise leak the other modality's engines into a kind-scoped reload).
+# Every TTS/ASR engine family MUST have a marker here.
 _ASR_KEY_MARKERS = ("ASR", "PARAFORMER", "SENSEVOICE")
-_TTS_KEY_MARKERS = ("TTS", "MATCHA", "KOKORO", "VOCOS", "SPARK", "SPEAKER_ENCODER")
+_TTS_KEY_MARKERS = (
+    "TTS", "MATCHA", "KOKORO", "VOCOS", "SPARK", "MOSS", "SPEAKER_ENCODER",
+)
 
 
 def _key_kind(key: str) -> str | None:

--- a/server/core/profile_loader.py
+++ b/server/core/profile_loader.py
@@ -395,9 +395,33 @@ def _expand_with_profile_env(value: str, profile_env: Mapping[str, object]) -> s
         return value
 
 
-def expected_artifact_paths(profile: dict) -> dict[str, str]:
+# Kind attribution for path-like env keys, so a *kind-scoped* reload (swap
+# only TTS, or only ASR) validates just that modality's engines and ignores
+# the other half of a bundled profile. Keys matching neither marker set are
+# treated as shared and always validated.
+_ASR_KEY_MARKERS = ("ASR", "PARAFORMER", "SENSEVOICE")
+_TTS_KEY_MARKERS = ("TTS", "MATCHA", "KOKORO", "VOCOS", "SPARK", "SPEAKER_ENCODER")
+
+
+def _key_kind(key: str) -> str | None:
+    """Classify a path-like env key as 'asr' / 'tts' / None (shared)."""
+    ku = key.upper()
+    is_asr = any(m in ku for m in _ASR_KEY_MARKERS)
+    is_tts = any(m in ku for m in _TTS_KEY_MARKERS)
+    if is_asr and not is_tts:
+        return "asr"
+    if is_tts and not is_asr:
+        return "tts"
+    return None
+
+
+def expected_artifact_paths(profile: dict, kind: str | None = None) -> dict[str, str]:
     """Return ``{env_key: expanded_absolute_path}`` for env entries that
     look like filesystem artifacts.
+
+    When ``kind`` is 'tts' or 'asr', keys that belong exclusively to the
+    *other* modality are skipped — a kind-scoped reload only needs its own
+    engines present, not the paired backend's (see :func:`_key_kind`).
 
     Variable expansion uses the profile's own env block layered on top of
     ``os.environ`` (see :func:`_expand_with_profile_env`), so profiles that
@@ -418,19 +442,24 @@ def expected_artifact_paths(profile: dict) -> dict[str, str]:
             continue
         if not any(k.endswith(s) for s in _PATH_LIKE_SUFFIXES):
             continue
+        if kind is not None:
+            kk = _key_kind(k)
+            if kk is not None and kk != kind:
+                continue
         expanded = _expand_with_profile_env(v, env_block)
         if expanded.startswith("/"):
             result[k] = expanded
     return result
 
 
-def find_missing_artifacts(profile: dict) -> list[dict]:
+def find_missing_artifacts(profile: dict, kind: str | None = None) -> list[dict]:
     """Return missing-path records for the given profile.
 
     Empty list means all expected absolute paths exist on disk. Record
-    shape: ``{"env_var": <key>, "path": <expanded>}``.
+    shape: ``{"env_var": <key>, "path": <expanded>}``. Pass ``kind`` to scope
+    the check to one modality (a TTS-only reload skips ASR engine paths).
     """
-    paths = expected_artifact_paths(profile)
+    paths = expected_artifact_paths(profile, kind=kind)
     missing: list[dict] = []
     for k, p in paths.items():
         if not os.path.exists(p):

--- a/server/main.py
+++ b/server/main.py
@@ -5202,3 +5202,52 @@ async def admin_backend_reload(
 async def admin_backend_status(_: None = Depends(_admin_dep())):
     from server.core.backend_manager import tts_manager, asr_manager
     return {"tts": tts_manager().status(), "asr": asr_manager().status()}
+
+
+@app.get("/admin/backend/loadable")
+async def admin_backend_loadable(_: None = Depends(_admin_dep())):
+    """Classify every server-side profile by whether *this* SLV can actually
+    load it, split per kind (tts / asr).
+
+    For each profile JSON under ``configs/profiles/`` we ask each manager to
+    preview its own half (``_load_profile_kind``) and run the same artifact
+    pre-flight the hot-reload path uses (``find_missing_artifacts``). A profile
+    is *loadable* for a kind when no expected artifact path is missing.
+
+    Because tts_manager loads the TTS side and asr_manager loads the ASR side,
+    the same profile can be loadable for one kind and not the other (e.g. the
+    ASR engine is absent) — which is exactly what the demo portal needs to
+    only offer switch targets that will succeed.
+
+    A single broken profile never fails the whole endpoint: load/parse errors
+    are captured per-profile under ``invalid``.
+    """
+    from server.core.backend_manager import tts_manager, asr_manager
+    from server.core import backend_manager as _bm_mod
+    from server.core import profile_loader as _pl
+    from pathlib import Path as _Path
+
+    repo_root = _Path(_bm_mod.__file__).resolve().parents[2]
+    profiles_dir = repo_root / "configs" / "profiles"
+    names: list[str] = []
+    if profiles_dir.is_dir():
+        names = sorted(p.stem for p in profiles_dir.glob("*.json"))
+
+    def _classify(mgr) -> dict:
+        loadable: list[str] = []
+        unloadable: list[dict] = []
+        invalid: list[dict] = []
+        for name in names:
+            try:
+                preview = mgr._load_profile_kind(name)
+                missing = _pl.find_missing_artifacts(preview)
+            except Exception as exc:  # noqa: BLE001 — one bad profile ≠ dead endpoint
+                invalid.append({"name": name, "error": str(exc)})
+                continue
+            if missing:
+                unloadable.append({"name": name, "missing": missing})
+            else:
+                loadable.append(name)
+        return {"loadable": loadable, "unloadable": unloadable, "invalid": invalid}
+
+    return {"tts": _classify(tts_manager()), "asr": _classify(asr_manager())}

--- a/server/main.py
+++ b/server/main.py
@@ -5240,7 +5240,7 @@ async def admin_backend_loadable(_: None = Depends(_admin_dep())):
         for name in names:
             try:
                 preview = mgr._load_profile_kind(name)
-                missing = _pl.find_missing_artifacts(preview)
+                missing = _pl.find_missing_artifacts(preview, kind=mgr.name)
             except Exception as exc:  # noqa: BLE001 — one bad profile ≠ dead endpoint
                 invalid.append({"name": name, "error": str(exc)})
                 continue

--- a/server/tests/test_admin_loadable.py
+++ b/server/tests/test_admin_loadable.py
@@ -1,0 +1,110 @@
+"""Tests for GET /admin/backend/loadable.
+
+The endpoint globs ``<repo>/configs/profiles/*.json`` and asks each manager to
+preview its own half of every profile, classifying each as loadable /
+unloadable / invalid. We redirect the glob to a temp profiles dir (by pointing
+``backend_manager.__file__`` at a fake repo root) and stub both managers plus
+``find_missing_artifacts`` so classification is fully controlled.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+class _FakeMgr:
+    """Stand-in manager: ``_load_profile_kind`` returns a tagged preview,
+    except for names in ``bad`` which raise (→ classified invalid)."""
+
+    def __init__(self, kind: str, bad: set[str] | None = None):
+        self._kind = kind
+        self._bad = bad or set()
+
+    def _load_profile_kind(self, ref: str) -> dict:
+        if ref in self._bad:
+            raise ValueError(f"boom:{ref}")
+        return {"name": ref, "kind": self._kind}
+
+
+@pytest.fixture
+def loadable_env(monkeypatch, tmp_path):
+    # Fake repo root so the endpoint globs OUR controlled profile set.
+    core = tmp_path / "server" / "core"
+    core.mkdir(parents=True)
+    fake_file = core / "backend_manager.py"
+    fake_file.write_text("# fake")
+    prof = tmp_path / "configs" / "profiles"
+    prof.mkdir(parents=True)
+    for stem in ("p-good", "p-missing", "p-bad"):
+        (prof / f"{stem}.json").write_text("{}")
+
+    from server.core import backend_manager as bm
+    from server.core import profile_loader as pl
+
+    monkeypatch.setattr(bm, "__file__", str(fake_file))
+
+    # tts: p-bad fails to LOAD → invalid; p-missing missing artifacts.
+    tts = _FakeMgr("tts", bad={"p-bad"})
+    # asr: p-bad LOADS fine but lacks its ASR engine → unloadable (not invalid).
+    asr = _FakeMgr("asr")
+    monkeypatch.setattr(bm, "tts_manager", lambda: tts)
+    monkeypatch.setattr(bm, "asr_manager", lambda: asr)
+
+    def fake_missing(preview: dict) -> list[dict]:
+        name = preview.get("name")
+        kind = preview.get("kind")
+        if name == "p-missing":
+            return [{"env_var": "SOME_ENGINE", "path": "/nope"}]
+        if kind == "asr" and name == "p-bad":
+            return [{"env_var": "ASR_ENGINE", "path": "/nope2"}]
+        return []
+
+    monkeypatch.setattr(pl, "find_missing_artifacts", fake_missing)
+    return tmp_path
+
+
+def _client(admin_allowed: bool):
+    from server.main import app
+    from server.core.admin_auth import require_admin
+
+    if admin_allowed:
+        async def _allow():
+            return None
+        app.dependency_overrides[require_admin] = _allow
+    return app, require_admin
+
+
+def test_loadable_classifies_per_kind(loadable_env):
+    app, require_admin = _client(admin_allowed=True)
+    try:
+        c = TestClient(app)
+        r = c.get("/admin/backend/loadable")
+    finally:
+        app.dependency_overrides.pop(require_admin, None)
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+
+    # TTS side: p-good loadable, p-missing unloadable, p-bad invalid.
+    assert body["tts"]["loadable"] == ["p-good"]
+    assert [u["name"] for u in body["tts"]["unloadable"]] == ["p-missing"]
+    assert body["tts"]["unloadable"][0]["missing"] == [
+        {"env_var": "SOME_ENGINE", "path": "/nope"}
+    ]
+    assert [i["name"] for i in body["tts"]["invalid"]] == ["p-bad"]
+    assert "boom:p-bad" in body["tts"]["invalid"][0]["error"]
+
+    # ASR side: same profile set, DIFFERENT verdicts — p-bad is loadable-parse
+    # but missing its ASR engine (unloadable), and p-good is loadable.
+    assert body["asr"]["loadable"] == ["p-good"]
+    assert {u["name"] for u in body["asr"]["unloadable"]} == {"p-missing", "p-bad"}
+    assert body["asr"]["invalid"] == []
+
+
+def test_loadable_requires_admin(loadable_env):
+    # No dependency override → non-loopback TestClient host, OVS_ADMIN_KEY unset
+    # → require_admin refuses with 403.
+    app, _ = _client(admin_allowed=False)
+    c = TestClient(app)
+    r = c.get("/admin/backend/loadable")
+    assert r.status_code == 403, r.text

--- a/server/tests/test_admin_loadable.py
+++ b/server/tests/test_admin_loadable.py
@@ -18,6 +18,7 @@ class _FakeMgr:
 
     def __init__(self, kind: str, bad: set[str] | None = None):
         self._kind = kind
+        self.name = kind  # real BackendManager exposes .name = "tts"/"asr"
         self._bad = bad or set()
 
     def _load_profile_kind(self, ref: str) -> dict:
@@ -50,9 +51,8 @@ def loadable_env(monkeypatch, tmp_path):
     monkeypatch.setattr(bm, "tts_manager", lambda: tts)
     monkeypatch.setattr(bm, "asr_manager", lambda: asr)
 
-    def fake_missing(preview: dict) -> list[dict]:
+    def fake_missing(preview: dict, kind: str | None = None) -> list[dict]:
         name = preview.get("name")
-        kind = preview.get("kind")
         if name == "p-missing":
             return [{"env_var": "SOME_ENGINE", "path": "/nope"}]
         if kind == "asr" and name == "p-bad":

--- a/server/tests/test_backend_manager.py
+++ b/server/tests/test_backend_manager.py
@@ -550,7 +550,7 @@ def test_reload_rollback_uses_original_profile_ref(monkeypatch):
     # MagicMock would also do this, but we want clean per-test state).
     apply_calls: list = []
 
-    def apply_mock(ref, *, overrides=None, resolve_engines=False):
+    def apply_mock(ref, *, overrides=None, resolve_engines=False, kind=None):
         apply_calls.append({"ref": ref, "resolve_engines": resolve_engines})
 
     monkeypatch.setattr(bm_mod.profile_loader, "apply_profile", apply_mock)
@@ -633,7 +633,7 @@ def test_first_reload_after_custom_path_startup_rollback_uses_path(monkeypatch):
 
     apply_calls: list = []
 
-    def apply_mock(ref, *, overrides=None, resolve_engines=False):
+    def apply_mock(ref, *, overrides=None, resolve_engines=False, kind=None):
         apply_calls.append({"ref": ref, "resolve_engines": resolve_engines})
 
     monkeypatch.setattr(bm_mod.profile_loader, "apply_profile", apply_mock)

--- a/server/tests/test_backend_manager.py
+++ b/server/tests/test_backend_manager.py
@@ -694,11 +694,13 @@ async def test_reload_rejects_profile_with_missing_engine_paths():
     bad_path = "/nonexistent/seeed/test/dryrun/foo.engine"
 
     def loader(self, ref):
+        # TTS-kind engine key so the tts manager's kind-scoped pre-flight
+        # (find_missing_artifacts(..., kind="tts")) actually validates it.
         return {
             "name": ref,
             "tts_backend": "fake",
             "asr_backend": "fake",
-            "env": {"EDGE_LLM_ASR_ENGINE_DIR": bad_path},
+            "env": {"EDGE_LLM_TTS_TALKER_DIR": bad_path},
         }
 
     original = BackendManager._load_profile_kind

--- a/server/tests/test_engine_resolver.py
+++ b/server/tests/test_engine_resolver.py
@@ -157,6 +157,11 @@ def test_entry_kind_classification():
     assert _entry_kind("MATCHA_SPLIT_ESTIMATOR_ENGINE") == "tts"
     assert _entry_kind("VOCOS_ENGINE") == "tts"
     assert _entry_kind("EDGE_LLM_TTS_TALKER_DIR") == "tts"
+    # MOSS is a TTS engine family — must be scoped out of ASR reloads (else a
+    # kind=asr reload of a MOSS bundle provisions/validates the MOSS TTS engines).
+    assert _entry_kind("MOSS_ENGINE_DIR") == "tts"
+    assert _entry_kind("MOSS_CODEC_ONNX_DIR") == "tts"
+    assert _entry_kind("MOSS_RESOLVED_PREFILL") == "tts"
     # Shared / ambiguous → None (validated for every kind)
     assert _entry_kind("QWEN3_ARTIFACT_ROOT") is None
     assert _entry_kind("MODEL_DIR") is None

--- a/server/tests/test_engine_resolver.py
+++ b/server/tests/test_engine_resolver.py
@@ -145,3 +145,37 @@ def test_resolve_one_keeps_unverified_engine_when_resolve_fails(tmp_path, monkey
     # ...but the unverified engine must SURVIVE the failed resolve.
     assert engine.exists()
     assert engine.read_bytes() == b"pre-staged-engine"
+
+
+def test_entry_kind_classification():
+    """Kind attribution for required_engines env_vars (bundled-profile split)."""
+    from server.core.engine_resolver import _entry_kind
+    assert _entry_kind("PARAFORMER_ENC_ENGINE") == "asr"
+    assert _entry_kind("SENSEVOICE_TRT_MODEL_DIR") == "asr"
+    assert _entry_kind("EDGE_LLM_ASR_ENGINE_DIR") == "asr"
+    assert _entry_kind("KOKORO_SPLIT_GENERATOR_ENGINE") == "tts"
+    assert _entry_kind("MATCHA_SPLIT_ESTIMATOR_ENGINE") == "tts"
+    assert _entry_kind("VOCOS_ENGINE") == "tts"
+    assert _entry_kind("EDGE_LLM_TTS_TALKER_DIR") == "tts"
+    # Shared / ambiguous → None (validated for every kind)
+    assert _entry_kind("QWEN3_ARTIFACT_ROOT") is None
+    assert _entry_kind("MODEL_DIR") is None
+
+
+def test_kind_scoped_entry_filter():
+    """A kind-scoped resolve of a paraformer+kokoro bundle keeps only that
+    modality's engines (+ shared) — the other kind is never provisioned, so an
+    offline reload can't hang fetching the paired backend's engines."""
+    from server.core.engine_resolver import _entry_kind
+    entries = [
+        {"env_var": "PARAFORMER_ENC_ENGINE"},
+        {"env_var": "KOKORO_SPLIT_GENERATOR_ENGINE"},
+        {"env_var": "QWEN3_ARTIFACT_ROOT"},  # shared → kept for both
+    ]
+
+    def keep(kind):
+        return [e["env_var"] for e in entries
+                if _entry_kind(e.get("env_var", "")) in (None, kind)]
+
+    assert keep("asr") == ["PARAFORMER_ENC_ENGINE", "QWEN3_ARTIFACT_ROOT"]
+    assert keep("tts") == ["KOKORO_SPLIT_GENERATOR_ENGINE", "QWEN3_ARTIFACT_ROOT"]

--- a/server/tests/test_main_hot_swap.py
+++ b/server/tests/test_main_hot_swap.py
@@ -290,7 +290,7 @@ def test_admin_backend_reload_loopback_allowed(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(
         profile_loader, "apply_profile",
-        lambda ref, *, overrides=None, resolve_engines=False: None,
+        lambda ref, *, overrides=None, resolve_engines=False, kind=None: None,
     )
 
     from server.main import app
@@ -317,7 +317,7 @@ def test_admin_backend_reload_success_swaps_backend(client, monkeypatch):
     )
     monkeypatch.setattr(
         profile_loader, "apply_profile",
-        lambda ref, *, overrides=None, resolve_engines=False: None,
+        lambda ref, *, overrides=None, resolve_engines=False, kind=None: None,
     )
 
     # Pre-set a synthetic profile path that parses to the same backend kind.

--- a/server/tests/test_profile_loader.py
+++ b/server/tests/test_profile_loader.py
@@ -482,7 +482,7 @@ def test_resolve_engines_injects_and_reconciles_engine_keys(tmp_path, monkeypatc
     monkeypatch.delenv("ENGINE_A", raising=False)
     monkeypatch.delenv("ENGINE_B", raising=False)
 
-    def fake_resolve_all(profile):
+    def fake_resolve_all(profile, kind=None):
         injected = {}
         for e in profile.get("required_engines", []):
             os.environ[e["env_var"]] = e["path"]

--- a/server/tests/test_profile_loader.py
+++ b/server/tests/test_profile_loader.py
@@ -515,6 +515,37 @@ def test_resolve_engines_injects_and_reconciles_engine_keys(tmp_path, monkeypatc
     assert "ENGINE_B" not in os.environ
 
 
+def test_kind_scoped_reload_leaves_other_modality_env_untouched(tmp_path, monkeypatch):
+    """A kind='asr' reload must touch ONLY ASR env keys — the live TTS backend's
+    env (OVS_TTS_MODEL_ID / MATCHA_* / MOSS_*) stays exactly as its own reload
+    left it, so its model_id can't drift and rollback can't clobber it."""
+    import os
+    for k in ("EDGE_LLM_ASR_ENGINE_DIR", "OVS_TTS_MODEL_ID",
+              "MATCHA_MODEL_BASE", "MOSS_ENGINE_DIR"):
+        monkeypatch.delenv(k, raising=False)
+
+    # Full load of a matcha-TTS bundle establishes the TTS env.
+    full = _write_profile(tmp_path, "full", {
+        "env": {"EDGE_LLM_ASR_ENGINE_DIR": "/asr/old", "MATCHA_MODEL_BASE": "/tts/matcha"},
+        "tts_model_id": "matcha-icefall-zh-en",
+    })
+    profile_loader.apply_profile(str(full))            # kind=None → full apply
+    assert os.environ["OVS_TTS_MODEL_ID"] == "matcha-icefall-zh-en"
+    assert os.environ["MATCHA_MODEL_BASE"] == "/tts/matcha"
+
+    # kind='asr' reload to a paraformer+MOSS bundle.
+    asr_bundle = _write_profile(tmp_path, "asrbundle", {
+        "env": {"EDGE_LLM_ASR_ENGINE_DIR": "/asr/new", "MOSS_ENGINE_DIR": "/tts/moss"},
+        "tts_model_id": "moss-tts-nano-v1",
+    })
+    profile_loader.apply_profile(str(asr_bundle), kind="asr")
+
+    assert os.environ["EDGE_LLM_ASR_ENGINE_DIR"] == "/asr/new"       # ASR updated
+    assert os.environ["MATCHA_MODEL_BASE"] == "/tts/matcha"          # TTS left intact
+    assert os.environ["OVS_TTS_MODEL_ID"] == "matcha-icefall-zh-en"  # NOT drifted to moss
+    assert "MOSS_ENGINE_DIR" not in os.environ                       # bundle's TTS not applied
+
+
 # ---------------------------------------------------------------------------
 # v0.9.0 profile contract (configs/profiles/jetson-edgellm-v090-*.json).
 # Pure-JSON checks: the v090 profiles must carry the absolute plugin path,


### PR DESCRIPTION
Per-kind multi-engine switching for the demo gallery: switch just the ASR or
just the TTS engine of a device, from either the portal or inside each demo,
picking by **model name** rather than bundle-profile stem.

## Server — kind-scoped hot reload (`server/core`, `server/main.py`)

Profiles bundle an ASR + a TTS backend, but a reload swaps only one. The
pre-flight **and** the engine-provisioning both walked the *whole* profile, so
switching TTS to a matcha profile failed on its (absent) ASR engines, and
switching ASR to a paraformer+kokoro profile hung forever trying to fetch the
kokoro TTS engines from an offline device.

- `find_missing_artifacts(profile, kind)` and `engine_resolver.build_report(…,
  kind)` now skip path-like keys / `required_engines` that belong exclusively to
  the *other* modality (ASR/TTS/engine-family markers). `apply_profile` and
  `BackendManager` reload + rollback thread their `kind` through.
- New `GET /admin/backend/loadable` classifies every profile as loadable /
  unloadable / invalid **per kind**, using the same kind-scoped pre-flight.

Underlying swap is now purely per-kind; bundled profiles are just upper-layer
recommended pairings. New/updated tests: `test_engine_resolver`,
`test_admin_loadable`, `test_backend_manager`, `test_profile_loader`.

## Demos — switchers everywhere, by model name

- Shared `common/backend/switch_api.py` (`/api/status`, `/api/profiles`,
  `/api/switch`) mounted on the gallery **and every demo backend**, so each demo
  page carries its own switcher — kind-limited: asr-caption/diarization → ASR,
  tts-playground/voice-clone → TTS, v2v-chat → both. `createModelSwitchPanel`
  gains `opts.kinds` (a single kind hides the ASR/TTS toggle).
- The dropdown lists **deduped model names** (Qwen3-ASR / Paraformer / Matcha /
  CustomVoice …), not bundle stems: profiles sharing one engine collapse to a
  single entry (keyed by `asr_backend` / `tts_model_id`), and profiles with no
  backend for the requested kind drop out.
- `/api/profiles?kind=` narrows to what the SLV reports it can actually load
  (`/admin/backend/loadable`); status pills show the model, not the raw engine.
- `run-local.sh`: run the frontends on localhost (secure context → mic works
  without HTTPS) against a tunnelled remote SLV.
- Fixes a latent crash the shared-router extraction surfaced: `/api/profiles`
  500'd when the SLV was unreachable (`backend_status is None`).

## Verification

- `server/tests`: 61 passed. `demos/tests`: 74 passed.
- On orin-nx (v0.9.0): TTS **Qwen3-TTS ↔ Matcha** and ASR **Qwen3-ASR ↔
  Paraformer** both switch bidirectionally, per-kind (the other modality stays
  put), transcription/synthesis correct after each swap.

> Paraformer's *outbound* hot-reload needs voxedge#5 (`paraformer_trt.unload`);
> everything else here works against current voxedge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016D5iyrpqJur3s8KVp5oDZt
